### PR TITLE
fix: warn about B42.20.3 username disguise crash

### DIFF
--- a/client/src/known-issues.css
+++ b/client/src/known-issues.css
@@ -1,0 +1,17 @@
+/* Known Project Zomboid issues that need an inline warning next to affected settings. */
+.perf-content-auto:has([aria-label="Username Disguises"]) > div:first-child > div:first-child::after,
+.perf-content-auto:has([aria-label="Hide Disguised Names"]) > div:first-child > div:first-child::after {
+  display: block;
+  margin-top: 0.375rem;
+  color: hsl(var(--warning));
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.perf-content-auto:has([aria-label="Username Disguises"]) > div:first-child > div:first-child::after {
+  content: "⚠ Known Project Zomboid 42.20.3 multiplayer issue: enabling this setting can crash clients while loading into the world. Keep it disabled until fixed upstream.";
+}
+
+.perf-content-auto:has([aria-label="Hide Disguised Names"]) > div:first-child > div:first-child::after {
+  content: "⚠ Known Project Zomboid 42.20.3 multiplayer issue: this setting can trigger the same loading crash. Keep it disabled until fixed upstream.";
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter, HashRouter } from 'react-router-dom'
 import App from './App'
 import './index.css'
+import './known-issues.css'
 import { isDemoMode, installDemoFetchShim } from './lib/demo'
 
 const Router = isDemoMode() ? HashRouter : BrowserRouter


### PR DESCRIPTION
## Summary

Adds an inline warning to the `UsernameDisguises` and `HideDisguisedUserName` server settings.

In Project Zomboid 42.20.3, enabling these settings can cause multiplayer clients to crash while loading into the world.

## Issue

The crash was reproduced on a dedicated 42.20.3 server with:

```text
java.lang.NullPointerException:
Cannot invoke "zombie.characters.Role.hasCapability(...)"
because "player.role" is null
at IsoPlayer.getUsername(...)
```

Disabling `UsernameDisguises` and `HideDisguisedUserName` allowed the same client to join normally.

The issue has also been reported upstream to Project Zomboid:

https://theindiestone.com/forums/topic/96995-4220-usernamedisguises-crashes-host-during-startup/

## Change

The affected settings now display a small warning in the panel's existing warning color.

The warning is informational only. The panel does not automatically disable, block, or otherwise modify either setting.

## Validation

- Manually tested in Server Configuration → Chat & Communication
- Verified both warnings render correctly
- Client lint passed
- TypeScript typecheck passed
- Client tests passed
- Server lint/tests passed
- CodeQL passed
- AIO Docker build passed