### PR TITLE
fix: stop managed Docker containers through Docker instead of RCON

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -29,4 +29,19 @@ fi
 mkdir -p /app/data /app/logs
 chown -R "$puid:$pgid" /app/data /app/logs
 
+# Carry over supplementary groups granted by `group_add` / `--group-add`. They
+# are the only way to reach a host resource whose group differs from PGID — most
+# notably /var/run/docker.sock (root:docker 0660), which the Docker lifecycle
+# controls need. `--clear-groups` alone drops them before Node starts, and the
+# panel then reports Docker as available (that check is only an existsSync)
+# while every API call fails with EACCES.
+# gid 0 is excluded: root group membership is not something to carry into an
+# unprivileged process. PGID is already applied via --regid.
+supplementary="$(id -G | tr ' ' '\n' | grep -vx '0' | grep -vx "$pgid" | paste -sd, -)"
+
+if [ -n "$supplementary" ]; then
+  echo "Preserving supplementary groups: $supplementary" >&2
+  exec setpriv --reuid="$puid" --regid="$pgid" --groups "$supplementary" "$@"
+fi
+
 exec setpriv --reuid="$puid" --regid="$pgid" --clear-groups "$@"

--- a/server/index.js
+++ b/server/index.js
@@ -38,6 +38,7 @@ import {
 import { RconService } from "./services/rcon.js";
 import { ServerManager } from "./services/serverManager.js";
 import { DockerClient } from "./services/dockerClient.js";
+import { setDockerClient } from "./services/managedContainer.js";
 import { ModChecker } from "./services/modChecker.js";
 import { Scheduler } from "./services/scheduler.js";
 import { DiscordBot } from "./services/discordBot.js";
@@ -669,6 +670,9 @@ app.use("/api/panel-bridge/command", panelBridgeCommandLimiter);
 const rconService = new RconService();
 const serverManager = new ServerManager();
 const dockerClient = new DockerClient();
+// Lets the scheduler and the Discord bot route lifecycle actions to Docker
+// without threading the client through their constructors.
+setDockerClient(dockerClient);
 const modChecker = new ModChecker();
 const logTailer = new LogTailer();
 const scheduler = new Scheduler(rconService, serverManager);

--- a/server/routes/docker.js
+++ b/server/routes/docker.js
@@ -29,6 +29,9 @@ router.get("/status", requireRole("admin"), async (req, res) => {
     return res.json({
       enabled: true,
       available: dockerClient.available,
+      // An unreadable socket looks exactly like "no managed containers" without
+      // this: `available` only proves the socket file exists.
+      ...(dockerClient.lastError ? { error: sanitizeError(dockerClient.lastError) } : {}),
       containers: containers.map((container) => ({
         id: container.Id,
         name: (container.Names?.[0] || "").replace(/^\//, ""),

--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -17,6 +17,7 @@ import { sanitizeError, sanitizeIniValue } from "../utils/sanitize.js";
 import { normalizeMemoryGb } from "../utils/memory.js";
 import { withFileLock, writeFileAtomic } from "../utils/fileWriteQueue.js";
 import { requireRole } from "../services/auth.js";
+import { runManagedLifecycle } from "../services/managedContainer.js";
 
 const router = express.Router();
 
@@ -674,6 +675,14 @@ router.post("/start", async (req, res) => {
     const serverManager = req.app.get("serverManager");
     const rconService = req.app.get("rconService");
 
+    // A container-managed server is started through Docker: the panel has no
+    // process to spawn, and after a `docker stop` there is nothing left running
+    // for it to reattach to.
+    const managed = await runManagedLifecycle("start");
+    if (managed.handled && !managed.success) {
+      return res.status(502).json({ error: sanitizeError(managed.error) });
+    }
+
     // Pre-configure RCON in the INI BEFORE starting the server process.
     // PZ reads the INI at startup, so we must write the password first.
     // On first run this also pre-creates the INI file with RCON settings.
@@ -690,8 +699,10 @@ router.post("/start", async (req, res) => {
       log.warn(`RCON pre-configuration failed: ${rconErr.message}`);
     }
 
-    // Regenerate startup scripts so any config changes (admin password, memory, etc.) take effect
+    // Regenerate startup scripts so any config changes (admin password, memory, etc.) take effect.
+    // Skipped for a managed container: its image owns the launch command.
     if (
+      !managed.handled &&
       activeServer &&
       !activeServer.startCommand &&
       activeServer.installPath
@@ -727,7 +738,9 @@ router.post("/start", async (req, res) => {
       }
     }
 
-    const result = await serverManager.startServer();
+    const result = managed.handled
+      ? { success: true, message: managed.message || "Container starting" }
+      : await serverManager.startServer();
 
     // Emit status update via Socket.IO
     const io = req.app.get("io");
@@ -917,8 +930,19 @@ router.post("/stop", async (req, res) => {
       });
     }
 
-    // Then quit
-    const result = await rconService.quit();
+    // A container-managed server must go down through Docker. RCON quit kills
+    // PID 1 inside the container, which exits the container and lets its
+    // restart policy bring the world straight back up.
+    const managed = await runManagedLifecycle("stop");
+    if (managed.handled && !managed.success) {
+      return res.status(502).json({
+        error: `The world was saved, but the container could not be stopped: ${sanitizeError(managed.error)}`,
+      });
+    }
+
+    const result = managed.handled
+      ? { success: true, message: managed.message || "Container stopping" }
+      : await rconService.quit();
 
     const io = req.app.get("io");
     if (io) io.to("server-status").emit("server:status", { running: false });
@@ -949,8 +973,23 @@ router.post("/force-stop", async (req, res) => {
       });
     }
 
+    // Killing the PID of a containerized server just triggers its restart
+    // policy. Docker's stop escalates SIGTERM to SIGKILL on its own and, unlike
+    // a process kill, keeps the container down afterwards.
+    const managed = await runManagedLifecycle("stop");
+    if (managed.handled && !managed.success) {
+      return res.status(502).json({ error: sanitizeError(managed.error) });
+    }
+
     const serverManager = req.app.get("serverManager");
-    const result = await serverManager.stopServer(false);
+    const result = managed.handled
+      ? {
+          success: true,
+          message:
+            managed.message ||
+            "Container stopped. Docker ran the container's own shutdown handler before killing it.",
+        }
+      : await serverManager.stopServer(false);
 
     const io = req.app.get("io");
     if (io) io.to("server-status").emit("server:status", { running: false });

--- a/server/services/discordBot.js
+++ b/server/services/discordBot.js
@@ -16,6 +16,7 @@ import { createLogger } from "../utils/logger.js";
 const log = createLogger("Discord");
 import { getSetting, setSetting } from "../database/init.js";
 import { sanitizeError } from "../utils/sanitize.js";
+import { runManagedLifecycle } from "./managedContainer.js";
 
 // Workaround for undici 8.x + Node.js 22+/24+: undici adds Symbol(sensitiveHeaders)
 // to response header objects, but the WebIDL ByteString converter in undici's
@@ -962,7 +963,12 @@ export class DiscordBot {
       return;
     }
 
-    const started = await this.serverManager.startServer();
+    // A container-managed server starts through Docker — the panel has no
+    // process to spawn inside another container.
+    const managed = await runManagedLifecycle("start");
+    const started = managed.handled
+      ? managed
+      : await this.serverManager.startServer();
     if (!started?.success) {
       await interaction.editReply(
         `❌ Failed to start the server: ${sanitizeError(started?.error || started?.message)}`,
@@ -1000,7 +1006,10 @@ export class DiscordBot {
       );
       return;
     }
-    const quit = await this.rconService.quit();
+    // A container-managed server must go down through Docker: RCON quit kills
+    // PID 1, the container exits, and its restart policy brings the world back.
+    const managed = await runManagedLifecycle("stop");
+    const quit = managed.handled ? managed : await this.rconService.quit();
     if (!quit?.success) {
       await interaction.editReply(
         `❌ The world was saved, but the shutdown command failed: ${sanitizeError(quit?.error)}`,

--- a/server/services/dockerClient.js
+++ b/server/services/dockerClient.js
@@ -5,6 +5,13 @@ import { createLogger } from "../utils/logger.js";
 const log = createLogger("DockerClient");
 const MANAGED_LABEL = "zomboid-panel.managed";
 const REQUEST_TIMEOUT_MS = 5000;
+// Lifecycle calls block until Docker finishes. `POST /containers/{id}/stop`
+// waits out the container's own StopTimeout (Compose's `stop_grace_period`,
+// which a modded B42 world sets to 90s or more) before it answers, so the 5s
+// read timeout would abort the socket and report a failure on every successful
+// stop. Budget the container's shutdown window plus room for the daemon.
+const LIFECYCLE_GRACE_MS = 30000;
+const DEFAULT_STOP_TIMEOUT_SEC = 10;
 
 export function isManagedContainer(container) {
   const labels = container?.Labels || container?.Config?.Labels;
@@ -52,10 +59,29 @@ export function parseContainerStats(stats) {
   };
 }
 
+/**
+ * How long to hold the socket open for a lifecycle action. Docker answers only
+ * once the action completes, and a stop waits out the container's configured
+ * StopTimeout before escalating to SIGKILL. A restart pays that cost and then
+ * starts the container again.
+ */
+export function lifecycleTimeoutMs(action, container) {
+  if (action === "start") return LIFECYCLE_GRACE_MS;
+  const configured = Number(container?.Config?.StopTimeout);
+  const stopTimeoutSec = configured > 0 ? configured : DEFAULT_STOP_TIMEOUT_SEC;
+  const grace = action === "restart" ? LIFECYCLE_GRACE_MS * 2 : LIFECYCLE_GRACE_MS;
+  return stopTimeoutSec * 1000 + grace;
+}
+
 export class DockerClient {
   constructor({ socketPath = "/var/run/docker.sock", enabled = process.env.PANEL_DOCKER_CONTROL_ENABLED === "true" } = {}) {
     this.socketPath = socketPath;
     this.enabled = enabled;
+    // Last discovery failure, surfaced through /api/docker/status. `available`
+    // is only an existsSync check, so a socket the panel can stat but not open
+    // (root:docker 0660 vs. a non-root panel user) otherwise looks identical to
+    // "no managed containers exist".
+    this.lastError = null;
   }
 
   get available() {
@@ -66,9 +92,13 @@ export class DockerClient {
     if (!this.available) return [];
     try {
       const containers = await this._requestJson("GET", "/containers/json?all=true");
+      this.lastError = null;
       return Array.isArray(containers) ? containers.filter(isManagedContainer) : [];
     } catch (error) {
-      log.debug(`Docker discovery failed: ${error.message}`);
+      this.lastError = error.message;
+      log.warn(
+        `Docker discovery failed: ${error.message}. The panel can see ${this.socketPath} but cannot query it — check that its user is in the socket's group.`,
+      );
       return [];
     }
   }
@@ -104,6 +134,7 @@ export class DockerClient {
       const statusCode = await this._requestStatus(
         "POST",
         `/containers/${encodeURIComponent(containerId)}/${action}`,
+        lifecycleTimeoutMs(action, container),
       );
       if (statusCode === 304) return { success: true, message: "Container is already in the requested state" };
       if (statusCode >= 200 && statusCode < 300) return { success: true };
@@ -128,10 +159,10 @@ export class DockerClient {
     }
   }
 
-  _requestJson(method, requestPath) {
+  _requestJson(method, requestPath, timeoutMs = REQUEST_TIMEOUT_MS) {
     return new Promise((resolve, reject) => {
       const request = http.request(
-        { socketPath: this.socketPath, method, path: requestPath, timeout: REQUEST_TIMEOUT_MS },
+        { socketPath: this.socketPath, method, path: requestPath, timeout: timeoutMs },
         (response) => {
           const chunks = [];
           response.on("data", (chunk) => chunks.push(chunk));
@@ -154,10 +185,10 @@ export class DockerClient {
     });
   }
 
-  _requestStatus(method, requestPath) {
+  _requestStatus(method, requestPath, timeoutMs = REQUEST_TIMEOUT_MS) {
     return new Promise((resolve, reject) => {
       const request = http.request(
-        { socketPath: this.socketPath, method, path: requestPath, timeout: REQUEST_TIMEOUT_MS },
+        { socketPath: this.socketPath, method, path: requestPath, timeout: timeoutMs },
         (response) => {
           response.resume();
           response.on("end", () => resolve(response.statusCode));

--- a/server/services/managedContainer.js
+++ b/server/services/managedContainer.js
@@ -1,0 +1,101 @@
+/**
+ * Routes server lifecycle actions to Docker when the target server is mapped
+ * to a managed container.
+ *
+ * Why this exists: RCON `quit` and `serverManager.stopServer()` both act on the
+ * *process*. Inside a container that process is PID 1, so killing it exits the
+ * container — and a `restart: always` / `unless-stopped` policy immediately
+ * brings the world back up. From the operator's seat the Stop button looks
+ * broken. `docker stop` is a *manual* stop, which Docker exempts from restart
+ * policies, so it is the only shutdown that actually sticks.
+ *
+ * Every caller keeps its own RCON save + guards; this module only decides who
+ * owns the lifecycle action and performs the Docker half.
+ */
+import { getActiveServer, getServer } from "../database/init.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("ManagedContainer");
+
+// Wired once from index.js. Routes may still pass an explicit client.
+let sharedDockerClient = null;
+
+export function setDockerClient(client) {
+  sharedDockerClient = client || null;
+}
+
+export function getDockerClient() {
+  return sharedDockerClient;
+}
+
+/**
+ * @returns {Promise<{handled: boolean, ref?: string, container?: object|null,
+ *   running?: boolean, error?: string}>}
+ *   `handled: false` means no managed container owns this server — the caller
+ *   must fall back to its existing RCON/process path.
+ */
+export async function resolveManagedContainer({
+  serverId = null,
+  dockerClient = sharedDockerClient,
+} = {}) {
+  if (!dockerClient?.enabled || !dockerClient.available) return { handled: false };
+
+  let server = null;
+  try {
+    server = serverId == null ? await getActiveServer() : await getServer(serverId);
+  } catch (error) {
+    log.debug(`Could not resolve the server profile: ${error.message}`);
+    return { handled: false };
+  }
+
+  const ref = server?.dockerContainerName || server?.dockerContainerId || null;
+  if (!ref) return { handled: false };
+
+  const container = await dockerClient.inspectManagedContainer(ref);
+  if (!container) {
+    // Fail closed. Falling back to RCON here would kill the game process and
+    // let the container's restart policy bring it straight back up — the exact
+    // failure this module exists to prevent.
+    return {
+      handled: true,
+      ref,
+      container: null,
+      error:
+        `Container "${ref}" is mapped to this server but the panel cannot manage it. ` +
+        `Check that it exists and carries the label zomboid-panel.managed=true.`,
+    };
+  }
+
+  return {
+    handled: true,
+    ref,
+    container,
+    running: container.State?.Running === true,
+  };
+}
+
+/**
+ * @param {"start"|"stop"|"restart"} action
+ * @returns {Promise<{handled: boolean, success?: boolean, message?: string, error?: string}>}
+ */
+export async function runManagedLifecycle(
+  action,
+  { serverId = null, dockerClient = sharedDockerClient } = {},
+) {
+  const resolved = await resolveManagedContainer({ serverId, dockerClient });
+  if (!resolved.handled) return { handled: false };
+  if (resolved.error) return { handled: true, success: false, error: resolved.error };
+
+  if (action === "stop" && !resolved.running) {
+    return { handled: true, success: true, message: "Container is already stopped" };
+  }
+  if (action === "start" && resolved.running) {
+    return { handled: true, success: true, message: "Container is already running" };
+  }
+
+  const result = await dockerClient.runManagedAction(resolved.ref, action);
+  log.info(
+    `Managed container ${resolved.ref}: ${action} -> ${result?.success ? "ok" : result?.error || "failed"}`,
+  );
+  return { handled: true, ...result };
+}

--- a/server/services/scheduler.js
+++ b/server/services/scheduler.js
@@ -4,6 +4,7 @@ const log = createLogger("Scheduler");
 import panelBridge from "./panelBridge.js";
 import { RconService } from "./rcon.js";
 import { ServerManager } from "./serverManager.js";
+import { runManagedLifecycle } from "./managedContainer.js";
 import {
   getScheduledTasks,
   updateTaskLastRun,
@@ -862,37 +863,62 @@ export class Scheduler {
       }
       await this.sleep(3000);
 
-      // Quit server - skip logging for automated quit
-      log.info("Auto-restart: Sending quit command...");
-      const quit = await rconService.quit({ skipLog: true });
-      if (!quit?.success) {
-        log.warn(
-          `Auto-restart: quit command failed (${quit?.error || "unknown error"}), falling back to a forced stop`,
+      // A container-managed server restarts through Docker. RCON quit only
+      // kills PID 1: the container exits, its restart policy races the panel to
+      // bring the world back, and the panel cannot spawn a process that lives
+      // inside another container anyway.
+      const managed = await runManagedLifecycle("restart", {
+        serverId: pinnedServerId,
+      });
+      if (managed.handled && !managed.success) {
+        const restartDuration = Date.now() - restartStartTime;
+        const errorMsg = `Container restart failed: ${managed.error || "unknown error"}`;
+        log.error(`Auto-restart failed: ${errorMsg}`);
+        await logScheduleExecution(
+          null,
+          "Auto Restart",
+          "restart",
+          false,
+          errorMsg,
+          restartDuration,
         );
-      }
-      await this.sleep(10000);
-
-      // Wait for server to stop
-      let attempts = 0;
-      while ((await serverManager.checkServerRunning()) && attempts < 60) {
-        await this.sleep(1000);
-        attempts++;
+        logServerEvent("auto_restart_error", errorMsg);
+        return { success: false, wasRunning: true, message: errorMsg };
       }
 
-      // Force stop if needed
-      if (await serverManager.checkServerRunning()) {
-        const forced = await serverManager.stopServer(false);
-        if (!forced?.success) {
+      if (!managed.handled) {
+        // Quit server - skip logging for automated quit
+        log.info("Auto-restart: Sending quit command...");
+        const quit = await rconService.quit({ skipLog: true });
+        if (!quit?.success) {
           log.warn(
-            `Auto-restart: forced stop reported failure: ${forced?.error || forced?.message || "unknown error"}`,
+            `Auto-restart: quit command failed (${quit?.error || "unknown error"}), falling back to a forced stop`,
           );
         }
-        await this.sleep(5000);
-      }
+        await this.sleep(10000);
 
-      // Extra delay after stop — give OS time to fully reap the process
-      // (zombie processes on Linux, WMI cache on Windows)
-      await this.sleep(3000);
+        // Wait for server to stop
+        let attempts = 0;
+        while ((await serverManager.checkServerRunning()) && attempts < 60) {
+          await this.sleep(1000);
+          attempts++;
+        }
+
+        // Force stop if needed
+        if (await serverManager.checkServerRunning()) {
+          const forced = await serverManager.stopServer(false);
+          if (!forced?.success) {
+            log.warn(
+              `Auto-restart: forced stop reported failure: ${forced?.error || forced?.message || "unknown error"}`,
+            );
+          }
+          await this.sleep(5000);
+        }
+
+        // Extra delay after stop — give OS time to fully reap the process
+        // (zombie processes on Linux, WMI cache on Windows)
+        await this.sleep(3000);
+      }
 
       // Set flag to prevent RCON auto-reconnect from interfering during startup
       // Use setServerStarting which has a 5-minute failsafe timeout
@@ -902,26 +928,35 @@ export class Scheduler {
         rconService.serverStarting = true;
       }
 
-      // Start server — skip the running check since we just confirmed the server stopped
-      log.info("Auto-restart: Starting server...");
-      await this._ensureRestartTarget(serverManager, pinnedServerId);
-      const restarted = await serverManager.startServer({
-        skipRunningCheck: true,
-      });
-      if (!restarted?.success) {
-        log.warn(
-          `Auto-restart: start command reported failure: ${restarted?.error || restarted?.message || "unknown error"}`,
-        );
-      }
-
-      // Wait for server process to be running (up to 60 seconds)
       let serverStarted = false;
-      for (let i = 0; i < 60; i++) {
-        await this.sleep(1000);
-        if (await serverManager.checkServerRunning()) {
-          serverStarted = true;
-          log.info("Auto-restart: Server process detected as running");
-          break;
+      if (managed.handled) {
+        // `docker restart` only answers once the container is running again, so
+        // there is nothing to poll for here. PZ itself is still booting — the
+        // RCON wait below is the real readiness gate. Polling the process table
+        // would fail outright unless the panel shares the host PID namespace.
+        serverStarted = true;
+        log.info("Auto-restart: Managed container restarted");
+      } else {
+        // Start server — skip the running check since we just confirmed the server stopped
+        log.info("Auto-restart: Starting server...");
+        await this._ensureRestartTarget(serverManager, pinnedServerId);
+        const restarted = await serverManager.startServer({
+          skipRunningCheck: true,
+        });
+        if (!restarted?.success) {
+          log.warn(
+            `Auto-restart: start command reported failure: ${restarted?.error || restarted?.message || "unknown error"}`,
+          );
+        }
+
+        // Wait for server process to be running (up to 60 seconds)
+        for (let i = 0; i < 60; i++) {
+          await this.sleep(1000);
+          if (await serverManager.checkServerRunning()) {
+            serverStarted = true;
+            log.info("Auto-restart: Server process detected as running");
+            break;
+          }
         }
       }
 

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -4,6 +4,7 @@ import fs from "fs";
 import { createLogger } from "../utils/logger.js";
 const log = createLogger("Updates");
 import { getSetting, setSetting, getActiveServer } from "../database/init.js";
+import { resolveManagedContainer } from "./managedContainer.js";
 
 async function getSteamLoginArgs() {
   const account = String((await getSetting("steamUpdateAccount")) || "").trim();
@@ -487,6 +488,14 @@ export class UpdateChecker {
       }
       const activeServer = await getActiveServer();
       const steamcmdPath = await getSetting("steamcmdPath");
+      // Refuse a container-managed server outright. Its image owns the game
+      // install, and the stop below would RCON-quit a process the container's
+      // restart policy immediately brings back — turning this into a silent
+      // five-minute wait that ends in a misleading timeout.
+      const managed = await resolveManagedContainer({ serverId: activeServer?.id });
+      if (managed.handled) {
+        throw new Error("This server runs in a panel-managed Docker container. Update the container image instead — the panel does not run SteamCMD against a managed container.");
+      }
       if (!activeServer?.installPath || !steamcmdPath) throw new Error("SteamCMD path or server install path is not configured");
 
       if (await this.serverManager.checkServerRunning()) {

--- a/server/tests/dockerClient.test.js
+++ b/server/tests/dockerClient.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isManagedContainer, parseContainerStats } from "../services/dockerClient.js";
+import { isManagedContainer, lifecycleTimeoutMs, parseContainerStats } from "../services/dockerClient.js";
 
 describe("Docker managed-container boundary", () => {
   it("accepts only containers explicitly opted into panel management", () => {
@@ -7,6 +7,28 @@ describe("Docker managed-container boundary", () => {
     expect(isManagedContainer({ Config: { Labels: { "zomboid-panel.managed": "true" } } })).toBe(true);
     expect(isManagedContainer({ Labels: { "zomboid-panel.role": "pz-server" } })).toBe(false);
     expect(isManagedContainer({ Image: "ich777/steamcmd:projectzomboid", Labels: {} })).toBe(false);
+  });
+});
+
+describe("lifecycleTimeoutMs", () => {
+  it("waits out the container's own stop grace period", () => {
+    // A modded B42 world sets stop_grace_period: 90s, which Compose writes to
+    // the container as StopTimeout. Anything shorter aborts the socket and
+    // reports a failure on a stop Docker went on to complete.
+    const container = { Config: { StopTimeout: 90 } };
+    expect(lifecycleTimeoutMs("stop", container)).toBeGreaterThan(90_000);
+    expect(lifecycleTimeoutMs("restart", container)).toBeGreaterThan(
+      lifecycleTimeoutMs("stop", container),
+    );
+  });
+
+  it("falls back to Docker's own default when the container sets no timeout", () => {
+    expect(lifecycleTimeoutMs("stop", { Config: {} })).toBe(10_000 + 30_000);
+    expect(lifecycleTimeoutMs("stop", undefined)).toBe(10_000 + 30_000);
+  });
+
+  it("does not budget a shutdown window for a start", () => {
+    expect(lifecycleTimeoutMs("start", { Config: { StopTimeout: 90 } })).toBe(30_000);
   });
 });
 

--- a/server/tests/managedContainer.test.js
+++ b/server/tests/managedContainer.test.js
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getServer, getActiveServer } = vi.hoisted(() => ({
+  getServer: vi.fn(),
+  getActiveServer: vi.fn(),
+}));
+
+vi.mock("../database/init.js", () => ({ getServer, getActiveServer }));
+
+const { runManagedLifecycle, resolveManagedContainer, setDockerClient } =
+  await import("../services/managedContainer.js");
+
+function createClient(overrides = {}) {
+  return {
+    enabled: true,
+    available: true,
+    inspectManagedContainer: vi.fn(async () => ({ State: { Running: true } })),
+    runManagedAction: vi.fn(async () => ({ success: true })),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  getServer.mockReset();
+  getActiveServer.mockReset();
+  setDockerClient(null);
+});
+
+describe("resolveManagedContainer", () => {
+  it("declines when Docker control is disabled", async () => {
+    getActiveServer.mockResolvedValue({ dockerContainerName: "pz" });
+    const client = createClient({ enabled: false });
+
+    expect(await resolveManagedContainer({ dockerClient: client })).toEqual({
+      handled: false,
+    });
+    expect(client.inspectManagedContainer).not.toHaveBeenCalled();
+  });
+
+  it("declines when the socket is not reachable", async () => {
+    getActiveServer.mockResolvedValue({ dockerContainerName: "pz" });
+
+    expect(
+      await resolveManagedContainer({ dockerClient: createClient({ available: false }) }),
+    ).toEqual({ handled: false });
+  });
+
+  it("declines when the server maps no container", async () => {
+    getActiveServer.mockResolvedValue({ id: "s1", dockerContainerName: null });
+
+    expect(await resolveManagedContainer({ dockerClient: createClient() })).toEqual({
+      handled: false,
+    });
+  });
+
+  it("falls back to the container id when no name is mapped", async () => {
+    getActiveServer.mockResolvedValue({ dockerContainerId: "abc123" });
+    const client = createClient();
+
+    const resolved = await resolveManagedContainer({ dockerClient: client });
+
+    expect(client.inspectManagedContainer).toHaveBeenCalledWith("abc123");
+    expect(resolved.ref).toBe("abc123");
+  });
+
+  it("reads the pinned server rather than the active one when given an id", async () => {
+    getServer.mockResolvedValue({ dockerContainerName: "pinned" });
+    const client = createClient();
+
+    await resolveManagedContainer({ serverId: "s9", dockerClient: client });
+
+    expect(getServer).toHaveBeenCalledWith("s9");
+    expect(getActiveServer).not.toHaveBeenCalled();
+  });
+
+  it("claims the action but fails when the mapped container is unmanageable", async () => {
+    getActiveServer.mockResolvedValue({ dockerContainerName: "pz" });
+    const client = createClient({ inspectManagedContainer: vi.fn(async () => null) });
+
+    const resolved = await resolveManagedContainer({ dockerClient: client });
+
+    // Must not decline: falling back to RCON would kill the process and let the
+    // restart policy bring the container straight back up.
+    expect(resolved.handled).toBe(true);
+    expect(resolved.error).toMatch(/zomboid-panel\.managed=true/);
+  });
+});
+
+describe("runManagedLifecycle", () => {
+  it("stops through Docker instead of the process path", async () => {
+    getActiveServer.mockResolvedValue({ dockerContainerName: "pz" });
+    const client = createClient();
+
+    const result = await runManagedLifecycle("stop", { dockerClient: client });
+
+    expect(client.runManagedAction).toHaveBeenCalledWith("pz", "stop");
+    expect(result).toEqual({ handled: true, success: true });
+  });
+
+  it("treats an already stopped container as a successful stop", async () => {
+    getActiveServer.mockResolvedValue({ dockerContainerName: "pz" });
+    const client = createClient({
+      inspectManagedContainer: vi.fn(async () => ({ State: { Running: false } })),
+    });
+
+    const result = await runManagedLifecycle("stop", { dockerClient: client });
+
+    expect(client.runManagedAction).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+  });
+
+  it("treats an already running container as a successful start", async () => {
+    getActiveServer.mockResolvedValue({ dockerContainerName: "pz" });
+    const client = createClient();
+
+    const result = await runManagedLifecycle("start", { dockerClient: client });
+
+    expect(client.runManagedAction).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+  });
+
+  it("restarts a running container through Docker", async () => {
+    getActiveServer.mockResolvedValue({ dockerContainerName: "pz" });
+    const client = createClient();
+
+    await runManagedLifecycle("restart", { dockerClient: client });
+
+    expect(client.runManagedAction).toHaveBeenCalledWith("pz", "restart");
+  });
+
+  it("surfaces a Docker failure instead of silently declining", async () => {
+    getActiveServer.mockResolvedValue({ dockerContainerName: "pz" });
+    const client = createClient({
+      runManagedAction: vi.fn(async () => ({ success: false, error: "Docker action failed" })),
+    });
+
+    expect(await runManagedLifecycle("stop", { dockerClient: client })).toEqual({
+      handled: true,
+      success: false,
+      error: "Docker action failed",
+    });
+  });
+
+  it("uses the client wired through setDockerClient", async () => {
+    getActiveServer.mockResolvedValue({ dockerContainerName: "pz" });
+    const client = createClient();
+    setDockerClient(client);
+
+    await runManagedLifecycle("stop");
+
+    expect(client.runManagedAction).toHaveBeenCalledWith("pz", "stop");
+  });
+
+  it("declines when no client has been wired at all", async () => {
+    getActiveServer.mockResolvedValue({ dockerContainerName: "pz" });
+
+    expect(await runManagedLifecycle("stop")).toEqual({ handled: false });
+  });
+});


### PR DESCRIPTION
## Problem

Stopping a Project Zomboid server that runs in a Docker container doesn't stop it. The panel reports success, the world goes down, and a moment later it is back up.

## Root cause

RCON `quit` and `serverManager.stopServer()` both act on the *process*. Inside a container that process is PID 1, so ending it exits the container — and a `restart: always` / `unless-stopped` policy immediately brings it back. Only `docker stop` counts as a **manual** stop, which Docker [exempts from restart policies](https://docs.docker.com/engine/containers/start-containers-automatically/#restart-policy-details).

`Servers.tsx` already hides its RCON start/stop controls when a managed container is mapped, but three other surfaces never got the same treatment:

- the Dashboard control bar (`Stop`, `Force stop`, `Restart`)
- the Discord bot's `/stop` and `/start`
- `Scheduler.performRestart()`, so scheduled restarts and `AUTO_RESTART_CRON` as well

Fixing this in the Dashboard alone would have left Discord and the scheduler broken, so the decision moved server-side.

## What changed

`server/services/managedContainer.js` is a single decision point. When the target server maps a container the panel can manage, the action goes to Docker; otherwise `runManagedLifecycle()` returns `{ handled: false }` and the caller keeps its existing RCON/process path untouched.

| Surface | Before | After |
| --- | --- | --- |
| `POST /api/server/stop` | RCON save + quit | RCON save, then `docker stop` |
| `POST /api/server/force-stop` | SIGKILL by PID | `docker stop` (no RCON required — the escape hatch when RCON is dead) |
| `POST /api/server/start` | spawn a local process | `docker start`; startup-script generation skipped, the image owns the launch command |
| Discord `/stop`, `/start` | RCON quit / spawn | same routing |
| `Scheduler.performRestart()` | quit → wait → force-kill → spawn | `docker restart`; the existing RCON wait still gates readiness |

It **fails closed**: a container that is mapped but unmanageable (missing, or without `zomboid-panel.managed=true`) returns an error rather than falling through to RCON, because that fallback is exactly what produces the respawn.

`UpdateChecker.runAutoUpdate()` now refuses a managed container outright. Previously it RCON-quit the server and then waited five minutes for a process the restart policy kept restoring, ending in a misleading "Server did not stop within 5 minutes".

## Two defects that made this hard to diagnose

**`runManagedAction` reused the 5 s read timeout.** `POST /containers/{id}/stop` blocks until the container is down, and Compose writes `stop_grace_period` to the container as `StopTimeout` — 90 s is normal for a modded B42 world. The socket was torn down long before Docker answered, so *every successful stop* reported `"Docker action failed"`. The budget now derives from the container's own `StopTimeout`; reads still use 5 s.

**`listManagedContainers` swallowed its error at debug level.** Since `available` is only an `existsSync` check, a socket the panel can stat but not open (`root:docker 0660` vs. a non-root panel user) was indistinguishable from "no managed containers exist" — `{enabled: true, available: true, containers: []}` with nothing in the logs. It is now a warning, and `lastError` is surfaced through `/api/docker/status`.

## Second commit: `setpriv --clear-groups` vs. `group_add`

The entrypoint dropped privileges with `setpriv --reuid --regid --clear-groups`, which wipes every supplementary group before Node starts. That makes `group_add` useless for reaching any host resource whose group differs from `PGID` — including `/var/run/docker.sock`, which the Docker controls need. The documented way to grant socket access silently did nothing, and combined with the swallowed EACCES above it produced no diagnosable symptom.

Supplementary groups are now carried across the drop. gid 0 is excluded so root group membership is not handed to an unprivileged process, and `PGID` is already applied via `--regid`. A container started without `group_add` keeps the previous `--clear-groups` behaviour exactly.

## Behaviour when Docker control is off

Unchanged. `PANEL_DOCKER_CONTROL_ENABLED` is off by default, and without it `runManagedLifecycle()` declines every action, so all existing code paths run as before. Servers with no mapped container behave identically even when Docker control is on.

## Verification

468/468 server tests pass (9 new), ESLint clean.

Beyond the unit tests, both changes were exercised against a real Docker daemon rather than asserted:

```
# entrypoint, real Debian container
WITH --group-add 998   -> uid=1000 gid=1000 groups=1000,998
WITHOUT group_add      -> uid=1000 gid=1000 groups=1000     (unchanged, no gid 0 leaked)

# lifecycle, labelled container with restart:always and a stop-timeout
graceful PID-1 exit     -> state=running, StartedAt changed   # the bug, reproduced
runManagedAction(stop)  -> {"success":true} in 8877ms         # old 5s timeout would have failed this
after stop              -> state=exited, policy=always        # restart policy did not fire
```

Confirmed in production afterwards: the container reports exit code 143 (SIGTERM, not 137/SIGKILL — the image's shutdown handler ran inside the grace window) and stays stopped under `restart: always`.
