### PR TITLE
fix(dashboard): route panel update banner to updates

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1049,7 +1049,7 @@ export default function Dashboard() {
               >
                 <X className="h-3.5 w-3.5" />
               </Button>
-              <Link to="/settings?tab=panel">
+              <Link to="/settings?tab=updates">
                 <Button
                   size="sm"
                   variant={lastFailed ? 'destructive' : 'default'}


### PR DESCRIPTION
## Summary

Fixes the dashboard panel-update banner CTA so it opens the actual **Updates** settings tab.

The banner currently links to `?tab=panel`, but `panel` is a legacy alias that now resolves to the General tab. The updater UI lives under `?tab=updates`.

## Validation

- Client lint passed
- TypeScript typecheck passed
- Client tests passed
- Branch is based on current upstream `main` (v1.2.3)