### PR TITLE
fix: restore world map tiles after upstream moved build_list.json and deleted 42.19.0

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -531,7 +531,13 @@ app.use(
         defaultSrc: ["'self'"],
         scriptSrc: ["'self'", "'unsafe-inline'"],
         styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
-        imgSrc: ["'self'", "data:", "https:"],
+          // blob: is required by the World Map tile loader: it fetches each
+          // tile, converts the response to a Blob and decodes it through
+          // URL.createObjectURL (WorldMap.tsx) so a decode failure can be told
+          // apart from a network failure. Without blob: the browser blocks
+          // img.src, img.onerror fires, and every such tile is recorded as a
+          // coverage failure even though its bytes arrived intact.
+          imgSrc: ["'self'", "data:", "blob:", "https:"],
         connectSrc: ["'self'", "ws:", "wss:"],
         fontSrc: ["'self'", "https://fonts.gstatic.com"],
         objectSrc: ["'none'"],

--- a/server/index.js
+++ b/server/index.js
@@ -531,13 +531,13 @@ app.use(
         defaultSrc: ["'self'"],
         scriptSrc: ["'self'", "'unsafe-inline'"],
         styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
-          // blob: is required by the World Map tile loader: it fetches each
-          // tile, converts the response to a Blob and decodes it through
-          // URL.createObjectURL (WorldMap.tsx) so a decode failure can be told
-          // apart from a network failure. Without blob: the browser blocks
-          // img.src, img.onerror fires, and every such tile is recorded as a
-          // coverage failure even though its bytes arrived intact.
-          imgSrc: ["'self'", "data:", "blob:", "https:"],
+        // blob: is required by the World Map tile loader: it fetches each
+        // tile, converts the response to a Blob and decodes it through
+        // URL.createObjectURL (WorldMap.tsx) so a decode failure can be told
+        // apart from a network failure. Without blob: the browser blocks
+        // img.src, img.onerror fires, and every such tile is recorded as a
+        // coverage failure even though its bytes arrived intact.
+        imgSrc: ["'self'", "data:", "blob:", "https:"],
         connectSrc: ["'self'", "ws:", "wss:"],
         fontSrc: ["'self'", "https://fonts.gstatic.com"],
         objectSrc: ["'none'"],

--- a/server/routes/mapProxy.js
+++ b/server/routes/mapProxy.js
@@ -72,21 +72,27 @@ function writeDiskCacheAsync(relPath, buffer) {
 // We resolve the latest B42 version directory dynamically from build_list.json
 // so tile loading stays current when PZ ships new map builds without a panel update.
 const PZ_MAP_ROOT = "https://map.projectzomboid.com";
-const B42_DIR_FALLBACK = "42.19.0";
+// 42.19.0 was removed from map.projectzomboid.com - /maps/42.19.0/base/ now
+// 404s in its entirety, so the previous fallback could not serve a single tile.
+// It is still listed in build_list.json, so "listed" is not evidence a build is
+// still rendered; only the fallback needs to be a build that actually exists.
+const B42_DIR_FALLBACK = "42.20.0";
 const B42_DIR_TTL_MS = 24 * 60 * 60 * 1000; // re-resolve at most once per 24 h
 const B42_DIR_RETRY_MS = 5 * 60 * 1000; // ...but retry a failed resolve sooner
 // Geometry of B42_DIR_FALLBACK, used only when layer0.dzi can't be fetched.
-// x0/y0/sqr/scale are the isometric projection origin, copied from 42.19.0's
-// own base/map_info.json (skip:1 => scale 1<<1 = 2).
+// x0/y0/sqr/scale are the isometric projection origin, copied from 42.20.0's
+// own base/map_info.json (skip:0 => scale 1<<0 = 1). Note x0 and scale both
+// differ from 42.19.0's, so the directory cannot be bumped on its own without
+// putting every player marker in the wrong place.
 const B42_GEOMETRY_FALLBACK = {
-  tileSize: 1024,
-  width: 1157312,
-  height: 509520,
-  maxLevel: 21,
-  x0: 1036288,
+  tileSize: 2048,
+  width: 2318656,
+  height: 1019040,
+  maxLevel: 22,
+  x0: 1040384,
   y0: -139296,
   sqr: 128,
-  scale: 2,
+  scale: 1,
 };
 
 // The projection origin is NOT derivable from the image dimensions: 42.20.0 is
@@ -242,21 +248,94 @@ async function getB42TopFormat(directory) {
   return TOP_FORMAT_FALLBACK;
 }
 
-async function getB42Map() {
+// ─── Versioned static root ───────────────────────────────────────────────────
+// map.projectzomboid.com moved build_list.json behind a cache-busting directory
+// (/static_<timestamp>/build_list.json); the bare /build_list.json it used to
+// serve now 404s. That failure is silent - getB42Map() simply falls back - so
+// every install quietly pinned itself to B42_DIR_FALLBACK, and once 42.19.0 was
+// deleted upstream that meant a blank map with no error surfaced anywhere.
+//
+// The root document publishes the current directory as
+//   window.__PZMAP_STATIC_ROOT = 'static_20260803224102/';
+// so read it from there rather than hardcoding a timestamp that would rot the
+// next time upstream re-versions.
+const STATIC_ROOT_TTL_MS = 24 * 60 * 60 * 1000;
+let _staticRoot = null; // "static_<ts>/", or "" meaning the bare site root
+let _staticRootFetchedAt = 0;
+
+async function getStaticRoot() {
   const now = Date.now();
-  if (_b42Map && now - _b42DirFetchedAt < B42_DIR_TTL_MS) {
-    return _b42Map;
+  if (_staticRoot !== null && now - _staticRootFetchedAt < STATIC_ROOT_TTL_MS) {
+    return _staticRoot;
   }
   try {
-    const resp = await fetch(`${PZ_MAP_ROOT}/build_list.json`, {
+    const resp = await fetch(`${PZ_MAP_ROOT}/`, {
       signal: AbortSignal.timeout(5000),
       headers: {
         "User-Agent":
           "ZomboidControlPanel/1.0 (+https://github.com/fpsacha/zomboid-control-panel)",
       },
     });
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    const list = await resp.json();
+    if (resp.ok) {
+      const html = await resp.text();
+      // Only the exact shape upstream publishes is accepted: this value becomes
+      // a URL path segment, so a looser pattern would let a malformed or
+      // adversarial match reach fetch().
+      const dir = html.match(
+        /__PZMAP_STATIC_ROOT\s*=\s*['"](static_\d+)\/?['"]/,
+      )?.[1];
+      if (dir) {
+        if (_staticRoot !== `${dir}/`) {
+          log.info(`PZ map static root resolved: ${dir}`);
+        }
+        _staticRoot = `${dir}/`;
+        _staticRootFetchedAt = now;
+        return _staticRoot;
+      }
+    }
+  } catch {
+    // Fall through to the bare site root below.
+  }
+  // Serving build_list.json from the site root is how upstream behaved before
+  // the move, so it stays the fallback: a revert keeps working untouched.
+  _staticRoot = _staticRoot ?? "";
+  _staticRootFetchedAt = now - STATIC_ROOT_TTL_MS + B42_DIR_RETRY_MS;
+  return _staticRoot;
+}
+
+// Try the versioned location first, then the legacy bare path, so the panel
+// keeps working whichever layout upstream is currently serving.
+async function fetchBuildList() {
+  const staticRoot = await getStaticRoot();
+  const candidates = staticRoot
+    ? [`${staticRoot}build_list.json`, "build_list.json"]
+    : ["build_list.json"];
+  let lastError = null;
+  for (const rel of candidates) {
+    try {
+      const resp = await fetch(`${PZ_MAP_ROOT}/${rel}`, {
+        signal: AbortSignal.timeout(5000),
+        headers: {
+          "User-Agent":
+            "ZomboidControlPanel/1.0 (+https://github.com/fpsacha/zomboid-control-panel)",
+        },
+      });
+      if (resp.ok) return await resp.json();
+      lastError = new Error(`HTTP ${resp.status} for /${rel}`);
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError || new Error("build_list.json is unreachable");
+}
+
+async function getB42Map() {
+  const now = Date.now();
+  if (_b42Map && now - _b42DirFetchedAt < B42_DIR_TTL_MS) {
+    return _b42Map;
+  }
+  try {
+    const list = await fetchBuildList();
     // Entries are ordered newest-first. Walk B42+ candidates until one
     // actually has rendered tile coverage, not just a build_list.json entry.
     // The full string (not just a prefix) must match a plain version


### PR DESCRIPTION
Fixes #39.

## What is broken

The World Map and Chunk Cleaner render blank on B42. Every tile request returns
404, and nothing surfaces as an error because `serveTile()` deliberately passes
upstream 404 through as "tile outside map bounds".

## Root cause

Two upstream changes at `map.projectzomboid.com` landed together, and the
combination is what makes it total:

1. **`build_list.json` moved.** It is now served from a cache-busting
   `/static_<timestamp>/` directory. The bare `/build_list.json` that
   `getB42Map()` fetches returns 404.
2. **`42.19.0` was deleted.** `/maps/42.19.0/base/` 404s in its entirety - yet
   it is still *listed* in `build_list.json`, so being listed is not evidence a
   build is still rendered.

Because `42.19.0` is `B42_DIR_FALLBACK`, step 1 silently routes every install
into step 2. The panel logs one warning and then serves 404s forever:

```
[WARN] [API:MapProxy] Failed to resolve B42 map directory from build_list.json:
       HTTP 404. Falling back to 42.19.0.
```

## What this changes

**Resolve the versioned directory instead of hardcoding it.** The root document
publishes it as `window.__PZMAP_STATIC_ROOT = 'static_20260803224102/'`, so
`getStaticRoot()` reads it from there with a 24h TTL. Hardcoding the current
timestamp would just rot at the next re-version. The match is deliberately
narrow (`static_\d+`) because the value becomes a URL path segment, and the
legacy bare path is still tried afterwards so an upstream revert keeps working.

**Move the fallback to a build that exists - both halves.** `B42_DIR_FALLBACK`
becomes `42.20.0` *and* `B42_GEOMETRY_FALLBACK` is updated from that build's own
`base/map_info.json`. This matters: `x0` differs (`1036288` -> `1040384`) and
`scale` differs (`2` -> `1`, since `skip:0`). Bumping only the directory renders
tiles but offsets every player marker, which is exactly what the existing
comment above `fetchMapProjection()` warns about.

**Allow `blob:` in the CSP `img-src`.** Separate but adjacent: `WorldMap.tsx`
decodes each tile via `URL.createObjectURL` so a decode failure can be told
apart from a network failure, but the server's own CSP omitted `blob:`. The
browser blocked `img.src`, `img.onerror` fired, and tiles whose bytes had
arrived intact were still recorded as coverage failures:

```
Loading the image 'blob:https://<host>/<uuid>' violates the following
Content Security Policy directive: "img-src 'self' data: https:".
```

## Verification

Ran against live upstream, then deployed to a real B42 server (42.20.0, 51 mods):

```
getStaticRoot()  : "static_20260803224102/"
build_list       : 200, 10 entries
B42+ candidates  : 42.20.0, 42.19.0
probe tile       : 200   /maps/42.20.0/base/layer0_files/12/0_0.jpg
layer0.dzi       : 200
fallback tile    : 200
```

In production after deploying:

```
[INFO] [API:MapProxy] PZ map static root resolved: static_20260803224102
```

World Map renders Knox County with live player and vehicle markers, and the
`blob:` tile requests return `200 image/jpeg` instead of being blocked. The only
remaining 404 is `12/1_0.jpg`, which upstream also 404s while `12/0_0.jpg` is
200 - a genuine out-of-bounds grid cell, unchanged by this PR.

Happy for you to squash-merge; the third commit is only whitespace alignment on
the second.