### PR TITLE
fix: remove MinutesPerPage from INI schema (it's a sandbox var)

### DIFF
--- a/client/src/lib/serverConfigSchema.ts
+++ b/client/src/lib/serverConfigSchema.ts
@@ -453,17 +453,6 @@ export const INI_SCHEMA: IniSetting[] = [
     default: true,
     category: 'players'
   },
-  {
-    key: 'MinutesPerPage',
-    label: 'Minutes Per Page',
-    description: 'In-game minutes needed to read a single page.',
-    type: 'number',
-    min: 0.1,
-    max: 10,
-    default: 1.0,
-    category: 'players'
-  },
-
   // Safehouses
   {
     key: 'PlayerSafehouse',


### PR DESCRIPTION
## Problem

`MinutesPerPage` is defined in **both** the INI schema and the Sandbox schema in `client/src/lib/serverConfigSchema.ts`.

- **INI definition** (line ~457): `{ key: "MinutesPerPage", min: 0.1, max: 10, default: 1, category: "players" }`
- **Sandbox definition** (line ~2902): `{ key: "MinutesPerPage", min: 0, max: 60, default: 2, category: "survival" }`

`MinutesPerPage` is a **sandbox variable** that lives in `SandboxVars.lua`, not the INI file. The game engine reads it from the sandbox lua file only.

### What happens

When a user opens the INI tab, the panel reads the INI file, doesn't find `MinutesPerPage` (because it doesn't exist there), and displays the hardcoded default of `1`. This creates a phantom field showing a stale value that can't be corrected from the INI tab.

If the user set `MinutesPerPage = 0.05` in `SandboxVars.lua` (for near-instant reading), the INI tab still shows `1` and clamps input to `min: 0.1`.

## Fix

Remove the `MinutesPerPage` entry from the `INI_SCHEMA` array. The sandbox definition is already correct (`min: 0, max: 60, default: 2`) and remains the single source of truth.

This works on both B41 and B42 — `MinutesPerPage` has always been a sandbox var in both builds.

## Verification

- `tsc --noEmit` — 0 errors
- `vite build` — succeeds (2.32s)
- Only 1 `MinutesPerPage` reference remains (the correct sandbox one)

## Files Changed

- `client/src/lib/serverConfigSchema.ts` — removed duplicate `MinutesPerPage` entry from `INI_SCHEMA` (~lines 456-465)