### PR TITLE
fix(settings): persist Steam cookies to canonical secret storage

### DIFF
--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -36,6 +36,7 @@ import {
   MAX_MEMORY_GB_MAX,
 } from "./server.js";
 import { parseBoundedInteger } from "../utils/queryNumbers.js";
+import { setSteamSessionCredentials } from "../services/steamSessionCredentials.js";
 
 // Local to this route: autoExportMaxPerPlayer has no counterpart check in
 // server.js (or anywhere else), so unlike the port/memory constants above
@@ -773,8 +774,25 @@ router.put("/app-settings", requirePermission("panel.settings"), async (req, res
       });
     }
 
+    const steamSessionIdEntry = filtered.find(
+      ([key]) => key === "steamSessionId",
+    );
+    const steamLoginSecureEntry = filtered.find(
+      ([key]) => key === "steamLoginSecure",
+    );
+    if (steamSessionIdEntry || steamLoginSecureEntry) {
+      await setSteamSessionCredentials(
+        steamSessionIdEntry?.[1],
+        steamLoginSecureEntry?.[1],
+      );
+    }
+
     for (const [key, value] of filtered) {
-      if (key === "modCheckInterval") continue;
+      if (
+        key === "modCheckInterval" ||
+        key === "steamSessionId" ||
+        key === "steamLoginSecure"
+      ) continue;
       await setSetting(key, value);
     }
 

--- a/server/routes/mods.js
+++ b/server/routes/mods.js
@@ -1476,7 +1476,7 @@ router.post("/collection/extract-cookies", async (req, res) => {
     // caller (this router's own permission floor) could ask this one
     // endpoint for the panel host's live Steam login token; now it can't
     // (2026-08-26 bug hunt, extract-cookies response shape finding).
-    setSteamSessionCredentials(result.sessionid, result.steamLoginSecure);
+    await setSteamSessionCredentials(result.sessionid, result.steamLoginSecure);
     res.json({
       ok: true,
       browser: result.browser,
@@ -1533,7 +1533,7 @@ router.post("/collection/extension-push", async (req, res) => {
         });
     }
 
-    setSteamSessionCredentials(sessionid, loginSecure);
+    await setSteamSessionCredentials(sessionid, loginSecure);
 
     log.info(
       `Steam cookies updated via browser extension (user: ${req.user?.username || "unknown"})`,

--- a/server/services/steamSessionCredentials.js
+++ b/server/services/steamSessionCredentials.js
@@ -1,0 +1,75 @@
+import { getSetting, setSetting } from "../database/init.js";
+import { createLogger } from "../utils/logger.js";
+import {
+  loadUiSecret,
+  readUiSecretFile,
+  replaceUiSecretFiles,
+} from "../utils/uiSecretFile.js";
+
+const log = createLogger("SteamSessionCredentials");
+
+export async function getSteamSessionCredentials() {
+  const [legacySessionId, legacyLoginSecure] = await Promise.all([
+    getSetting("steamSessionId"),
+    getSetting("steamLoginSecure"),
+  ]);
+  const [sessionId, loginSecure] = await Promise.all([
+    loadUiSecret("steamSessionId", {
+      legacyValue: legacySessionId,
+      clearLegacy: () => setSetting("steamSessionId", null),
+      log,
+    }),
+    loadUiSecret("steamLoginSecure", {
+      legacyValue: legacyLoginSecure,
+      clearLegacy: () => setSetting("steamLoginSecure", null),
+      log,
+    }),
+  ]);
+  return { sessionId, loginSecure };
+}
+
+/**
+ * Persist the cookie pair in canonical secret files. An undefined argument
+ * means "unchanged", which lets partial Settings saves preserve the other
+ * half of the pair. Legacy database copies are removed only after the new
+ * pair has been activated and read back through the production reader.
+ */
+export async function setSteamSessionCredentials(sessionId, loginSecure) {
+  const [legacySessionId, legacyLoginSecure] = await Promise.all([
+    getSetting("steamSessionId"),
+    getSetting("steamLoginSecure"),
+  ]);
+  const currentSessionId =
+    readUiSecretFile("steamSessionId", log) ?? legacySessionId;
+  const currentLoginSecure =
+    readUiSecretFile("steamLoginSecure", log) ?? legacyLoginSecure;
+  const nextSessionId =
+    sessionId === undefined ? currentSessionId : sessionId;
+  const nextLoginSecure =
+    loginSecure === undefined ? currentLoginSecure : loginSecure;
+
+  try {
+    replaceUiSecretFiles([
+      ["steamSessionId", nextSessionId],
+      ["steamLoginSecure", nextLoginSecure],
+    ]);
+    const normalize = (value) => {
+      if (value == null || value === "") return null;
+      return String(value).trim() || null;
+    };
+    if (
+      readUiSecretFile("steamSessionId", log) !== normalize(nextSessionId) ||
+      readUiSecretFile("steamLoginSecure", log) !== normalize(nextLoginSecure)
+    ) {
+      throw new Error("canonical read-back verification failed");
+    }
+    await Promise.all([
+      setSetting("steamSessionId", null),
+      setSetting("steamLoginSecure", null),
+    ]);
+  } catch (err) {
+    throw new Error(
+      `Could not persist Steam session credentials: ${err.message}`,
+    );
+  }
+}

--- a/server/services/workshopCollectionSync.js
+++ b/server/services/workshopCollectionSync.js
@@ -22,8 +22,13 @@
  */
 
 import { createLogger } from '../utils/logger.js';
-import { getSetting, setSetting } from '../database/init.js';
-import { loadUiSecret, writeUiSecretFile } from '../utils/uiSecretFile.js';
+import { getSetting } from '../database/init.js';
+import {
+  getSteamSessionCredentials,
+  setSteamSessionCredentials,
+} from './steamSessionCredentials.js';
+
+export { getSteamSessionCredentials, setSteamSessionCredentials };
 
 const log = createLogger('WorkshopCollectionSync');
 
@@ -148,32 +153,6 @@ export async function fetchPublishedFileTitles(workshopIds) {
  * goes through this instead of getSetting directly, so the migration logic
  * lives in one place.
  */
-export async function getSteamSessionCredentials() {
-  const [legacySessionId, legacyLoginSecure] = await Promise.all([
-    getSetting('steamSessionId'),
-    getSetting('steamLoginSecure'),
-  ]);
-  const [sessionId, loginSecure] = await Promise.all([
-    loadUiSecret('steamSessionId', {
-      legacyValue: legacySessionId,
-      clearLegacy: () => setSetting('steamSessionId', null),
-      log,
-    }),
-    loadUiSecret('steamLoginSecure', {
-      legacyValue: legacyLoginSecure,
-      clearLegacy: () => setSetting('steamLoginSecure', null),
-      log,
-    }),
-  ]);
-  return { sessionId, loginSecure };
-}
-
-/** Synchronous — file I/O, not a settings-store write. */
-export function setSteamSessionCredentials(sessionId, loginSecure) {
-  writeUiSecretFile('steamSessionId', sessionId);
-  writeUiSecretFile('steamLoginSecure', loginSecure);
-}
-
 /**
  * Build the cookie header from settings. Returns null if either piece is missing.
  */

--- a/server/tests/appSettingsCapabilityPartition.test.js
+++ b/server/tests/appSettingsCapabilityPartition.test.js
@@ -46,11 +46,16 @@ const ROLES = {
 const getRoleByName = vi.fn(async (name) => ROLES[name] || null);
 const getAllSettings = vi.fn();
 const setSetting = vi.fn();
+const setSteamSessionCredentials = vi.fn();
 
 vi.mock("../database/init.js", () => ({
   getAllSettings,
   setSetting,
   getRoleByName,
+}));
+
+vi.mock("../services/steamSessionCredentials.js", () => ({
+  setSteamSessionCredentials,
 }));
 
 const { default: router } = await import("../routes/config.js");
@@ -91,6 +96,7 @@ describe("PUT /config/app-settings -- per-key capability partition", () => {
   beforeEach(() => {
     getAllSettings.mockReset();
     setSetting.mockReset();
+    setSteamSessionCredentials.mockReset().mockResolvedValue(undefined);
     getRoleByName.mockClear();
   });
 
@@ -226,7 +232,10 @@ describe("PUT /config/app-settings -- per-key capability partition", () => {
       "discordGuildId",
       "123456789012345678",
     );
-    expect(setSetting).toHaveBeenCalledWith("steamSessionId", "new-session");
+    expect(setSteamSessionCredentials).toHaveBeenCalledWith(
+      "new-session",
+      undefined,
+    );
     expect(response.json).toHaveBeenCalledWith(
       expect.objectContaining({ success: true }),
     );

--- a/server/tests/appSettingsRoute.test.js
+++ b/server/tests/appSettingsRoute.test.js
@@ -3,11 +3,16 @@ import { mockGetRoleByName } from "./helpers/mockPermissionsDb.js";
 
 const getAllSettings = vi.fn();
 const setSetting = vi.fn();
+const setSteamSessionCredentials = vi.fn();
 
 vi.mock("../database/init.js", () => ({
   getAllSettings,
   setSetting,
   getRoleByName: mockGetRoleByName,
+}));
+
+vi.mock("../services/steamSessionCredentials.js", () => ({
+  setSteamSessionCredentials,
 }));
 
 const { default: router } = await import("../routes/config.js");
@@ -63,10 +68,76 @@ describe("GET /api/config/app-settings", () => {
 });
 
 describe("PUT /api/config/app-settings", () => {
+  beforeEach(() => {
+    setSetting.mockReset();
+    setSteamSessionCredentials.mockReset().mockResolvedValue(undefined);
+  });
+
   function makeApp(overrides = {}) {
     const values = { modChecker: null, serverManager: null, rconService: null, ...overrides };
     return { get: (key) => values[key] };
   }
+
+  it("writes Steam cookies through canonical secret storage instead of db.json", async () => {
+    setSetting.mockReset();
+    setSteamSessionCredentials.mockReset().mockResolvedValue(undefined);
+    getAllSettings.mockResolvedValue({
+      steamSessionId: "old-session",
+      steamLoginSecure: "old-login",
+    });
+    const response = createResponse();
+
+    await runRoute(
+      "/app-settings",
+      "put",
+      {
+        body: {
+          settings: {
+            steamSessionId: "new-session",
+            steamLoginSecure: "new-login",
+          },
+        },
+        user: { role: "admin" },
+        app: makeApp(),
+      },
+      response,
+    );
+
+    expect(setSteamSessionCredentials).toHaveBeenCalledWith(
+      "new-session",
+      "new-login",
+    );
+    expect(setSetting).not.toHaveBeenCalledWith("steamSessionId", expect.anything());
+    expect(setSetting).not.toHaveBeenCalledWith("steamLoginSecure", expect.anything());
+  });
+
+  it("passes an omitted or masked Steam cookie as unchanged during a partial update", async () => {
+    setSetting.mockReset();
+    setSteamSessionCredentials.mockReset().mockResolvedValue(undefined);
+    getAllSettings.mockResolvedValue({ steamSessionId: "old-session" });
+    const response = createResponse();
+
+    await runRoute(
+      "/app-settings",
+      "put",
+      {
+        body: {
+          settings: {
+            steamSessionId: "replacement-session",
+            steamLoginSecure: "••••••••1234",
+          },
+        },
+        user: { role: "admin" },
+        app: makeApp(),
+      },
+      response,
+    );
+
+    expect(setSteamSessionCredentials).toHaveBeenCalledWith(
+      "replacement-session",
+      undefined,
+    );
+  });
 
   it("is rejected for a non-admin authenticated user (Finding 5)", async () => {
     const response = createResponse();

--- a/server/tests/steamSessionMigration.test.js
+++ b/server/tests/steamSessionMigration.test.js
@@ -19,7 +19,7 @@ vi.mock("../utils/paths.js", () => ({
 
 const { getSteamSessionCredentials, setSteamSessionCredentials } =
   await import("../services/workshopCollectionSync.js");
-const { readUiSecretFile } = await import("../utils/uiSecretFile.js");
+const { readUiSecretFile, writeUiSecretFile } = await import("../utils/uiSecretFile.js");
 
 describe("Steam session cookie pair — migration out of db.json", () => {
   beforeEach(() => {
@@ -55,15 +55,72 @@ describe("Steam session cookie pair — migration out of db.json", () => {
   });
 
   it("cookies pushed via setSteamSessionCredentials are written to files, not db.json, and read back correctly", async () => {
-    setSteamSessionCredentials("fresh-session-id", "fresh-login-secure");
+    await setSteamSessionCredentials("fresh-session-id", "fresh-login-secure");
 
-    expect(settings.get("steamSessionId")).toBeUndefined();
-    expect(settings.get("steamLoginSecure")).toBeUndefined();
+    expect(settings.get("steamSessionId")).toBeNull();
+    expect(settings.get("steamLoginSecure")).toBeNull();
 
     const result = await getSteamSessionCredentials();
     expect(result).toEqual({
       sessionId: "fresh-session-id",
       loginSecure: "fresh-login-secure",
+    });
+  });
+
+  it("atomically replaces an existing canonical pair and clears stale database values", async () => {
+    writeUiSecretFile("steamSessionId", "old-file-session");
+    writeUiSecretFile("steamLoginSecure", "old-file-login");
+    settings.set("steamSessionId", "stale-db-session");
+    settings.set("steamLoginSecure", "stale-db-login");
+
+    await setSteamSessionCredentials("new-file-session", "new-file-login");
+
+    expect(await getSteamSessionCredentials()).toEqual({
+      sessionId: "new-file-session",
+      loginSecure: "new-file-login",
+    });
+    expect(settings.get("steamSessionId")).toBeNull();
+    expect(settings.get("steamLoginSecure")).toBeNull();
+  });
+
+  it("preserves the canonical counterpart when only one cookie is updated", async () => {
+    await setSteamSessionCredentials("initial-session", "initial-login");
+
+    await setSteamSessionCredentials("replacement-session", undefined);
+
+    expect(await getSteamSessionCredentials()).toEqual({
+      sessionId: "replacement-session",
+      loginSecure: "initial-login",
+    });
+  });
+
+  it("restores the complete previous pair when the second activation fails", async () => {
+    await setSteamSessionCredentials("stable-session", "stable-login");
+    const originalRename = fs.renameSync.bind(fs);
+    const renameSpy = vi.spyOn(fs, "renameSync").mockImplementation((source, destination) => {
+      if (
+        String(source).includes(".tmp-") &&
+        String(destination).endsWith("steamLoginSecure.secret")
+      ) {
+        throw Object.assign(new Error("simulated second-file failure"), { code: "EIO" });
+      }
+      return originalRename(source, destination);
+    });
+
+    const failedWrite = setSteamSessionCredentials(
+      "uncommitted-session",
+      "uncommitted-login",
+    );
+    await expect(failedWrite).rejects.toThrow(
+      "Could not persist Steam session credentials",
+    );
+    await expect(failedWrite).rejects.not.toThrow("uncommitted-session");
+    await expect(failedWrite).rejects.not.toThrow("uncommitted-login");
+    renameSpy.mockRestore();
+
+    expect(await getSteamSessionCredentials()).toEqual({
+      sessionId: "stable-session",
+      loginSecure: "stable-login",
     });
   });
 

--- a/server/utils/uiSecretFile.js
+++ b/server/utils/uiSecretFile.js
@@ -27,6 +27,12 @@ function secretFilePath(name) {
   return path.join(getDataPaths().dataDir, `${name}.secret`);
 }
 
+function normalizeUiSecret(value) {
+  if (value == null || value === "") return null;
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
 export function readUiSecretFile(name, log) {
   const filePath = secretFilePath(name);
   if (!fs.existsSync(filePath)) return null;
@@ -61,6 +67,100 @@ export function writeUiSecretFile(name, value) {
     fs.chmodSync(filePath, 0o600);
   } catch {
     /* best-effort: Windows / network shares */
+  }
+}
+
+/**
+ * Replace a related set of UI secrets as one filesystem transaction.
+ * Every new value is staged and verified before a live file is touched.
+ * Existing files remain available as backups until every replacement has
+ * been activated and verified; any failure restores the complete old set.
+ */
+export function replaceUiSecretFiles(entries) {
+  const transactionId = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const files = entries.map(([name, value]) => {
+    const target = secretFilePath(name);
+    return {
+      name,
+      value: normalizeUiSecret(value),
+      target,
+      staged: `${target}.tmp-${transactionId}`,
+      backup: `${target}.bak-${transactionId}`,
+      hadOriginal: fs.existsSync(target),
+      backedUp: false,
+      activated: false,
+    };
+  });
+
+  try {
+    for (const file of files) {
+      if (file.value === null) continue;
+      fs.writeFileSync(file.staged, file.value, {
+        encoding: "utf8",
+        mode: 0o600,
+        flag: "wx",
+      });
+      if (fs.readFileSync(file.staged, "utf8").trim() !== file.value) {
+        throw new Error(`staged verification failed for ${file.name}`);
+      }
+    }
+
+    for (const file of files) {
+      if (file.hadOriginal) {
+        fs.renameSync(file.target, file.backup);
+        file.backedUp = true;
+      }
+    }
+    for (const file of files) {
+      if (file.value !== null) {
+        fs.renameSync(file.staged, file.target);
+        file.activated = true;
+      }
+    }
+
+    for (const file of files) {
+      if (readUiSecretFile(file.name) !== file.value) {
+        throw new Error(`live verification failed for ${file.name}`);
+      }
+      if (file.value !== null) {
+        try {
+          fs.chmodSync(file.target, 0o600);
+        } catch {
+          /* best-effort: Windows / network shares */
+        }
+      }
+    }
+
+    for (const file of files) {
+      try {
+        fs.unlinkSync(file.backup);
+      } catch {
+        /* no previous file */
+      }
+    }
+  } catch (err) {
+    const rollbackErrors = [];
+    for (const file of files) {
+      try {
+        if ((file.activated || file.backedUp) && fs.existsSync(file.target)) {
+          fs.unlinkSync(file.target);
+        }
+        if (file.backedUp && fs.existsSync(file.backup)) {
+          fs.renameSync(file.backup, file.target);
+        }
+      } catch (rollbackErr) {
+        rollbackErrors.push(`${file.name}: ${rollbackErr.message}`);
+      }
+      try {
+        if (fs.existsSync(file.staged)) fs.unlinkSync(file.staged);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+    const rollbackDetail = rollbackErrors.length
+      ? `; rollback incomplete (${rollbackErrors.join(", ")})`
+      : "";
+    throw new Error(`UI secret transaction failed: ${err.message}${rollbackDetail}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Persist Steam `sessionid` and `steamLoginSecure` values through their canonical secret-file storage from every write path, including the panel Settings endpoint.

## Root Cause

The production reader prefers the dedicated `.secret` files, but `PUT /app-settings` wrote new Steam cookies through the legacy database settings API. When an older secret file already existed, the reader continued returning that stale value after a successful Settings save.

## Changes

- Route Settings saves through an awaited `setSteamSessionCredentials()` operation.
- Preserve an omitted or masked counterpart during partial updates.
- Stage and verify both secret files, activate them as a pair, and restore the complete previous pair if either activation fails.
- Verify canonical storage before clearing legacy database copies.
- Await the same operation for browser-extraction and extension-push writes.
- Keep cookie values out of responses, logs, and persistence errors.

## Regression Proof

The new tests fail on the previous implementation because Settings calls `setSetting()` for both cookie keys, partial updates delete the counterpart, stale database values are not cleared, and a second-file failure can leave a mixed pair. They pass with the transactional canonical-storage path.

## Test Results

- `npx vitest run server/tests/steamSessionMigration.test.js server/tests/appSettingsRoute.test.js server/tests/appSettingsCapabilityPartition.test.js server/tests/modsExtractCookiesResponseShape.test.js` — 31 passed
- `npm run lint:server` — passed
- `npm run test:server` — 2,679 passed, 14 skipped
- `cd client && npm run lint` — passed with 66 pre-existing warnings and no errors
- `cd client && npx vitest run` — passed
- `cd client && npm run build` — passed (includes TypeScript project build)
- `git diff --check` — passed

## Risks

The transaction performs short synchronous filesystem operations for two small credential files. On a filesystem that cannot atomically rename files, the request fails and attempts to restore both previous files; no cookie contents are included in the error.

## Rollback

Revert this commit to restore the previous independent secret-file writer and database-backed Settings behavior. Existing canonical `.secret` files remain readable by the previous code.
