### PR TITLE
Allow item IDs that start with a digit in add-item

### DIFF
--- a/server/routes/players.js
+++ b/server/routes/players.js
@@ -24,7 +24,11 @@ const router = express.Router();
 // Allow normal in-game names (spaces/symbols) but block control chars and quote/backslash.
 const USERNAME_REGEX = /^[^\x00-\x1F\x7F"\\]{1,64}$/;
 const SAFE_TEXT_REGEX = /^[a-zA-Z0-9\s.,!?'":;()@#&+=%_\-\u00C0-\u024F]{0,256}$/;
-const ITEM_REGEX = /^[a-zA-Z][a-zA-Z0-9_]*\.[a-zA-Z][a-zA-Z0-9_]*$/;
+// Mirrors the add-vehicle check below: item names legitimately start with a
+// digit (all rifle ammunition, and mod vehicle parts named by model year) and
+// weapon-attachment mods use - and &. Quotes, backslashes and whitespace stay
+// excluded, which is what matters for the RCON command this is spliced into.
+const ITEM_REGEX = /^[A-Za-z0-9_]+\.[A-Za-z0-9_&-]+$/;
 
 function isValidUsername(username) {
   if (typeof username !== 'string') return false;

--- a/server/tests/addItemRoute.test.js
+++ b/server/tests/addItemRoute.test.js
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const logPlayerAction = vi.fn();
+
+vi.mock("../database/init.js", () => ({
+  logPlayerAction,
+  getPlayerLogs: vi.fn(),
+  getPlayerNotes: vi.fn(),
+  getPlayerNote: vi.fn(),
+  upsertPlayerNote: vi.fn(),
+  deletePlayerNote: vi.fn(),
+  getPlayerStats: vi.fn(),
+  getPlayerStat: vi.fn(),
+  getSteamIdBans: vi.fn(),
+  addSteamIdBan: vi.fn(),
+  removeSteamIdBan: vi.fn(),
+}));
+
+const { default: router } = await import("../routes/players.js");
+
+function createResponse() {
+  const response = { status: vi.fn(), json: vi.fn() };
+  response.status.mockReturnValue(response);
+  return response;
+}
+
+function getHandler(path) {
+  const layer = router.stack.find(
+    (entry) => entry.route?.path === path && entry.route.methods.post,
+  );
+  return layer.route.stack[0].handle;
+}
+
+const addItem = vi.fn();
+const addVehicle = vi.fn();
+
+function createRequest(body) {
+  return {
+    body,
+    app: { get: () => ({ addItem, addVehicle }) },
+  };
+}
+
+async function giveItem(item) {
+  const response = createResponse();
+  await getHandler("/add-item")(
+    createRequest({ username: "Tester", item, count: 1 }),
+    response,
+  );
+  return response;
+}
+
+describe("POST /api/players/add-item item ID validation", () => {
+  beforeEach(() => {
+    addItem.mockReset();
+    addItem.mockResolvedValue({ success: true });
+    logPlayerAction.mockReset();
+  });
+
+  // Plenty of real item names start with a digit -- all rifle/pistol ammunition
+  // in the base game, and every vehicle part in mods that name parts by model
+  // year. Rejecting them made roughly a quarter of a modded catalogue
+  // un-giveable even though PZ's own /additem accepts these IDs happily.
+  it.each([
+    "Base.556Clip",
+    "Base.3030Bullets",
+    "Base.308Box",
+    "Base.3rdGenChevyCKseriesBumperFront0",
+    "Base.69fordMustangFenderFrame",
+  ])("accepts item IDs whose name starts with a digit (%s)", async (item) => {
+    const response = await giveItem(item);
+
+    expect(addItem).toHaveBeenCalledWith("Tester", item, 1);
+    expect(response.status).not.toHaveBeenCalledWith(400);
+  });
+
+  // Weapon-attachment mods use hyphens and ampersands in item names.
+  it.each([
+    "MarzGuns.M&P_Suppressor",
+    "MarzGuns.LRX-7_Laser",
+    "MarzGuns.BrightPoint-5_Light",
+  ])("accepts item IDs containing - or & (%s)", async (item) => {
+    const response = await giveItem(item);
+
+    expect(addItem).toHaveBeenCalledWith("Tester", item, 1);
+    expect(response.status).not.toHaveBeenCalledWith(400);
+  });
+
+  it("still accepts ordinary letter-initial IDs", async () => {
+    const response = await giveItem("Base.AssaultRifle");
+
+    expect(addItem).toHaveBeenCalledWith("Tester", "Base.AssaultRifle", 1);
+    expect(response.status).not.toHaveBeenCalledWith(400);
+  });
+
+  // The value is interpolated into an RCON command, so the characters that
+  // matter are quotes, backslashes and whitespace -- not digits.
+  it.each([
+    'Base.Axe" ',
+    "Base.Axe\\",
+    "Base.Axe Base.Nails",
+    "NoDotHere",
+    "Base.",
+    ".Axe",
+  ])("still rejects malformed or injection-prone IDs (%j)", async (item) => {
+    const response = await giveItem(item);
+
+    expect(addItem).not.toHaveBeenCalled();
+    expect(response.status).toHaveBeenCalledWith(400);
+  });
+
+  it("accepts the same IDs the sibling add-vehicle route already allows", async () => {
+    addVehicle.mockResolvedValue({ success: true });
+    const vehicleResponse = createResponse();
+    await getHandler("/add-vehicle")(
+      createRequest({ username: "Tester", vehicle: "Base.49powerWagonMP" }),
+      vehicleResponse,
+    );
+
+    expect(vehicleResponse.status).not.toHaveBeenCalledWith(400);
+    // The item route should not be stricter than the vehicle route about digits.
+    const itemResponse = await giveItem("Base.49powerWagonMP");
+    expect(itemResponse.status).not.toHaveBeenCalledWith(400);
+  });
+});


### PR DESCRIPTION
Fixes #27.

`ITEM_REGEX` required a letter immediately after the module dot, so `POST /api/players/add-item` rejected any item whose name starts with a digit — which is all rifle and pistol ammunition in the base game, plus every vehicle part in mods that name parts by model year. On my 136-mod server that was **1,971 of 8,094 catalogued items (24.4%)** coming back as "Invalid item format", even though the route hands straight off to RCON `additem`, which takes those IDs happily.

## The change

```diff
-const ITEM_REGEX = /^[a-zA-Z][a-zA-Z0-9_]*\.[a-zA-Z][a-zA-Z0-9_]*$/;
+const ITEM_REGEX = /^[A-Za-z0-9_]+\.[A-Za-z0-9_&-]+$/;
```

This is the pattern `add-vehicle` already uses a few hundred lines below — which is why spawning `Base.49powerWagonMP` works while giving `Base.556Clip` doesn't — plus `-` and `&` so weapon-attachment mods work (`MarzGuns.M&P_Suppressor`, `MarzGuns.LRX-7_Laser`).

Quotes, backslashes and whitespace stay excluded, which is what actually matters given the value is spliced into an RCON command string. I deliberately left out `#`, `+` and a second dot — nothing in the catalogue needs them, so allowing them would be speculative.

## Tests

New `server/tests/addItemRoute.test.js`, following the pattern in `serversRoute.test.js` — mock the DB, pull the handler off `router.stack`, drive it with a stub req/res. It exercises the real route rather than a copy of the regex, so it can't drift.

16 cases: digit-initial IDs, `-`/`&` IDs, ordinary letter-initial IDs, six malformed or injection-shaped inputs that must still be rejected, and one asserting the item route isn't stricter than `add-vehicle` about the same ID.

I wrote the test first and confirmed it fails against unpatched code — 6 failed / 7 passed, the failures being exactly the digit-initial cases. After the change:

```
Test Files  12 passed (12)
     Tests  149 passed (149)
```

Baseline before the change was 133 passing, so nothing regressed.

Two notes: I left `package-lock.json` untouched, and `npm run lint:server` fails at HEAD on an eslint flat-config migration error unrelated to this change, so I didn't touch that either.
