### PR TITLE
fix(updater): activate frontend and backend as one versioned bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,40 @@ jobs:
       - name: Tests
         working-directory: client
         run: npx vitest run
+
+  windows-packaged-updater:
+    name: Windows packaged updater
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install server dependencies
+        run: npm install --no-audit --prefer-offline --include=optional
+
+      - name: Install client dependencies
+        working-directory: client
+        run: npm install --no-audit --prefer-offline --include=optional
+
+      - name: Exercise bundle transaction and generated supervisor
+        run: npx vitest run server/tests/panelUpdateBundle.test.js server/tests/supervisor-restart.test.js
+
+      - name: Build packaged Windows executable
+        run: node build.js --windows
+
+      - name: Verify packaged updater artifacts
+        shell: pwsh
+        run: |
+          if (-not (Test-Path release\ZomboidControlPanel.exe)) { throw "Packaged executable is missing" }
+          if (-not (Test-Path release\Start.bat)) { throw "Generated supervisor is missing" }
+          $buildInfo = Get-Content release\client\dist\build-info.json -Raw | ConvertFrom-Json
+          $manifest = Get-Content release\release-manifest.json -Raw | ConvertFrom-Json
+          if ($buildInfo.panelVersion -ne $manifest.version) { throw "Frontend/backend version mismatch" }
+          if ($buildInfo.buildSha -ne $manifest.buildSha) { throw "Frontend/backend build SHA mismatch" }
+          if ($buildInfo.apiContractVersion -ne $manifest.apiContractVersion) { throw "Frontend/backend API contract mismatch" }

--- a/build.js
+++ b/build.js
@@ -243,8 +243,8 @@ set "APPLYING=%INSTALL_DIR%.update-applying"
 set "JOURNAL=%INSTALL_DIR%update-bundle.json"
 set "BASE_EXE=ZomboidControlPanel.exe"
 set "BIN_BACKUP=ZomboidControlPanel.exe.bundle-previous"
-set "CLIENT_LIVE=%INSTALL_DIR%client\dist"
-set "CLIENT_BACKUP=%INSTALL_DIR%client\dist.previous"
+set "CLIENT_LIVE=%INSTALL_DIR%client\\dist"
+set "CLIENT_BACKUP=%INSTALL_DIR%client\\dist.previous"
 set "LOG_DIR=%INSTALL_DIR%logs"
 set "LOG_FILE=%LOG_DIR%\\supervisor.log"
 
@@ -380,7 +380,7 @@ echo.
 rem ============================================================
 rem :apply_update  — activate the journaled frontend/backend bundle.
 rem  - Picks newest of .exe.new / .exe.new2 as the binary source.
-rem  - Backs up current .exe and client\dist under fixed transaction names.
+rem  - Backs up current .exe and client\\dist under fixed transaction names.
 rem  - Keeps both backups until the new backend acknowledges listener startup.
 rem ============================================================
 :apply_update
@@ -407,7 +407,7 @@ rem ============================================================
     call :stamp "Apply: staged frontend path missing from journal [version_mismatch]"
     goto :eof
   )
-  if not exist "!STAGED_CLIENT!\index.html" (
+  if not exist "!STAGED_CLIENT!\\index.html" (
     call :stamp "Apply: staged frontend missing index.html [frontend_swap_failed]"
     goto :eof
   )

--- a/build.js
+++ b/build.js
@@ -450,18 +450,93 @@ rem ============================================================
     goto :eof
   )
 
-  move "%MARKER%" "%APPLYING%" >nul 2>&1
+  move /y "%MARKER%" "%APPLYING%" >nul 2>&1
+  if errorlevel 1 (
+    call :stamp "Apply: could not move pending marker to applying state [bundle_apply_failed]"
+    call :rollback_update
+    goto :eof
+  )
+  if not exist "%APPLYING%" (
+    call :stamp "Apply: applying marker missing after state transition [bundle_apply_failed]"
+    call :rollback_update
+    goto :eof
+  )
   call :stamp "Apply: bundle activated; waiting for backend startup acknowledgement"
 goto :eof
 
 
 :rollback_update
   call :stamp "Apply: restoring previous frontend and backend"
-  if exist "%BASE_EXE%" del /f /q "%BASE_EXE%" >nul 2>&1
-  if exist "%BIN_BACKUP%" ren "%BIN_BACKUP%" "%BASE_EXE%" >nul 2>&1
-  if exist "%CLIENT_LIVE%" rmdir /s /q "%CLIENT_LIVE%" >nul 2>&1
-  if exist "%CLIENT_BACKUP%" move "%CLIENT_BACKUP%" "%CLIENT_LIVE%" >nul 2>&1
-  del /f /q "%MARKER%" "%APPLYING%" "%JOURNAL%" >nul 2>&1
+  set "ROLLBACK_FAILED=0"
+  set "BINARY_RESTORE_OK=1"
+  if not exist "%BIN_BACKUP%" (
+    call :stamp "Apply: binary restore failed; backup is missing [rollback_failed]"
+    set "BINARY_RESTORE_OK=0"
+  ) else (
+    if exist "%BASE_EXE%" (
+      del /f /q "%BASE_EXE%" >nul 2>&1
+      if exist "%BASE_EXE%" (
+        call :stamp "Apply: binary restore failed; active executable could not be removed [rollback_failed]"
+        set "BINARY_RESTORE_OK=0"
+      )
+    )
+    if "!BINARY_RESTORE_OK!"=="1" (
+      ren "%BIN_BACKUP%" "%BASE_EXE%" >nul 2>&1
+      if errorlevel 1 (
+        call :stamp "Apply: binary restore failed; backup could not be activated [rollback_failed]"
+        set "BINARY_RESTORE_OK=0"
+      )
+    )
+    if not exist "%BASE_EXE%" set "BINARY_RESTORE_OK=0"
+    if exist "%BIN_BACKUP%" set "BINARY_RESTORE_OK=0"
+  )
+  if "!BINARY_RESTORE_OK!"=="0" set "ROLLBACK_FAILED=1"
+
+  set "CLIENT_RESTORE_OK=1"
+  if not exist "%CLIENT_BACKUP%" (
+    call :stamp "Apply: frontend restore failed; backup is missing [rollback_failed]"
+    set "CLIENT_RESTORE_OK=0"
+  ) else (
+    if exist "%CLIENT_LIVE%" (
+      rmdir /s /q "%CLIENT_LIVE%" >nul 2>&1
+      if exist "%CLIENT_LIVE%" (
+        call :stamp "Apply: frontend restore failed; active frontend could not be removed [rollback_failed]"
+        set "CLIENT_RESTORE_OK=0"
+      )
+    )
+    if "!CLIENT_RESTORE_OK!"=="1" (
+      move "%CLIENT_BACKUP%" "%CLIENT_LIVE%" >nul 2>&1
+      if errorlevel 1 (
+        call :stamp "Apply: frontend restore failed; backup could not be activated [rollback_failed]"
+        set "CLIENT_RESTORE_OK=0"
+      )
+    )
+    if not exist "%CLIENT_LIVE%" set "CLIENT_RESTORE_OK=0"
+    if exist "%CLIENT_BACKUP%" set "CLIENT_RESTORE_OK=0"
+  )
+  if "!CLIENT_RESTORE_OK!"=="0" set "ROLLBACK_FAILED=1"
+
+  if "!ROLLBACK_FAILED!"=="1" (
+    call :stamp "Apply: rollback incomplete; journal retained for recovery [rollback_failed]"
+    echo ERROR: update rollback was incomplete. Recovery files were retained.
+    goto :eof
+  )
+
+  del /f /q "%MARKER%" "%APPLYING%" >nul 2>&1
+  if exist "%MARKER%" (
+    call :stamp "Apply: rollback cleanup incomplete; pending marker remains, journal retained [rollback_failed]"
+    goto :eof
+  )
+  if exist "%APPLYING%" (
+    call :stamp "Apply: rollback cleanup incomplete; applying marker remains, journal retained [rollback_failed]"
+    goto :eof
+  )
+
+  del /f /q "%JOURNAL%" >nul 2>&1
+  if exist "%JOURNAL%" (
+    call :stamp "Apply: rollback restored artifacts but could not remove journal [rollback_failed]"
+    goto :eof
+  )
   call :stamp "Apply: rollback complete"
 goto :eof
 

--- a/build.js
+++ b/build.js
@@ -214,13 +214,12 @@ export function generateStartBat() {
   //      ZomboidControlPanel.exe-dir\.update-pending  (a small JSON marker)
   //      and exits with code 75.
   //   3. This .bat sees exit 75 OR sees .update-pending and performs the
-  //      apply: back up the running .exe -> rename newest .new/.new2 to .exe
-  //      -> delete the marker -> relaunch.
+  //      apply: back up the running .exe and client/dist, activate both staged
+  //      artifacts, and retain both backups until the new listener acknowledges.
   //   4. All apply events are logged to logs\supervisor.log for diagnostics.
   //
-  // Picks the launch target by mtime among .exe / .exe.new / .exe.new2 so a
-  // freshly-staged file always wins on the very first launch (before any
-  // apply has run), keeping the original one-shot install behavior intact.
+  // A staged binary is never selected by mtime alone. It is launched only
+  // after the matching frontend has been activated by the journaled apply.
   //
   // Crash-loop protection: any exit code other than 0 (clean shutdown) or 75
   // (update requested), with no update marker present, is treated as a crash
@@ -240,7 +239,12 @@ cd /d "%~dp0"
 set "PANEL_SUPERVISOR_V=2"
 set "INSTALL_DIR=%~dp0"
 set "MARKER=%INSTALL_DIR%.update-pending"
+set "APPLYING=%INSTALL_DIR%.update-applying"
+set "JOURNAL=%INSTALL_DIR%update-bundle.json"
 set "BASE_EXE=ZomboidControlPanel.exe"
+set "BIN_BACKUP=ZomboidControlPanel.exe.bundle-previous"
+set "CLIENT_LIVE=%INSTALL_DIR%client\dist"
+set "CLIENT_BACKUP=%INSTALL_DIR%client\dist.previous"
 set "LOG_DIR=%INSTALL_DIR%logs"
 set "LOG_FILE=%LOG_DIR%\\supervisor.log"
 
@@ -264,18 +268,14 @@ echo.
   rem === If an update is pending, apply it before launching. ===
   if exist "%MARKER%" call :apply_update
 
-  rem === Pick the binary to launch. Newest of .exe / .exe.new / .exe.new2. ===
-  rem === A fresh install only ever has the plain .exe -- build.js copies   ===
-  rem === the packaged binary straight to ZomboidControlPanel.exe, and the  ===
-  rem === release zip is that folder as-is, so there is no .new on first    ===
-  rem === run. .new/.new2 only appear later, staged in place by an update.  ===
-  set "TARGET="
-  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "Get-ChildItem -LiteralPath '.' -File | Where-Object { $_.Name -match '^ZomboidControlPanel\\.exe(\\.new2?)?$' } | Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty Name"\`) do set "TARGET=%%F"
+  rem === A staged binary must never launch by mtime alone: its matching    ===
+  rem === frontend is still inactive until the journaled apply transaction. ===
+  set "TARGET=%BASE_EXE%"
 
-  if not defined TARGET (
+  if not exist "%INSTALL_DIR%!TARGET!" (
     call :stamp "ERROR no ZomboidControlPanel binary found"
     echo ERROR: No ZomboidControlPanel binary found in this folder.
-    echo Expected one of: ZomboidControlPanel.exe, .exe.new, .exe.new2
+    echo Expected: ZomboidControlPanel.exe
     pause
     exit /b 1
   )
@@ -288,6 +288,12 @@ echo.
   "%INSTALL_DIR%!TARGET!"
   set "EXITCODE=!ERRORLEVEL!"
   call :stamp "Panel exited with code !EXITCODE!"
+
+  if exist "%APPLYING%" (
+    call :stamp "Apply: startup handshake failed; rolling back bundle [startup_handshake_failed]"
+    call :rollback_update
+    goto run_loop
+  )
 
   rem Exit code 75 = panel requested restart-for-update.
   if "!EXITCODE!"=="75" (
@@ -372,53 +378,91 @@ echo.
 
 
 rem ============================================================
-rem :apply_update  — rename staged binary into place.
-rem  - Picks newest of .exe.new / .exe.new2 as the source.
-rem  - Backs up current .exe to .exe.bak-yyyyMMdd-HHmmss.
-rem  - Renames staged -> .exe.
-rem  - Keeps the 3 most recent .bak-* files, deletes older.
+rem :apply_update  — activate the journaled frontend/backend bundle.
+rem  - Picks newest of .exe.new / .exe.new2 as the binary source.
+rem  - Backs up current .exe and client\dist under fixed transaction names.
+rem  - Keeps both backups until the new backend acknowledges listener startup.
 rem ============================================================
 :apply_update
   call :stamp "Apply: marker present, beginning swap"
+
+  if not exist "%JOURNAL%" (
+    call :stamp "Apply: update-bundle.json missing [version_mismatch]"
+    del /f /q "%MARKER%" >nul 2>&1
+    goto :eof
+  )
 
   set "STAGED_NAME="
   for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "Get-ChildItem -LiteralPath '.' -File | Where-Object { $_.Name -match '^ZomboidControlPanel\\.exe\\.new2?$' } | Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty Name"\`) do set "STAGED_NAME=%%F"
 
   if not defined STAGED_NAME (
-    call :stamp "Apply: no .new/.new2 staged file found; clearing marker"
+    call :stamp "Apply: staged binary missing or quarantined [av_quarantine]"
     del /f /q "%MARKER%" >nul 2>&1
     goto :eof
   )
 
+  set "STAGED_CLIENT="
+  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "$j=Get-Content -LiteralPath $env:JOURNAL -Raw | ConvertFrom-Json; $j.paths.stagedClient"\`) do set "STAGED_CLIENT=%%F"
+  if not defined STAGED_CLIENT (
+    call :stamp "Apply: staged frontend path missing from journal [version_mismatch]"
+    goto :eof
+  )
+  if not exist "!STAGED_CLIENT!\index.html" (
+    call :stamp "Apply: staged frontend missing index.html [frontend_swap_failed]"
+    goto :eof
+  )
+
+  if exist "%BIN_BACKUP%" del /f /q "%BIN_BACKUP%" >nul 2>&1
+  if exist "%CLIENT_BACKUP%" rmdir /s /q "%CLIENT_BACKUP%" >nul 2>&1
+
   if not exist "%BASE_EXE%" goto :do_rename
 
-  rem Build a timestamp suffix for the backup file.
-  for /f "usebackq delims=" %%T in (\`powershell -NoProfile -Command "Get-Date -Format 'yyyyMMdd-HHmmss'"\`) do set "TS=%%T"
-  set "BACKUP=%BASE_EXE%.bak-!TS!"
-  call :stamp "Apply: backing up %BASE_EXE% to !BACKUP!"
-  ren "%BASE_EXE%" "!BACKUP!" >nul 2>&1
+  call :stamp "Apply: backing up %BASE_EXE% to %BIN_BACKUP%"
+  ren "%BASE_EXE%" "%BIN_BACKUP%" >nul 2>&1
   if errorlevel 1 (
-    call :stamp "Apply: ERROR could not back up running .exe ^(still locked?^); aborting swap"
+    call :stamp "Apply: could not back up running executable [binary_swap_failed]"
     echo ERROR: could not rename %BASE_EXE% — is the panel still running?
-    pause
     goto :eof
   )
 
 :do_rename
-  call :stamp "Apply: renaming !STAGED_NAME! to %BASE_EXE%"
-  ren "!STAGED_NAME!" "%BASE_EXE%" >nul 2>&1
+  if exist "%CLIENT_LIVE%" (
+    move "%CLIENT_LIVE%" "%CLIENT_BACKUP%" >nul 2>&1
+    if errorlevel 1 (
+      call :stamp "Apply: could not back up live frontend [frontend_swap_failed]"
+      call :rollback_update
+      goto :eof
+    )
+  )
+  move "!STAGED_CLIENT!" "%CLIENT_LIVE%" >nul 2>&1
   if errorlevel 1 (
-    call :stamp "Apply: ERROR rename of staged file failed"
-    echo ERROR: could not rename !STAGED_NAME! to %BASE_EXE%.
-    pause
+    call :stamp "Apply: could not activate staged frontend [frontend_swap_failed]"
+    call :rollback_update
     goto :eof
   )
 
-  del /f /q "%MARKER%" >nul 2>&1
-  call :stamp "Apply: success — update applied"
+  call :stamp "Apply: renaming !STAGED_NAME! to %BASE_EXE%"
+  ren "!STAGED_NAME!" "%BASE_EXE%" >nul 2>&1
+  if errorlevel 1 (
+    call :stamp "Apply: executable activation failed [binary_swap_failed]"
+    echo ERROR: could not rename !STAGED_NAME! to %BASE_EXE%.
+    call :rollback_update
+    goto :eof
+  )
 
-  rem Prune .bak-* keeping the 3 most recent.
-  powershell -NoProfile -Command "Get-ChildItem -LiteralPath '.' -File -Filter 'ZomboidControlPanel.exe.bak-*' | Sort-Object LastWriteTime -Descending | Select-Object -Skip 3 | Remove-Item -Force -ErrorAction SilentlyContinue" >nul 2>&1
+  move "%MARKER%" "%APPLYING%" >nul 2>&1
+  call :stamp "Apply: bundle activated; waiting for backend startup acknowledgement"
+goto :eof
+
+
+:rollback_update
+  call :stamp "Apply: restoring previous frontend and backend"
+  if exist "%BASE_EXE%" del /f /q "%BASE_EXE%" >nul 2>&1
+  if exist "%BIN_BACKUP%" ren "%BIN_BACKUP%" "%BASE_EXE%" >nul 2>&1
+  if exist "%CLIENT_LIVE%" rmdir /s /q "%CLIENT_LIVE%" >nul 2>&1
+  if exist "%CLIENT_BACKUP%" move "%CLIENT_BACKUP%" "%CLIENT_LIVE%" >nul 2>&1
+  del /f /q "%MARKER%" "%APPLYING%" "%JOURNAL%" >nul 2>&1
+  call :stamp "Apply: rollback complete"
 goto :eof
 
 
@@ -469,6 +513,17 @@ fi
 async function main() {
   const args = process.argv.slice(2);
   const targets = resolveTargets(args);
+  const rootPkg = JSON.parse(fs.readFileSync("./package.json", "utf-8"));
+  const panelVersion = rootPkg.version || "0.0.0";
+  let buildSha = process.env.GITHUB_SHA || process.env.PANEL_BUILD_SHA || "";
+  if (!buildSha) {
+    try {
+      buildSha = execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
+    } catch {
+      buildSha = "unknown";
+    }
+  }
+  const apiContractVersion = 1;
 
   await cleanDir(distDir);
   if (!fs.existsSync(distDir)) {
@@ -482,7 +537,15 @@ async function main() {
 
   console.log("Building client...");
   try {
-    execSync("npm run build", { cwd: "./client", stdio: "inherit" });
+    execSync("npm run build", {
+      cwd: "./client",
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        PANEL_BUILD_SHA: buildSha,
+        PANEL_API_CONTRACT_VERSION: String(apiContractVersion),
+      },
+    });
     console.log("Client built successfully");
   } catch (error) {
     console.error("Client build failed:", error.message);
@@ -491,9 +554,8 @@ async function main() {
 
   console.log("Building server bundle...");
 
-  const rootPkg = JSON.parse(fs.readFileSync("./package.json", "utf-8"));
-  const panelVersion = rootPkg.version || "0.0.0";
   console.log(`Version: ${panelVersion}`);
+  console.log(`Build SHA: ${buildSha}`);
 
   // Read PanelBridge.lua and inline it as a base64 define so it lives INSIDE
   // server.cjs (and therefore inside the pkg binary). pkg's `assets` glob was
@@ -531,6 +593,8 @@ async function main() {
     define: {
       "import.meta.url": "import_meta_url",
       PANEL_VERSION: JSON.stringify(panelVersion),
+      PANEL_BUILD_SHA: JSON.stringify(buildSha),
+      PANEL_API_CONTRACT_VERSION: JSON.stringify(apiContractVersion),
       PANEL_BRIDGE_LUA_B64: JSON.stringify(panelBridgeLuaB64),
     },
     banner: {
@@ -795,6 +859,8 @@ Recommended safe-upgrade commands:
     JSON.stringify(
       {
         version: panelVersion,
+        buildSha,
+        apiContractVersion,
         builtAt: new Date().toISOString(),
         hostPlatform: process.platform,
         targets,

--- a/client/src/components/BuildCompatibilityGate.tsx
+++ b/client/src/components/BuildCompatibilityGate.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import {
+  assessBuildCompatibility,
+  compiledBuildMetadata,
+  type BuildMetadata,
+} from '../lib/buildCompatibility'
+
+type GateState =
+  | { status: 'checking' | 'compatible' }
+  | { status: 'mismatch'; backend: Partial<BuildMetadata> }
+
+export function BuildCompatibilityGate({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<GateState>({ status: 'checking' })
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const timer = window.setTimeout(() => controller.abort(), 8_000)
+    fetch('/api/health', { signal: controller.signal, cache: 'no-store' })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`Health check returned ${response.status}`)
+        return response.json() as Promise<Partial<BuildMetadata>>
+      })
+      .then((backend) => {
+        const result = assessBuildCompatibility(compiledBuildMetadata(), backend)
+        setState(result.compatible ? { status: 'compatible' } : { status: 'mismatch', backend })
+      })
+      .catch(() => {
+        // Authentication screens already surface an unreachable backend. The
+        // compatibility gate only blocks a backend that answered with a
+        // demonstrably different build.
+        setState({ status: 'compatible' })
+      })
+      .finally(() => window.clearTimeout(timer))
+    return () => {
+      window.clearTimeout(timer)
+      controller.abort()
+    }
+  }, [])
+
+  if (state.status === 'checking') {
+    return <main className="min-h-screen bg-background" aria-label="Checking panel compatibility" />
+  }
+  if (state.status === 'mismatch') {
+    const frontend = compiledBuildMetadata()
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-background p-6 text-foreground">
+        <section className="w-full max-w-xl rounded-lg border border-destructive/40 bg-card p-6 shadow-lg">
+          <p className="text-sm font-semibold uppercase tracking-wide text-destructive">Update recovery required</p>
+          <h1 className="mt-2 text-2xl font-bold">Frontend and backend versions do not match</h1>
+          <p className="mt-3 text-sm text-muted-foreground">
+            The panel stopped before authentication and live connections were initialized. Restart with Start.bat to let the updater finish or roll back the incomplete bundle.
+          </p>
+          <dl className="mt-5 grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+            <dt>Frontend</dt><dd className="font-mono">{frontend.panelVersion} ({frontend.buildSha.slice(0, 12)})</dd>
+            <dt>Backend</dt><dd className="font-mono">{state.backend.panelVersion || 'unknown'} ({String(state.backend.buildSha || 'unknown').slice(0, 12)})</dd>
+          </dl>
+          <button className="mt-6 rounded-md bg-primary px-4 py-2 text-primary-foreground" onClick={() => window.location.reload()}>
+            Check again
+          </button>
+        </section>
+      </main>
+    )
+  }
+  return children
+}

--- a/client/src/lib/__tests__/buildCompatibility.test.ts
+++ b/client/src/lib/__tests__/buildCompatibility.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { assessBuildCompatibility, type BuildMetadata } from '../buildCompatibility'
+
+const backend: BuildMetadata = {
+  panelVersion: '2.0.0',
+  buildSha: 'same-build',
+  apiContractVersion: 1,
+}
+
+describe('build compatibility', () => {
+  it('accepts identical frontend and backend metadata', () => {
+    expect(assessBuildCompatibility(backend, backend)).toEqual({ compatible: true })
+  })
+
+  it('rejects both frontend-older and backend-older version mixes', () => {
+    expect(
+      assessBuildCompatibility({ ...backend, panelVersion: '1.9.0' }, backend),
+    ).toEqual(expect.objectContaining({ compatible: false, code: 'version_mismatch' }))
+    expect(
+      assessBuildCompatibility({ ...backend, panelVersion: '2.1.0' }, backend),
+    ).toEqual(expect.objectContaining({ compatible: false, code: 'version_mismatch' }))
+  })
+
+  it('rejects a different build or API contract within the same version', () => {
+    expect(
+      assessBuildCompatibility({ ...backend, buildSha: 'other-build' }, backend),
+    ).toEqual(expect.objectContaining({ compatible: false }))
+    expect(
+      assessBuildCompatibility({ ...backend, apiContractVersion: 2 }, backend),
+    ).toEqual(expect.objectContaining({ compatible: false }))
+  })
+})

--- a/client/src/lib/buildCompatibility.ts
+++ b/client/src/lib/buildCompatibility.ts
@@ -1,0 +1,33 @@
+export type BuildMetadata = {
+  panelVersion: string
+  buildSha: string
+  apiContractVersion: number
+}
+
+export function compiledBuildMetadata(): BuildMetadata {
+  return {
+    panelVersion: typeof __PANEL_VERSION__ !== 'undefined' ? __PANEL_VERSION__ : '0.0.0',
+    buildSha: typeof __PANEL_BUILD_SHA__ !== 'undefined' ? __PANEL_BUILD_SHA__ : 'unknown',
+    apiContractVersion:
+      typeof __PANEL_API_CONTRACT_VERSION__ !== 'undefined'
+        ? __PANEL_API_CONTRACT_VERSION__
+        : 1,
+  }
+}
+
+export function assessBuildCompatibility(
+  frontend: BuildMetadata,
+  backend: Partial<BuildMetadata>,
+) {
+  const compatible =
+    backend.panelVersion === frontend.panelVersion &&
+    backend.buildSha === frontend.buildSha &&
+    backend.apiContractVersion === frontend.apiContractVersion
+  return compatible
+    ? { compatible: true as const }
+    : {
+        compatible: false as const,
+        code: 'version_mismatch' as const,
+        reason: 'The frontend and backend were built from different panel versions.',
+      }
+}

--- a/client/src/lib/demo.ts
+++ b/client/src/lib/demo.ts
@@ -449,7 +449,12 @@ export function installDemoFetchShim(): void {
       return jsonResponse({ needsSetup: false, authEnabled: false })
     }
     if (path === '/api/health') {
-      return jsonResponse({ version: `${(typeof __PANEL_VERSION__ !== 'undefined' ? __PANEL_VERSION__ : '0.0.0')}-demo` })
+      return jsonResponse({
+        version: `${(typeof __PANEL_VERSION__ !== 'undefined' ? __PANEL_VERSION__ : '0.0.0')}-demo`,
+        panelVersion: typeof __PANEL_VERSION__ !== 'undefined' ? __PANEL_VERSION__ : '0.0.0',
+        buildSha: typeof __PANEL_BUILD_SHA__ !== 'undefined' ? __PANEL_BUILD_SHA__ : 'unknown',
+        apiContractVersion: typeof __PANEL_API_CONTRACT_VERSION__ !== 'undefined' ? __PANEL_API_CONTRACT_VERSION__ : 1,
+      })
     }
     if (path === '/api/system/storage-health') {
       return jsonResponse(demoStorageHealth())

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App'
 import './index.css'
 import './i18n'
 import { isDemoMode, installDemoFetchShim } from './lib/demo'
+import { BuildCompatibilityGate } from './components/BuildCompatibilityGate'
 
 const Router = isDemoMode() ? HashRouter : BrowserRouter
 
@@ -18,7 +19,9 @@ if (isDemoMode()) {
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <Router>
-      <App />
+      <BuildCompatibilityGate>
+        <App />
+      </BuildCompatibilityGate>
     </Router>
   </React.StrictMode>,
 )

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,6 +1,8 @@
 /// <reference types="vite/client" />
 
 declare const __PANEL_VERSION__: string;
+declare const __PANEL_BUILD_SHA__: string;
+declare const __PANEL_API_CONTRACT_VERSION__: number;
 
 declare module '*.css' {
   const content: { [className: string]: string };

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,22 +2,55 @@ import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 import { readFileSync } from 'fs'
+import { execFileSync } from 'child_process'
 
 /// <reference types="vitest" />
 
 const rootPkg = JSON.parse(readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'))
 
+function resolveBuildSha() {
+  if (process.env.PANEL_BUILD_SHA) return process.env.PANEL_BUILD_SHA
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: path.resolve(__dirname, '..'),
+      encoding: 'utf8',
+    }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const basePath = env.VITE_BASE_PATH || '/'
+  const buildSha = resolveBuildSha()
+  const apiContractVersion = Number(process.env.PANEL_API_CONTRACT_VERSION || 1)
 
   return {
     base: basePath,
     define: {
       __PANEL_VERSION__: JSON.stringify(rootPkg.version),
+      __PANEL_BUILD_SHA__: JSON.stringify(buildSha),
+      __PANEL_API_CONTRACT_VERSION__: JSON.stringify(apiContractVersion),
     },
-    plugins: [react()],
+    plugins: [
+      react(),
+      {
+        name: 'panel-build-info',
+        generateBundle() {
+          this.emitFile({
+            type: 'asset',
+            fileName: 'build-info.json',
+            source: JSON.stringify({
+              panelVersion: rootPkg.version,
+              buildSha,
+              apiContractVersion,
+            }, null, 2),
+          })
+        },
+      },
+    ],
     esbuild: {
       drop: ['console', 'debugger'],
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,8 @@ export default [
         ...globals.node,
         // Injected by esbuild at build time; guarded with typeof at runtime.
         PANEL_VERSION: "readonly",
+        PANEL_BUILD_SHA: "readonly",
+        PANEL_API_CONTRACT_VERSION: "readonly",
         PANEL_BRIDGE_LUA_B64: "readonly",
       },
     },

--- a/server/index.js
+++ b/server/index.js
@@ -50,6 +50,13 @@ import { DiscordBot } from "./services/discordBot.js";
 import { BackupService } from "./services/backupService.js";
 import { UpdateChecker } from "./services/updateChecker.js";
 import { PanelUpdateChecker } from "./services/panelUpdateChecker.js";
+import {
+  acknowledgeUpdateBundle,
+  applyUpdateBundle,
+  PANEL_API_CONTRACT_VERSION as DEFAULT_API_CONTRACT_VERSION,
+  recoverInterruptedUpdateBundle,
+  validateBuildCompatibility,
+} from "./services/updateBundle.js";
 import { LogTailer } from "./services/logTailer.js";
 import { DiskMonitor } from "./services/diskMonitor.js";
 import authService from "./services/auth.js";
@@ -1310,6 +1317,7 @@ app.use("/api/permissions", permissionsRoutes);
 // In exe builds, PANEL_VERSION is injected by esbuild at compile time.
 // In dev mode, fall back to reading package.json.
 let _pkgVersion;
+let _buildSha;
 try {
   _pkgVersion =
     typeof PANEL_VERSION !== "undefined"
@@ -1317,13 +1325,56 @@ try {
       : JSON.parse(
           fs.readFileSync(path.join(__dirname, "../package.json"), "utf-8"),
         ).version;
+  _buildSha =
+    typeof PANEL_BUILD_SHA !== "undefined"
+      ? PANEL_BUILD_SHA
+      : process.env.PANEL_BUILD_SHA ||
+        execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
 } catch {
   _pkgVersion = "0.0.0";
+  _buildSha = "unknown";
+}
+const _apiContractVersion =
+  typeof PANEL_API_CONTRACT_VERSION !== "undefined"
+    ? Number(PANEL_API_CONTRACT_VERSION)
+    : DEFAULT_API_CONTRACT_VERSION;
+const _buildMetadata = {
+  panelVersion: _pkgVersion,
+  buildSha: _buildSha,
+  apiContractVersion: _apiContractVersion,
+};
+
+function updateBundleJournalPath() {
+  return path.join(path.dirname(panelUpdateChecker.getExeBasePath()), "update-bundle.json");
+}
+
+function validatePendingUpdateBundle() {
+  const journalPath = updateBundleJournalPath();
+  if (!fs.existsSync(journalPath)) return;
+  const journal = JSON.parse(fs.readFileSync(journalPath, "utf8"));
+  const applyingMarker = path.join(path.dirname(journalPath), ".update-applying");
+  if (journal.phase === "staged" && fs.existsSync(applyingMarker)) {
+    journal.phase = "awaiting_startup_ack";
+    journal.appliedAt = new Date().toISOString();
+    fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2), "utf8");
+  }
+  if (journal.phase !== "awaiting_startup_ack") return;
+  const clientMetadata = JSON.parse(
+    fs.readFileSync(path.join(journal.paths.liveClient, "build-info.json"), "utf8"),
+  );
+  const backendResult = validateBuildCompatibility(journal.metadata, _buildMetadata);
+  const frontendResult = validateBuildCompatibility(clientMetadata, _buildMetadata);
+  if (!backendResult.compatible || !frontendResult.compatible) {
+    const error = new Error("Applied update bundle metadata does not match the running backend");
+    error.code = "version_mismatch";
+    throw error;
+  }
 }
 app.get("/api/health", (req, res) => {
   res.json({
     status: "ok",
     version: _pkgVersion,
+    ..._buildMetadata,
     timestamp: new Date().toISOString(),
   });
 });
@@ -1400,44 +1451,14 @@ app.post("/api/panel/restart", requireRole("admin"), async (req, res) => {
       }
     }
 
-    // Legacy path: spawn a detached cmd helper. Kept for installs that
-    // haven't yet picked up Start.bat v2 (first run after upgrading from
-    // pre-supervisor releases).
-    try {
-      // Commit the apply: write the pending marker FIRST and flush to disk
-      // before we exit. reconcilePendingUpdate() on next boot uses this to
-      // detect success/failure. If the flush is skipped we silently lose the
-      // ability to warn the user that apply failed.
-      if (staged.version) {
-        await setSetting("pendingPanelUpdate", staged.version);
-        await flushWrites();
-      }
-      const { helperPath, logPath } = await checker.spawnWindowsApplyHelper();
-      log.info(
-        `Staged update will be applied by helper: ${helperPath} (log: ${logPath})`,
-      );
-      res.json({
-        success: true,
-        message: "Applying staged update...",
-        applyingUpdate: true,
-      });
-      setTimeout(() => process.exit(0), 500);
-      return;
-    } catch (err) {
-      // 409 Conflict for the specific "already in progress" race so the UI
-      // can show a tailored message instead of a generic 500.
-      if (err.code === "apply_in_progress") {
-        log.warn(
-          "Restart-and-apply request rejected: another apply is in progress",
-        );
-        return res.status(409).json({
-          error: "An update apply is already in progress.",
-          code: "apply_in_progress",
-        });
-      }
-      log.error(`Could not spawn update apply helper: ${err.message}`);
-      return res.status(500).json({ error: sanitizeError(err.message) });
-    }
+    // A detached legacy helper can launch a binary, but cannot safely keep a
+    // matching frontend transaction alive until startup acknowledgement.
+    // Refuse that unsafe path instead of recreating the mixed-version bug.
+    checker.isApplying = false;
+    return res.status(409).json({
+      error:
+        "This update requires the packaged Start.bat supervisor. Stop the panel and launch Start.bat, then apply again.",
+    });
   }
 
   // Linux + packaged + staged update → overwrite in place (safe on Linux), then restart.
@@ -1458,57 +1479,24 @@ app.post("/api/panel/restart", requireRole("admin"), async (req, res) => {
     }
     checker.isApplying = true;
     try {
-      // NOTE: use the statically-imported `fs` here. A runtime `await
-      // import('fs')` is emitted by esbuild as a native dynamic import that
-      // fails inside the pkg binary with "A dynamic import callback was not
-      // specified", which previously broke Restart-and-Apply on Linux.
-      const fsp = fs.promises;
       if (staged.version) {
         await setSetting("pendingPanelUpdate", staged.version);
         await flushWrites();
       }
-      // Target the canonical binary path (strip any .new/.new2 suffix — if
-      // we were launched from a staged file the running execPath may carry
-      // that suffix). On Linux overwriting the running binary is safe: the
-      // kernel keeps the old inode mapped until this process exits, and the
-      // next spawn picks up the new file.
-      const targetPath =
-        typeof checker.getExeBasePath === "function"
-          ? checker.getExeBasePath()
-          : staged.exePath;
-      // Try atomic rename first. If staged and target are on different
-      // filesystems (e.g. /opt vs /home with a tmpfs in between), rename
-      // throws EXDEV. Fall back to copy+unlink in that case.
+      const appliedBundle = applyUpdateBundle(staged.journalPath);
+      const targetPath = appliedBundle.paths.binary;
       try {
-        await fsp.rename(staged.stagedPath, targetPath);
-      } catch (renameErr) {
-        if (renameErr.code === "EXDEV") {
-          log.warn(
-            `Cross-device rename (EXDEV); falling back to copy+unlink for ${staged.stagedPath} → ${targetPath}`,
-          );
-          await fsp.copyFile(staged.stagedPath, targetPath);
-          try {
-            await fsp.unlink(staged.stagedPath);
-          } catch (unlinkErr) {
-            log.warn(
-              `Could not remove staged source after copy: ${unlinkErr.message}`,
-            );
-          }
-        } else {
-          throw renameErr;
-        }
-      }
-      // chmod is best-effort, but if it fails we MUST verify the file is
-      // still executable — otherwise the respawn below will silently die
-      // with EACCES and leave the user with no panel.
-      try {
-        await fsp.chmod(targetPath, 0o755);
+        await fs.promises.chmod(targetPath, 0o755);
       } catch (chmodErr) {
         log.warn(`Could not chmod new binary: ${chmodErr.message}`);
       }
       try {
-        await fsp.access(targetPath, fs.constants.X_OK);
+        await fs.promises.access(targetPath, fs.constants.X_OK);
       } catch (accessErr) {
+        recoverInterruptedUpdateBundle(
+          staged.journalPath,
+          "binary_not_executable",
+        );
         checker.isApplying = false;
         log.error(
           `New binary at ${targetPath} is not executable: ${accessErr.message}`,
@@ -1519,19 +1507,10 @@ app.post("/api/panel/restart", requireRole("admin"), async (req, res) => {
           ),
         });
       }
-      // Best-effort cleanup of the OTHER staging slot if it exists (e.g.,
-      // a previous .new2 left behind by a long-ago apply). Stale staging
-      // files would otherwise confuse getStagedUpdate() on next boot.
-      try {
-        const otherSlot = `${targetPath}.new2`;
-        if (fs.existsSync(otherSlot) && otherSlot !== staged.stagedPath) {
-          await fsp.unlink(otherSlot);
-        }
-      } catch (cleanErr) {
-        log.debug(`Could not clean other staging slot: ${cleanErr.message}`);
-      }
       linuxRespawnPath = targetPath;
-      log.info(`Linux staged update applied to ${targetPath}; restarting`);
+      log.info(
+        `Linux update bundle applied to ${targetPath}; awaiting startup acknowledgement after restart`,
+      );
     } catch (err) {
       // Release the apply guard so the user can retry after fixing whatever
       // failed (e.g. permission, disk full).
@@ -2561,6 +2540,18 @@ async function start() {
     }
     logBanner(panelVersion);
 
+    if (typeof process.pkg !== "undefined") {
+      try {
+        validatePendingUpdateBundle();
+      } catch (error) {
+        log.error(
+          `Update startup validation failed [${error.code || "version_mismatch"}]: ${error.message}`,
+        );
+        process.exit(76);
+        return;
+      }
+    }
+
     // ── Single-instance lock ──
     // Prevents two panels racing on the same data folder, which causes
     // EADDRINUSE restart loops (systemd respawn vs. live process) and
@@ -3009,6 +3000,22 @@ async function start() {
           });
         }
         logReady(urls);
+        try {
+          const journalPath = updateBundleJournalPath();
+          if (acknowledgeUpdateBundle(journalPath, _buildMetadata)) {
+            fs.rmSync(path.join(path.dirname(journalPath), ".update-applying"), {
+              force: true,
+            });
+            log.info("Update bundle startup acknowledged; previous artifacts removed");
+          }
+        } catch (error) {
+          log.error(
+            `Update startup handshake failed [${error.code || "startup_handshake_failed"}]: ${error.message}`,
+          );
+          process.exitCode = 76;
+          setImmediate(() => process.exit(76));
+          return;
+        }
         await logExposureWarningIfNeeded({ needsSetup, boundPort, localIp });
         await logSetupTokenIfNeeded(needsSetup);
 

--- a/server/index.js
+++ b/server/index.js
@@ -53,9 +53,9 @@ import { PanelUpdateChecker } from "./services/panelUpdateChecker.js";
 import {
   acknowledgeUpdateBundle,
   applyUpdateBundle,
+  inspectPendingUpdateBundle,
   PANEL_API_CONTRACT_VERSION as DEFAULT_API_CONTRACT_VERSION,
   recoverInterruptedUpdateBundle,
-  validateBuildCompatibility,
 } from "./services/updateBundle.js";
 import { LogTailer } from "./services/logTailer.js";
 import { DiskMonitor } from "./services/diskMonitor.js";
@@ -1348,27 +1348,15 @@ function updateBundleJournalPath() {
   return path.join(path.dirname(panelUpdateChecker.getExeBasePath()), "update-bundle.json");
 }
 
-function validatePendingUpdateBundle() {
+let _pendingUpdateInspection = { pending: false, awaitingStartupAck: false };
+
+function inspectPendingPanelUpdate() {
   const journalPath = updateBundleJournalPath();
-  if (!fs.existsSync(journalPath)) return;
-  const journal = JSON.parse(fs.readFileSync(journalPath, "utf8"));
-  const applyingMarker = path.join(path.dirname(journalPath), ".update-applying");
-  if (journal.phase === "staged" && fs.existsSync(applyingMarker)) {
-    journal.phase = "awaiting_startup_ack";
-    journal.appliedAt = new Date().toISOString();
-    fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2), "utf8");
-  }
-  if (journal.phase !== "awaiting_startup_ack") return;
-  const clientMetadata = JSON.parse(
-    fs.readFileSync(path.join(journal.paths.liveClient, "build-info.json"), "utf8"),
-  );
-  const backendResult = validateBuildCompatibility(journal.metadata, _buildMetadata);
-  const frontendResult = validateBuildCompatibility(clientMetadata, _buildMetadata);
-  if (!backendResult.compatible || !frontendResult.compatible) {
-    const error = new Error("Applied update bundle metadata does not match the running backend");
-    error.code = "version_mismatch";
-    throw error;
-  }
+  return inspectPendingUpdateBundle({
+    journalPath,
+    applyingMarkerPath: path.join(path.dirname(journalPath), ".update-applying"),
+    runningMetadata: _buildMetadata,
+  });
 }
 app.get("/api/health", (req, res) => {
   res.json({
@@ -2542,10 +2530,10 @@ async function start() {
 
     if (typeof process.pkg !== "undefined") {
       try {
-        validatePendingUpdateBundle();
+        _pendingUpdateInspection = inspectPendingPanelUpdate();
       } catch (error) {
         log.error(
-          `Update startup validation failed [${error.code || "version_mismatch"}]: ${error.message}`,
+          `Update startup validation failed [${error.code || "invalid_bundle"}]: ${error.message}`,
         );
         process.exit(76);
         return;
@@ -3002,10 +2990,14 @@ async function start() {
         logReady(urls);
         try {
           const journalPath = updateBundleJournalPath();
-          if (acknowledgeUpdateBundle(journalPath, _buildMetadata)) {
-            fs.rmSync(path.join(path.dirname(journalPath), ".update-applying"), {
-              force: true,
-            });
+          if (
+            _pendingUpdateInspection.awaitingStartupAck &&
+            acknowledgeUpdateBundle(journalPath, _buildMetadata, {
+              transactionId: _pendingUpdateInspection.transactionId,
+              expectedMetadata: _pendingUpdateInspection.metadata,
+              applyingMarkerPath: _pendingUpdateInspection.applyingMarkerPath,
+            })
+          ) {
             log.info("Update bundle startup acknowledged; previous artifacts removed");
           }
         } catch (error) {

--- a/server/services/panelUpdateChecker.js
+++ b/server/services/panelUpdateChecker.js
@@ -17,6 +17,7 @@ import { createLogger } from "../utils/logger.js";
 import { getSetting, setSetting } from "../database/init.js";
 import { getDataPaths } from "../utils/paths.js";
 import { DockerUpdateProxy } from "./dockerUpdateProxy.js";
+import { stageUpdateBundle } from "./updateBundle.js";
 
 const log = createLogger("PanelUpdater");
 
@@ -476,6 +477,7 @@ export class PanelUpdateChecker {
       exeDir,
       `.client-dist-${this.latestRelease.version}.partial.${process.pid}${clientArchiveExtension}`,
     );
+    let incomingClientPath = null;
 
     try {
       log.info(
@@ -550,12 +552,13 @@ export class PanelUpdateChecker {
           `Could not verify ${clientArchive.name}; refusing to replace the web interface`,
         );
       }
-      await this.replaceClientDist(
+      const stagedClient = await this.stageClientDist(
         tmpClientArchivePath,
         isWindows,
         tmpDownloadPath,
         asset.name,
       );
+      incomingClientPath = stagedClient.incomingClientPath;
       fs.unlinkSync(tmpClientArchivePath);
 
       // Promote .partial → .new atomically. If a stale .new exists, drop it first.
@@ -573,6 +576,19 @@ export class PanelUpdateChecker {
           log.warn(`Could not chmod staged binary: ${chmodErr.message}`);
         }
       }
+
+      const exeBasePath = this.getExeBasePath();
+      const journalPath = stageUpdateBundle({
+        installDir: exeDir,
+        version: this.latestRelease.version,
+        binaryPath: exeBasePath,
+        stagedBinaryPath: stagedPath,
+        liveClientPath: path.join(exeDir, "client", "dist"),
+        incomingClientPath,
+        metadata: stagedClient.metadata,
+      });
+      fs.rmSync(incomingClientPath, { recursive: true, force: true });
+      incomingClientPath = null;
 
       // NOTE: We intentionally do NOT set `pendingPanelUpdate` here. That
       // setting is the "we actually committed to apply this" marker used by
@@ -607,6 +623,7 @@ export class PanelUpdateChecker {
       return {
         success: true,
         message: `Update to v${this.latestRelease.version} downloaded. Restart the panel to apply.`,
+        journal: path.basename(journalPath),
       };
     } catch (error) {
       this.lastError = error.message;
@@ -622,7 +639,16 @@ export class PanelUpdateChecker {
       } catch (delErr) {
         log.debug(`Failed to clean client archive after error: ${delErr.message}`);
       }
-      return { success: false, error: error.message };
+      if (incomingClientPath) {
+        fs.rmSync(incomingClientPath, { recursive: true, force: true });
+      }
+      if (
+        fs.existsSync(stagedPath) &&
+        !fs.existsSync(path.join(exeDir, "update-bundle.json"))
+      ) {
+        fs.rmSync(stagedPath, { force: true });
+      }
+      return { success: false, error: error.message, code: error.code };
     } finally {
       this.isDownloading = false;
     }
@@ -660,6 +686,9 @@ export class PanelUpdateChecker {
     const payload = {
       version: staged?.version || null,
       stagedFile: staged?.stagedPath ? path.basename(staged.stagedPath) : null,
+      journalFile: staged?.journalPath
+        ? path.basename(staged.journalPath)
+        : "update-bundle.json",
       stagedAt: new Date().toISOString(),
       requestedBy: `panel-pid-${process.pid}`,
     };
@@ -728,8 +757,24 @@ export class PanelUpdateChecker {
   getStagedUpdate() {
     if (typeof process.pkg === "undefined") return null;
     const exePath = process.execPath;
-    const stagedPath = this.findStagedFileOnDisk();
-    if (!stagedPath) return null;
+    const journalPath = path.join(
+      path.dirname(this.getExeBasePath()),
+      "update-bundle.json",
+    );
+    if (!fs.existsSync(journalPath)) return null;
+    let journal;
+    try {
+      journal = JSON.parse(fs.readFileSync(journalPath, "utf8"));
+    } catch (error) {
+      log.warn(`Ignoring invalid update bundle journal: ${error.message}`);
+      return null;
+    }
+    if (journal.phase !== "staged") return null;
+    const stagedPath = journal.paths?.stagedBinary;
+    if (!stagedPath || !fs.existsSync(journal.paths?.stagedClient || "")) {
+      log.warn("Ignoring incomplete staged update bundle");
+      return null;
+    }
     let size;
     try {
       const stats = fs.statSync(stagedPath);
@@ -749,9 +794,9 @@ export class PanelUpdateChecker {
     // latestRelease if we somehow never persisted it (older builds, manual
     // file drops). Reading the setting synchronously from the in-memory DB
     // is fine — this method is called often and must stay non-async.
-    let version = this._stagedVersionCache ?? null;
+    let version = journal.version || this._stagedVersionCache || null;
     if (!version) version = this.latestRelease?.version || null;
-    return { stagedPath, exePath, version, size };
+    return { stagedPath, exePath, version, size, journalPath, journal };
   }
 
   /**
@@ -1032,7 +1077,7 @@ export class PanelUpdateChecker {
   /**
    * Download a file with progress tracking
    */
-  async replaceClientDist(archivePath, isWindows, binaryPath, artifactName) {
+  async stageClientDist(archivePath, isWindows, binaryPath, artifactName) {
     const exeDir = path.dirname(process.execPath);
     const extractDir = fs.mkdtempSync(path.join(os.tmpdir(), "zpanel-update-"));
     const escapePowerShellLiteral = (value) => String(value).replace(/'/g, "''");
@@ -1078,26 +1123,35 @@ export class PanelUpdateChecker {
       if (!fs.existsSync(path.join(incoming, "index.html"))) {
         throw new Error("Release archive does not contain client/dist/index.html");
       }
-
-      const clientDir = path.join(exeDir, "client");
-      const liveDist = path.join(clientDir, "dist");
-      const nextDist = path.join(clientDir, "dist.new");
-      const backupDist = path.join(clientDir, "dist.previous");
-      fs.mkdirSync(clientDir, { recursive: true });
-      fs.rmSync(nextDist, { recursive: true, force: true });
-      fs.cpSync(incoming, nextDist, { recursive: true });
-      fs.rmSync(backupDist, { recursive: true, force: true });
-      if (fs.existsSync(liveDist)) fs.renameSync(liveDist, backupDist);
-      try {
-        fs.renameSync(nextDist, liveDist);
-      } catch (error) {
-        if (fs.existsSync(backupDist) && !fs.existsSync(liveDist)) {
-          fs.renameSync(backupDist, liveDist);
-        }
-        throw error;
+      const metadata = {
+        panelVersion: manifest.version,
+        buildSha: manifest.buildSha,
+        apiContractVersion: manifest.apiContractVersion,
+      };
+      if (
+        !metadata.buildSha ||
+        Number(metadata.apiContractVersion) !== 1
+      ) {
+        throw new Error("Release archive is missing compatible build metadata");
       }
-      fs.rmSync(backupDist, { recursive: true, force: true });
-      log.info("Updated client/dist from verified release archive");
+      const clientMetadata = JSON.parse(
+        fs.readFileSync(path.join(incoming, "build-info.json"), "utf8"),
+      );
+      if (
+        clientMetadata.panelVersion !== metadata.panelVersion ||
+        clientMetadata.buildSha !== metadata.buildSha ||
+        Number(clientMetadata.apiContractVersion) !== metadata.apiContractVersion
+      ) {
+        throw new Error("Release frontend metadata does not match its backend artifact");
+      }
+      const incomingClientPath = path.join(
+        exeDir,
+        `.update-client-incoming-${process.pid}`,
+      );
+      fs.rmSync(incomingClientPath, { recursive: true, force: true });
+      fs.cpSync(incoming, incomingClientPath, { recursive: true });
+      log.info("Staged verified client bundle without changing live client/dist");
+      return { incomingClientPath, metadata };
     } finally {
       if (windowsArchiveCopy) {
         fs.rmSync(windowsArchiveCopy, { force: true });

--- a/server/services/updateBundle.js
+++ b/server/services/updateBundle.js
@@ -1,0 +1,290 @@
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+
+export const PANEL_API_CONTRACT_VERSION = 1;
+
+function updateError(code, message, cause) {
+  const error = new Error(message, cause ? { cause } : undefined);
+  error.code = code;
+  return error;
+}
+
+function sha256File(filePath) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function writeJournal(journalPath, journal) {
+  const temporaryPath = `${journalPath}.tmp-${process.pid}`;
+  const previousPath = `${journalPath}.previous`;
+  fs.writeFileSync(temporaryPath, JSON.stringify(journal, null, 2), "utf8");
+  fs.rmSync(previousPath, { force: true });
+  if (fs.existsSync(journalPath)) fs.renameSync(journalPath, previousPath);
+  try {
+    fs.renameSync(temporaryPath, journalPath);
+    fs.rmSync(previousPath, { force: true });
+  } catch (error) {
+    if (!fs.existsSync(journalPath) && fs.existsSync(previousPath)) {
+      fs.renameSync(previousPath, journalPath);
+    }
+    fs.rmSync(temporaryPath, { force: true });
+    throw error;
+  }
+}
+
+function normalizedMetadata(value) {
+  return {
+    panelVersion: String(value?.panelVersion || ""),
+    buildSha: String(value?.buildSha || ""),
+    apiContractVersion: Number(value?.apiContractVersion),
+  };
+}
+
+export function validateBuildCompatibility(frontend, backend) {
+  const client = normalizedMetadata(frontend);
+  const server = normalizedMetadata(backend);
+  const compatible =
+    client.panelVersion !== "" &&
+    client.panelVersion === server.panelVersion &&
+    client.buildSha !== "" &&
+    client.buildSha === server.buildSha &&
+    client.apiContractVersion === server.apiContractVersion;
+  return compatible
+    ? { compatible: true }
+    : {
+        compatible: false,
+        diagnosticCode: "version_mismatch",
+        reason: "Frontend and backend build metadata do not match.",
+      };
+}
+
+function assertInsideInstall(installDir, candidate, label) {
+  const root = `${path.resolve(installDir)}${path.sep}`;
+  const resolved = path.resolve(candidate);
+  if (resolved !== path.resolve(installDir) && !resolved.startsWith(root)) {
+    throw updateError("invalid_bundle", `${label} is outside the install directory`);
+  }
+  return resolved;
+}
+
+function validateJournal(journal) {
+  if (!journal || journal.schemaVersion !== 1 || !journal.paths) {
+    throw updateError("invalid_bundle", "Update bundle journal is invalid");
+  }
+  for (const [label, candidate] of Object.entries(journal.paths)) {
+    assertInsideInstall(journal.installDir, candidate, label);
+  }
+}
+
+export function stageUpdateBundle({
+  installDir,
+  version,
+  binaryPath,
+  stagedBinaryPath,
+  liveClientPath,
+  incomingClientPath,
+  metadata,
+}) {
+  const expectedMetadata = normalizedMetadata(metadata);
+  const compatibility = validateBuildCompatibility(
+    readJson(path.join(incomingClientPath, "build-info.json")),
+    expectedMetadata,
+  );
+  if (!compatibility.compatible) {
+    throw updateError(compatibility.diagnosticCode, compatibility.reason);
+  }
+  if (!fs.existsSync(stagedBinaryPath)) {
+    throw updateError("av_quarantine", "Staged update binary is missing");
+  }
+  if (!fs.existsSync(path.join(incomingClientPath, "index.html"))) {
+    throw updateError(
+      "frontend_swap_failed",
+      "Staged frontend does not contain index.html",
+    );
+  }
+
+  const resolvedInstallDir = path.resolve(installDir);
+  const safeVersion = String(version).replace(/[^0-9A-Za-z._-]/g, "-");
+  const stagedClientPath = path.join(
+    resolvedInstallDir,
+    "client",
+    `dist.new-${safeVersion}`,
+  );
+  const backupBinaryPath = `${binaryPath}.bundle-previous`;
+  const backupClientPath = path.join(
+    path.dirname(liveClientPath),
+    "dist.previous",
+  );
+  const journalPath = path.join(resolvedInstallDir, "update-bundle.json");
+
+  for (const [label, candidate] of Object.entries({
+    binaryPath,
+    stagedBinaryPath,
+    liveClientPath,
+    incomingClientPath,
+    stagedClientPath,
+    backupBinaryPath,
+    backupClientPath,
+  })) {
+    assertInsideInstall(resolvedInstallDir, candidate, label);
+  }
+
+  fs.rmSync(stagedClientPath, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(stagedClientPath), { recursive: true });
+  fs.cpSync(incomingClientPath, stagedClientPath, { recursive: true });
+
+  const journal = {
+    schemaVersion: 1,
+    transactionId: crypto.randomUUID(),
+    version: String(version),
+    phase: "staged",
+    stagedAt: new Date().toISOString(),
+    installDir: resolvedInstallDir,
+    metadata: expectedMetadata,
+    hashes: { binarySha256: sha256File(stagedBinaryPath) },
+    paths: {
+      binary: path.resolve(binaryPath),
+      stagedBinary: path.resolve(stagedBinaryPath),
+      backupBinary: path.resolve(backupBinaryPath),
+      liveClient: path.resolve(liveClientPath),
+      stagedClient: path.resolve(stagedClientPath),
+      backupClient: path.resolve(backupClientPath),
+    },
+  };
+  writeJournal(journalPath, journal);
+  return journalPath;
+}
+
+function rollback(journalPath, journal, reason) {
+  const { paths } = journal;
+  const rollbackErrors = [];
+  const restore = (live, backup, isDirectory) => {
+    try {
+      if (fs.existsSync(backup)) {
+        fs.rmSync(live, { recursive: isDirectory, force: true });
+        fs.renameSync(backup, live);
+      }
+    } catch (error) {
+      rollbackErrors.push(error.message);
+    }
+  };
+  restore(paths.binary, paths.backupBinary, false);
+  restore(paths.liveClient, paths.backupClient, true);
+  journal.phase = rollbackErrors.length ? "rollback_failed" : "rolled_back";
+  journal.failureCode = reason;
+  journal.rollbackErrors = rollbackErrors;
+  writeJournal(journalPath, journal);
+  if (!rollbackErrors.length) fs.rmSync(journalPath, { force: true });
+  return rollbackErrors;
+}
+
+export function applyUpdateBundle(journalPath) {
+  const journal = readJson(journalPath);
+  validateJournal(journal);
+  const { paths } = journal;
+  if (!fs.existsSync(paths.stagedBinary)) {
+    throw updateError("av_quarantine", "Staged update binary is missing");
+  }
+  if (sha256File(paths.stagedBinary) !== journal.hashes.binarySha256) {
+    throw updateError("av_quarantine", "Staged update binary hash changed");
+  }
+  const clientCompatibility = validateBuildCompatibility(
+    readJson(path.join(paths.stagedClient, "build-info.json")),
+    journal.metadata,
+  );
+  if (!clientCompatibility.compatible) {
+    throw updateError(
+      clientCompatibility.diagnosticCode,
+      clientCompatibility.reason,
+    );
+  }
+
+  fs.rmSync(paths.backupBinary, { force: true });
+  fs.rmSync(paths.backupClient, { recursive: true, force: true });
+  journal.phase = "applying";
+  writeJournal(journalPath, journal);
+
+  try {
+    if (fs.existsSync(paths.binary)) fs.renameSync(paths.binary, paths.backupBinary);
+    journal.phase = "binary_backed_up";
+    writeJournal(journalPath, journal);
+
+    if (fs.existsSync(paths.liveClient)) {
+      fs.renameSync(paths.liveClient, paths.backupClient);
+    }
+    journal.phase = "client_backed_up";
+    writeJournal(journalPath, journal);
+
+    try {
+      fs.renameSync(paths.stagedClient, paths.liveClient);
+    } catch (error) {
+      throw updateError("frontend_swap_failed", "Could not activate staged frontend", error);
+    }
+    journal.phase = "client_activated";
+    writeJournal(journalPath, journal);
+
+    try {
+      fs.renameSync(paths.stagedBinary, paths.binary);
+    } catch (error) {
+      throw updateError("binary_swap_failed", "Could not activate staged binary", error);
+    }
+    journal.phase = "awaiting_startup_ack";
+    journal.appliedAt = new Date().toISOString();
+    writeJournal(journalPath, journal);
+    return journal;
+  } catch (error) {
+    const code = error.code || "bundle_apply_failed";
+    rollback(journalPath, journal, code);
+    throw error;
+  }
+}
+
+export function acknowledgeUpdateBundle(journalPath, runningMetadata) {
+  if (!fs.existsSync(journalPath)) return false;
+  const journal = readJson(journalPath);
+  validateJournal(journal);
+  if (journal.phase !== "awaiting_startup_ack") return false;
+  const backendCompatibility = validateBuildCompatibility(
+    journal.metadata,
+    runningMetadata,
+  );
+  const frontendCompatibility = validateBuildCompatibility(
+    readJson(path.join(journal.paths.liveClient, "build-info.json")),
+    runningMetadata,
+  );
+  if (!backendCompatibility.compatible || !frontendCompatibility.compatible) {
+    rollback(journalPath, journal, "version_mismatch");
+    throw updateError(
+      "version_mismatch",
+      "Applied frontend and backend metadata do not match",
+    );
+  }
+  fs.rmSync(journal.paths.backupBinary, { force: true });
+  fs.rmSync(journal.paths.backupClient, { recursive: true, force: true });
+  fs.rmSync(journalPath, { force: true });
+  return true;
+}
+
+export function recoverInterruptedUpdateBundle(
+  journalPath,
+  reason = "startup_handshake_failed",
+) {
+  if (!fs.existsSync(journalPath)) return false;
+  const journal = readJson(journalPath);
+  validateJournal(journal);
+  if (journal.phase === "staged") return false;
+  const errors = rollback(journalPath, journal, reason);
+  if (errors.length) {
+    throw updateError(
+      "rollback_failed",
+      `Update rollback was incomplete: ${errors.join(", ")}`,
+    );
+  }
+  return true;
+}

--- a/server/services/updateBundle.js
+++ b/server/services/updateBundle.js
@@ -4,6 +4,26 @@ import path from "path";
 
 export const PANEL_API_CONTRACT_VERSION = 1;
 
+const JOURNAL_PHASES = new Set([
+  "staged",
+  "applying",
+  "binary_backed_up",
+  "client_backed_up",
+  "client_activated",
+  "awaiting_startup_ack",
+  "rollback_failed",
+  "rolled_back",
+]);
+
+const REQUIRED_JOURNAL_PATHS = [
+  "binary",
+  "stagedBinary",
+  "backupBinary",
+  "liveClient",
+  "stagedClient",
+  "backupClient",
+];
+
 function updateError(code, message, cause) {
   const error = new Error(message, cause ? { cause } : undefined);
   error.code = code;
@@ -16,8 +36,23 @@ function sha256File(filePath) {
   return hash.digest("hex");
 }
 
-function readJson(filePath) {
-  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+function readJson(filePath, errorCode = "invalid_bundle") {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === errorCode) throw error;
+    throw updateError(errorCode, `Could not read JSON from ${filePath}`, error);
+  }
+}
+
+function renameIfPresent(source, destination) {
+  try {
+    fs.renameSync(source, destination);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
 }
 
 function writeJournal(journalPath, journal) {
@@ -25,14 +60,12 @@ function writeJournal(journalPath, journal) {
   const previousPath = `${journalPath}.previous`;
   fs.writeFileSync(temporaryPath, JSON.stringify(journal, null, 2), "utf8");
   fs.rmSync(previousPath, { force: true });
-  if (fs.existsSync(journalPath)) fs.renameSync(journalPath, previousPath);
+  renameIfPresent(journalPath, previousPath);
   try {
     fs.renameSync(temporaryPath, journalPath);
     fs.rmSync(previousPath, { force: true });
   } catch (error) {
-    if (!fs.existsSync(journalPath) && fs.existsSync(previousPath)) {
-      fs.renameSync(previousPath, journalPath);
-    }
+    renameIfPresent(previousPath, journalPath);
     fs.rmSync(temporaryPath, { force: true });
     throw error;
   }
@@ -44,6 +77,16 @@ function normalizedMetadata(value) {
     buildSha: String(value?.buildSha || ""),
     apiContractVersion: Number(value?.apiContractVersion),
   };
+}
+
+function hasValidMetadata(value) {
+  const metadata = normalizedMetadata(value);
+  return (
+    metadata.panelVersion !== "" &&
+    metadata.buildSha !== "" &&
+    Number.isInteger(metadata.apiContractVersion) &&
+    metadata.apiContractVersion > 0
+  );
 }
 
 export function validateBuildCompatibility(frontend, backend) {
@@ -65,21 +108,139 @@ export function validateBuildCompatibility(frontend, backend) {
 }
 
 function assertInsideInstall(installDir, candidate, label) {
-  const root = `${path.resolve(installDir)}${path.sep}`;
+  if (typeof installDir !== "string" || typeof candidate !== "string") {
+    throw updateError("invalid_bundle", `${label} is not a valid path`);
+  }
+  const resolvedInstallDir = path.resolve(installDir);
+  const root = `${resolvedInstallDir}${path.sep}`;
   const resolved = path.resolve(candidate);
-  if (resolved !== path.resolve(installDir) && !resolved.startsWith(root)) {
+  if (resolved !== resolvedInstallDir && !resolved.startsWith(root)) {
     throw updateError("invalid_bundle", `${label} is outside the install directory`);
   }
   return resolved;
 }
 
-function validateJournal(journal) {
-  if (!journal || journal.schemaVersion !== 1 || !journal.paths) {
+function validateJournal(journal, journalPath) {
+  if (
+    !journal ||
+    journal.schemaVersion !== 1 ||
+    typeof journal.transactionId !== "string" ||
+    journal.transactionId === "" ||
+    typeof journal.version !== "string" ||
+    !JOURNAL_PHASES.has(journal.phase) ||
+    typeof journal.installDir !== "string" ||
+    !hasValidMetadata(journal.metadata) ||
+    typeof journal.hashes?.binarySha256 !== "string" ||
+    journal.hashes.binarySha256 === "" ||
+    !journal.paths
+  ) {
     throw updateError("invalid_bundle", "Update bundle journal is invalid");
   }
-  for (const [label, candidate] of Object.entries(journal.paths)) {
-    assertInsideInstall(journal.installDir, candidate, label);
+
+  const installDir = path.resolve(journal.installDir);
+  if (path.dirname(path.resolve(journalPath)) !== installDir) {
+    throw updateError(
+      "invalid_bundle",
+      "Update bundle journal does not match its installation directory",
+    );
   }
+  assertInsideInstall(installDir, journalPath, "journal");
+  for (const label of REQUIRED_JOURNAL_PATHS) {
+    assertInsideInstall(installDir, journal.paths[label], label);
+  }
+  return journal;
+}
+
+export function readUpdateBundleJournalIfPresent(journalPath) {
+  let descriptor;
+  try {
+    descriptor = fs.openSync(journalPath, "r");
+    let journal;
+    try {
+      journal = JSON.parse(fs.readFileSync(descriptor, "utf8"));
+    } catch (error) {
+      throw updateError("invalid_bundle", "Update bundle journal is not valid JSON", error);
+    }
+    return validateJournal(journal, journalPath);
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    if (error?.code === "invalid_bundle") throw error;
+    throw updateError("invalid_bundle", "Could not read update bundle journal", error);
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}
+
+function markerIsPresent(markerPath, installDir) {
+  if (!markerPath) return false;
+  assertInsideInstall(installDir, markerPath, "applying marker");
+  let descriptor;
+  try {
+    descriptor = fs.openSync(markerPath, "r");
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw updateError("invalid_bundle", "Could not inspect update applying marker", error);
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}
+
+function ensureCompatibleBundle(journal, runningMetadata) {
+  const backendCompatibility = validateBuildCompatibility(
+    journal.metadata,
+    runningMetadata,
+  );
+  const frontendCompatibility = validateBuildCompatibility(
+    readJson(path.join(journal.paths.liveClient, "build-info.json")),
+    runningMetadata,
+  );
+  if (!backendCompatibility.compatible || !frontendCompatibility.compatible) {
+    throw updateError(
+      "version_mismatch",
+      "Applied frontend and backend metadata do not match",
+    );
+  }
+}
+
+function sameAcknowledgementState(previous, current) {
+  return (
+    previous.transactionId === current.transactionId &&
+    previous.phase === current.phase &&
+    previous.hashes.binarySha256 === current.hashes.binarySha256 &&
+    validateBuildCompatibility(previous.metadata, current.metadata).compatible &&
+    REQUIRED_JOURNAL_PATHS.every(
+      (label) => previous.paths[label] === current.paths[label],
+    )
+  );
+}
+
+export function inspectPendingUpdateBundle({
+  journalPath,
+  applyingMarkerPath,
+  runningMetadata,
+}) {
+  const journal = readUpdateBundleJournalIfPresent(journalPath);
+  if (!journal) {
+    return { pending: false, awaitingStartupAck: false };
+  }
+
+  const windowsApplication =
+    journal.phase === "staged" &&
+    markerIsPresent(applyingMarkerPath, journal.installDir);
+  const awaitingStartupAck =
+    journal.phase === "awaiting_startup_ack" || windowsApplication;
+
+  if (awaitingStartupAck) ensureCompatibleBundle(journal, runningMetadata);
+
+  return {
+    pending: true,
+    awaitingStartupAck,
+    phase: journal.phase,
+    transactionId: journal.transactionId,
+    metadata: normalizedMetadata(journal.metadata),
+    applyingMarkerPath,
+  };
 }
 
 export function stageUpdateBundle({
@@ -99,14 +260,30 @@ export function stageUpdateBundle({
   if (!compatibility.compatible) {
     throw updateError(compatibility.diagnosticCode, compatibility.reason);
   }
-  if (!fs.existsSync(stagedBinaryPath)) {
-    throw updateError("av_quarantine", "Staged update binary is missing");
+
+  let binarySha256;
+  try {
+    binarySha256 = sha256File(stagedBinaryPath);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw updateError("av_quarantine", "Staged update binary is missing", error);
+    }
+    throw error;
   }
-  if (!fs.existsSync(path.join(incomingClientPath, "index.html"))) {
-    throw updateError(
-      "frontend_swap_failed",
-      "Staged frontend does not contain index.html",
-    );
+  let indexDescriptor;
+  try {
+    indexDescriptor = fs.openSync(path.join(incomingClientPath, "index.html"), "r");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw updateError(
+        "frontend_swap_failed",
+        "Staged frontend does not contain index.html",
+        error,
+      );
+    }
+    throw error;
+  } finally {
+    if (indexDescriptor !== undefined) fs.closeSync(indexDescriptor);
   }
 
   const resolvedInstallDir = path.resolve(installDir);
@@ -147,7 +324,7 @@ export function stageUpdateBundle({
     stagedAt: new Date().toISOString(),
     installDir: resolvedInstallDir,
     metadata: expectedMetadata,
-    hashes: { binarySha256: sha256File(stagedBinaryPath) },
+    hashes: { binarySha256 },
     paths: {
       binary: path.resolve(binaryPath),
       stagedBinary: path.resolve(stagedBinaryPath),
@@ -165,10 +342,16 @@ function rollback(journalPath, journal, reason) {
   const { paths } = journal;
   const rollbackErrors = [];
   const restore = (live, backup, isDirectory) => {
+    const capturedBackup = `${backup}.restoring-${process.pid}`;
     try {
-      if (fs.existsSync(backup)) {
+      fs.rmSync(capturedBackup, { recursive: isDirectory, force: true });
+      if (!renameIfPresent(backup, capturedBackup)) return;
+      try {
         fs.rmSync(live, { recursive: isDirectory, force: true });
-        fs.renameSync(backup, live);
+        fs.renameSync(capturedBackup, live);
+      } catch (error) {
+        renameIfPresent(capturedBackup, backup);
+        throw error;
       }
     } catch (error) {
       rollbackErrors.push(error.message);
@@ -185,13 +368,19 @@ function rollback(journalPath, journal, reason) {
 }
 
 export function applyUpdateBundle(journalPath) {
-  const journal = readJson(journalPath);
-  validateJournal(journal);
+  const journal = readUpdateBundleJournalIfPresent(journalPath);
+  if (!journal) throw updateError("invalid_bundle", "Update bundle journal is missing");
   const { paths } = journal;
-  if (!fs.existsSync(paths.stagedBinary)) {
-    throw updateError("av_quarantine", "Staged update binary is missing");
+  let stagedBinaryHash;
+  try {
+    stagedBinaryHash = sha256File(paths.stagedBinary);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw updateError("av_quarantine", "Staged update binary is missing", error);
+    }
+    throw error;
   }
-  if (sha256File(paths.stagedBinary) !== journal.hashes.binarySha256) {
+  if (stagedBinaryHash !== journal.hashes.binarySha256) {
     throw updateError("av_quarantine", "Staged update binary hash changed");
   }
   const clientCompatibility = validateBuildCompatibility(
@@ -211,13 +400,11 @@ export function applyUpdateBundle(journalPath) {
   writeJournal(journalPath, journal);
 
   try {
-    if (fs.existsSync(paths.binary)) fs.renameSync(paths.binary, paths.backupBinary);
+    renameIfPresent(paths.binary, paths.backupBinary);
     journal.phase = "binary_backed_up";
     writeJournal(journalPath, journal);
 
-    if (fs.existsSync(paths.liveClient)) {
-      fs.renameSync(paths.liveClient, paths.backupClient);
-    }
+    renameIfPresent(paths.liveClient, paths.backupClient);
     journal.phase = "client_backed_up";
     writeJournal(journalPath, journal);
 
@@ -245,29 +432,69 @@ export function applyUpdateBundle(journalPath) {
   }
 }
 
-export function acknowledgeUpdateBundle(journalPath, runningMetadata) {
-  if (!fs.existsSync(journalPath)) return false;
-  const journal = readJson(journalPath);
-  validateJournal(journal);
-  if (journal.phase !== "awaiting_startup_ack") return false;
-  const backendCompatibility = validateBuildCompatibility(
-    journal.metadata,
-    runningMetadata,
-  );
-  const frontendCompatibility = validateBuildCompatibility(
-    readJson(path.join(journal.paths.liveClient, "build-info.json")),
-    runningMetadata,
-  );
-  if (!backendCompatibility.compatible || !frontendCompatibility.compatible) {
-    rollback(journalPath, journal, "version_mismatch");
+export function acknowledgeUpdateBundle(
+  journalPath,
+  runningMetadata,
+  { transactionId, expectedMetadata, applyingMarkerPath } = {},
+) {
+  const journal = readUpdateBundleJournalIfPresent(journalPath);
+  if (!journal) return false;
+
+  if (transactionId && journal.transactionId !== transactionId) {
     throw updateError(
-      "version_mismatch",
-      "Applied frontend and backend metadata do not match",
+      "invalid_bundle",
+      "Update bundle transaction changed before startup acknowledgement",
     );
   }
-  fs.rmSync(journal.paths.backupBinary, { force: true });
-  fs.rmSync(journal.paths.backupClient, { recursive: true, force: true });
+  if (
+    expectedMetadata &&
+    !validateBuildCompatibility(journal.metadata, expectedMetadata).compatible
+  ) {
+    throw updateError(
+      "invalid_bundle",
+      "Update bundle metadata changed before startup acknowledgement",
+    );
+  }
+
+  const windowsApplication =
+    journal.phase === "staged" &&
+    markerIsPresent(applyingMarkerPath, journal.installDir);
+  if (journal.phase !== "awaiting_startup_ack" && !windowsApplication) return false;
+
+  const confirmedJournal = readUpdateBundleJournalIfPresent(journalPath);
+  if (!confirmedJournal) return false;
+  if (!sameAcknowledgementState(journal, confirmedJournal)) {
+    throw updateError(
+      "invalid_bundle",
+      "Update bundle state changed before startup acknowledgement",
+    );
+  }
+  if (
+    windowsApplication &&
+    !markerIsPresent(applyingMarkerPath, confirmedJournal.installDir)
+  ) {
+    return false;
+  }
+
+  try {
+    ensureCompatibleBundle(confirmedJournal, runningMetadata);
+  } catch (error) {
+    if (error?.code !== "version_mismatch") throw error;
+    const rollbackErrors = rollback(
+      journalPath,
+      confirmedJournal,
+      "version_mismatch",
+    );
+    if (!rollbackErrors.length && applyingMarkerPath) {
+      fs.rmSync(applyingMarkerPath, { force: true });
+    }
+    throw error;
+  }
+
+  fs.rmSync(confirmedJournal.paths.backupBinary, { force: true });
+  fs.rmSync(confirmedJournal.paths.backupClient, { recursive: true, force: true });
   fs.rmSync(journalPath, { force: true });
+  if (applyingMarkerPath) fs.rmSync(applyingMarkerPath, { force: true });
   return true;
 }
 
@@ -275,9 +502,8 @@ export function recoverInterruptedUpdateBundle(
   journalPath,
   reason = "startup_handshake_failed",
 ) {
-  if (!fs.existsSync(journalPath)) return false;
-  const journal = readJson(journalPath);
-  validateJournal(journal);
+  const journal = readUpdateBundleJournalIfPresent(journalPath);
+  if (!journal) return false;
   if (journal.phase === "staged") return false;
   const errors = rollback(journalPath, journal, reason);
   if (errors.length) {

--- a/server/tests/buildLaunchers.test.js
+++ b/server/tests/buildLaunchers.test.js
@@ -12,4 +12,32 @@ describe("standalone launchers", () => {
   it("does not promise a fixed URL from the Windows supervisor", () => {
     expect(generateStartBat()).not.toContain("localhost:3001");
   });
+
+  it("checks that the pending marker becomes the applying marker before launch", () => {
+    const launcher = generateStartBat();
+    const moveStart = launcher.indexOf('move /y "%MARKER%" "%APPLYING%"');
+    const moveFailureCheck = launcher.indexOf("if errorlevel 1", moveStart);
+    const activationLog = launcher.indexOf(
+      "Apply: bundle activated; waiting for backend startup acknowledgement",
+      moveStart,
+    );
+
+    expect(moveStart).toBeGreaterThan(-1);
+    expect(moveFailureCheck).toBeGreaterThan(moveStart);
+    expect(moveFailureCheck).toBeLessThan(activationLog);
+  });
+
+  it("retains the update journal unless every rollback restore succeeds", () => {
+    const launcher = generateStartBat();
+    const rollbackStart = launcher.indexOf(":rollback_update");
+    const restoreFailureCheck = launcher.indexOf(
+      'if "!ROLLBACK_FAILED!"=="1"',
+      rollbackStart,
+    );
+    const journalDelete = launcher.indexOf('del /f /q "%JOURNAL%"', rollbackStart);
+
+    expect(rollbackStart).toBeGreaterThan(-1);
+    expect(restoreFailureCheck).toBeGreaterThan(rollbackStart);
+    expect(journalDelete).toBeGreaterThan(restoreFailureCheck);
+  });
 });

--- a/server/tests/buildLaunchers.test.js
+++ b/server/tests/buildLaunchers.test.js
@@ -13,6 +13,16 @@ describe("standalone launchers", () => {
     expect(generateStartBat()).not.toContain("localhost:3001");
   });
 
+  it("preserves Windows separators in generated frontend paths", () => {
+    const launcher = generateStartBat();
+
+    expect(launcher).toContain(
+      'set "CLIENT_LIVE=%INSTALL_DIR%client\\dist"',
+    );
+    expect(launcher).toContain('if not exist "!STAGED_CLIENT!\\index.html"');
+    expect(launcher).not.toContain("clientdist");
+  });
+
   it("checks that the pending marker becomes the applying marker before launch", () => {
     const launcher = generateStartBat();
     const moveStart = launcher.indexOf('move /y "%MARKER%" "%APPLYING%"');

--- a/server/tests/panelUpdateBundle.test.js
+++ b/server/tests/panelUpdateBundle.test.js
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  acknowledgeUpdateBundle,
+  applyUpdateBundle,
+  recoverInterruptedUpdateBundle,
+  stageUpdateBundle,
+  validateBuildCompatibility,
+} from "../services/updateBundle.js";
+
+let installDir;
+
+function writeFile(filePath, contents) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+}
+
+function metadata(version = "2.0.0", buildSha = "new-build") {
+  return { panelVersion: version, buildSha, apiContractVersion: 1 };
+}
+
+function prepareBundle() {
+  const binaryPath = path.join(installDir, "ZomboidControlPanel");
+  const stagedBinaryPath = `${binaryPath}.new`;
+  const liveClientPath = path.join(installDir, "client", "dist");
+  const incomingClientPath = path.join(installDir, "incoming-client");
+  writeFile(binaryPath, "old-binary");
+  writeFile(stagedBinaryPath, "new-binary");
+  writeFile(path.join(liveClientPath, "index.html"), "old-client");
+  writeFile(path.join(incomingClientPath, "index.html"), "new-client");
+  writeFile(
+    path.join(incomingClientPath, "build-info.json"),
+    JSON.stringify(metadata()),
+  );
+  const sentinelPath = path.join(installDir, "data", "db.json");
+  writeFile(sentinelPath, "operator-state");
+  const journalPath = stageUpdateBundle({
+    installDir,
+    version: "2.0.0",
+    binaryPath,
+    stagedBinaryPath,
+    liveClientPath,
+    incomingClientPath,
+    metadata: metadata(),
+  });
+  return { binaryPath, stagedBinaryPath, liveClientPath, journalPath, sentinelPath };
+}
+
+describe("versioned panel update bundles", () => {
+  beforeEach(() => {
+    installDir = fs.mkdtempSync(path.join(os.tmpdir(), "zcp-update-bundle-"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(installDir, { recursive: true, force: true });
+  });
+
+  it("stages matching frontend and backend artifacts without touching the live client", () => {
+    const { liveClientPath, journalPath } = prepareBundle();
+
+    expect(fs.readFileSync(path.join(liveClientPath, "index.html"), "utf8")).toBe(
+      "old-client",
+    );
+    const journal = JSON.parse(fs.readFileSync(journalPath, "utf8"));
+    expect(journal.phase).toBe("staged");
+    expect(journal.metadata).toEqual(metadata());
+    expect(fs.existsSync(path.join(journal.paths.stagedClient, "index.html"))).toBe(true);
+  });
+
+  it("retains both backups until the new backend acknowledges startup", () => {
+    const { binaryPath, liveClientPath, journalPath, sentinelPath } = prepareBundle();
+
+    applyUpdateBundle(journalPath);
+
+    expect(fs.readFileSync(binaryPath, "utf8")).toBe("new-binary");
+    expect(fs.readFileSync(path.join(liveClientPath, "index.html"), "utf8")).toBe(
+      "new-client",
+    );
+    expect(JSON.parse(fs.readFileSync(journalPath, "utf8")).phase).toBe(
+      "awaiting_startup_ack",
+    );
+
+    acknowledgeUpdateBundle(journalPath, metadata());
+
+    expect(fs.existsSync(journalPath)).toBe(false);
+    expect(fs.readFileSync(sentinelPath, "utf8")).toBe("operator-state");
+  });
+
+  it("rejects a missing staged binary before changing either live artifact", () => {
+    const { stagedBinaryPath, binaryPath, liveClientPath, journalPath } = prepareBundle();
+    fs.unlinkSync(stagedBinaryPath);
+
+    expect(() => applyUpdateBundle(journalPath)).toThrowError(
+      expect.objectContaining({ code: "av_quarantine" }),
+    );
+    expect(fs.readFileSync(binaryPath, "utf8")).toBe("old-binary");
+    expect(fs.readFileSync(path.join(liveClientPath, "index.html"), "utf8")).toBe(
+      "old-client",
+    );
+  });
+
+  it("rolls back the frontend when binary activation fails", () => {
+    const { binaryPath, liveClientPath, journalPath } = prepareBundle();
+    const originalRename = fs.renameSync.bind(fs);
+    vi.spyOn(fs, "renameSync").mockImplementation((source, destination) => {
+      if (String(source).endsWith(".new") && destination === binaryPath) {
+        throw Object.assign(new Error("simulated binary swap failure"), { code: "EIO" });
+      }
+      return originalRename(source, destination);
+    });
+
+    expect(() => applyUpdateBundle(journalPath)).toThrowError(
+      expect.objectContaining({ code: "binary_swap_failed" }),
+    );
+    expect(fs.readFileSync(binaryPath, "utf8")).toBe("old-binary");
+    expect(fs.readFileSync(path.join(liveClientPath, "index.html"), "utf8")).toBe(
+      "old-client",
+    );
+  });
+
+  it("restores the binary when frontend activation fails", () => {
+    const { binaryPath, liveClientPath, journalPath } = prepareBundle();
+    const journal = JSON.parse(fs.readFileSync(journalPath, "utf8"));
+    const originalRename = fs.renameSync.bind(fs);
+    vi.spyOn(fs, "renameSync").mockImplementation((source, destination) => {
+      if (source === journal.paths.stagedClient && destination === liveClientPath) {
+        throw Object.assign(new Error("simulated frontend swap failure"), { code: "EIO" });
+      }
+      return originalRename(source, destination);
+    });
+
+    expect(() => applyUpdateBundle(journalPath)).toThrowError(
+      expect.objectContaining({ code: "frontend_swap_failed" }),
+    );
+    expect(fs.readFileSync(binaryPath, "utf8")).toBe("old-binary");
+    expect(fs.readFileSync(path.join(liveClientPath, "index.html"), "utf8")).toBe(
+      "old-client",
+    );
+  });
+
+  it("recovers both artifacts from an interrupted awaiting-ack transaction", () => {
+    const { binaryPath, liveClientPath, journalPath } = prepareBundle();
+    applyUpdateBundle(journalPath);
+
+    recoverInterruptedUpdateBundle(journalPath, "startup_handshake_failed");
+
+    expect(fs.readFileSync(binaryPath, "utf8")).toBe("old-binary");
+    expect(fs.readFileSync(path.join(liveClientPath, "index.html"), "utf8")).toBe(
+      "old-client",
+    );
+  });
+
+  it("detects frontend-older and backend-older mismatches", () => {
+    expect(
+      validateBuildCompatibility(metadata("1.9.0"), metadata("2.0.0")),
+    ).toEqual(
+      expect.objectContaining({
+        compatible: false,
+        diagnosticCode: "version_mismatch",
+      }),
+    );
+    expect(
+      validateBuildCompatibility(metadata("2.1.0"), metadata("2.0.0")),
+    ).toEqual(
+      expect.objectContaining({
+        compatible: false,
+        diagnosticCode: "version_mismatch",
+      }),
+    );
+  });
+
+  it("rolls back both artifacts when the new backend acknowledges with mismatched metadata", () => {
+    const { binaryPath, liveClientPath, journalPath } = prepareBundle();
+    applyUpdateBundle(journalPath);
+
+    expect(() =>
+      acknowledgeUpdateBundle(journalPath, metadata("2.0.1", "other-build")),
+    ).toThrowError(expect.objectContaining({ code: "version_mismatch" }));
+
+    expect(fs.readFileSync(binaryPath, "utf8")).toBe("old-binary");
+    expect(fs.readFileSync(path.join(liveClientPath, "index.html"), "utf8")).toBe(
+      "old-client",
+    );
+  });
+});

--- a/server/tests/panelUpdateBundle.test.js
+++ b/server/tests/panelUpdateBundle.test.js
@@ -5,6 +5,8 @@ import path from "path";
 import {
   acknowledgeUpdateBundle,
   applyUpdateBundle,
+  inspectPendingUpdateBundle,
+  readUpdateBundleJournalIfPresent,
   recoverInterruptedUpdateBundle,
   stageUpdateBundle,
   validateBuildCompatibility,
@@ -46,6 +48,17 @@ function prepareBundle() {
     metadata: metadata(),
   });
   return { binaryPath, stagedBinaryPath, liveClientPath, journalPath, sentinelPath };
+}
+
+function simulateWindowsApplication(journalPath) {
+  const journal = JSON.parse(fs.readFileSync(journalPath, "utf8"));
+  fs.renameSync(journal.paths.binary, journal.paths.backupBinary);
+  fs.renameSync(journal.paths.liveClient, journal.paths.backupClient);
+  fs.renameSync(journal.paths.stagedClient, journal.paths.liveClient);
+  fs.renameSync(journal.paths.stagedBinary, journal.paths.binary);
+  const applyingMarkerPath = path.join(installDir, ".update-applying");
+  writeFile(applyingMarkerPath, "applying");
+  return { journal, applyingMarkerPath };
 }
 
 describe("versioned panel update bundles", () => {
@@ -180,6 +193,170 @@ describe("versioned panel update bundles", () => {
       acknowledgeUpdateBundle(journalPath, metadata("2.0.1", "other-build")),
     ).toThrowError(expect.objectContaining({ code: "version_mismatch" }));
 
+    expect(fs.readFileSync(binaryPath, "utf8")).toBe("old-binary");
+    expect(fs.readFileSync(path.join(liveClientPath, "index.html"), "utf8")).toBe(
+      "old-client",
+    );
+  });
+
+  it("treats a journal missing at open time as no pending update", () => {
+    const journalPath = path.join(installDir, "update-bundle.json");
+    const originalOpen = fs.openSync.bind(fs);
+    vi.spyOn(fs, "openSync").mockImplementation((candidate, ...args) => {
+      if (candidate === journalPath) {
+        throw Object.assign(new Error("journal disappeared"), { code: "ENOENT" });
+      }
+      return originalOpen(candidate, ...args);
+    });
+
+    expect(readUpdateBundleJournalIfPresent(journalPath)).toBeNull();
+    expect(
+      inspectPendingUpdateBundle({
+        journalPath,
+        applyingMarkerPath: path.join(installDir, ".update-applying"),
+        runningMetadata: metadata(),
+      }),
+    ).toEqual(expect.objectContaining({ pending: false }));
+  });
+
+  it("fails closed for a corrupt update journal", () => {
+    const journalPath = path.join(installDir, "update-bundle.json");
+    writeFile(journalPath, "{not-json");
+
+    expect(() =>
+      inspectPendingUpdateBundle({
+        journalPath,
+        applyingMarkerPath: path.join(installDir, ".update-applying"),
+        runningMetadata: metadata(),
+      }),
+    ).toThrowError(expect.objectContaining({ code: "invalid_bundle" }));
+  });
+
+  it("rejects journal paths outside the installation directory", () => {
+    const { journalPath } = prepareBundle();
+    const journal = JSON.parse(fs.readFileSync(journalPath, "utf8"));
+    journal.paths.liveClient = path.join(path.dirname(installDir), "escaped-client");
+    fs.writeFileSync(journalPath, JSON.stringify(journal), "utf8");
+
+    expect(() =>
+      inspectPendingUpdateBundle({
+        journalPath,
+        applyingMarkerPath: path.join(installDir, ".update-applying"),
+        runningMetadata: metadata(),
+      }),
+    ).toThrowError(expect.objectContaining({ code: "invalid_bundle" }));
+  });
+
+  it("recognizes staged plus the Windows applying marker without rewriting the journal", () => {
+    const { journalPath } = prepareBundle();
+    const { journal, applyingMarkerPath } = simulateWindowsApplication(journalPath);
+    const originalJournal = fs.readFileSync(journalPath, "utf8");
+
+    const inspection = inspectPendingUpdateBundle({
+      journalPath,
+      applyingMarkerPath,
+      runningMetadata: metadata(),
+    });
+
+    expect(inspection).toEqual(
+      expect.objectContaining({
+        pending: true,
+        awaitingStartupAck: true,
+        transactionId: journal.transactionId,
+      }),
+    );
+    expect(fs.readFileSync(journalPath, "utf8")).toBe(originalJournal);
+    expect(JSON.parse(originalJournal).phase).toBe("staged");
+  });
+
+  it("keeps backups when the Windows applying marker disappears before acknowledgement", () => {
+    const { journalPath } = prepareBundle();
+    const { journal, applyingMarkerPath } = simulateWindowsApplication(journalPath);
+    const inspection = inspectPendingUpdateBundle({
+      journalPath,
+      applyingMarkerPath,
+      runningMetadata: metadata(),
+    });
+    fs.unlinkSync(applyingMarkerPath);
+
+    expect(
+      acknowledgeUpdateBundle(journalPath, metadata(), {
+        transactionId: inspection.transactionId,
+        applyingMarkerPath,
+      }),
+    ).toBe(false);
+    expect(fs.existsSync(journalPath)).toBe(true);
+    expect(fs.existsSync(journal.paths.backupBinary)).toBe(true);
+    expect(fs.existsSync(journal.paths.backupClient)).toBe(true);
+  });
+
+  it("keeps backups when the journal transaction changes before acknowledgement", () => {
+    const { journalPath } = prepareBundle();
+    const { journal, applyingMarkerPath } = simulateWindowsApplication(journalPath);
+    const inspection = inspectPendingUpdateBundle({
+      journalPath,
+      applyingMarkerPath,
+      runningMetadata: metadata(),
+    });
+    const replacement = JSON.parse(fs.readFileSync(journalPath, "utf8"));
+    replacement.transactionId = "replacement-transaction";
+    fs.writeFileSync(journalPath, JSON.stringify(replacement), "utf8");
+
+    expect(() =>
+      acknowledgeUpdateBundle(journalPath, metadata(), {
+        transactionId: inspection.transactionId,
+        applyingMarkerPath,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "invalid_bundle" }));
+    expect(fs.existsSync(journal.paths.backupBinary)).toBe(true);
+    expect(fs.existsSync(journal.paths.backupClient)).toBe(true);
+  });
+
+  it("acknowledges a matching Windows bundle and removes both backups and its marker", () => {
+    const { binaryPath, liveClientPath, journalPath } = prepareBundle();
+    const { journal, applyingMarkerPath } = simulateWindowsApplication(journalPath);
+    const inspection = inspectPendingUpdateBundle({
+      journalPath,
+      applyingMarkerPath,
+      runningMetadata: metadata(),
+    });
+
+    expect(
+      acknowledgeUpdateBundle(journalPath, metadata(), {
+        transactionId: inspection.transactionId,
+        applyingMarkerPath,
+      }),
+    ).toBe(true);
+    expect(fs.readFileSync(binaryPath, "utf8")).toBe("new-binary");
+    expect(fs.readFileSync(path.join(liveClientPath, "index.html"), "utf8")).toBe(
+      "new-client",
+    );
+    expect(fs.existsSync(journal.paths.backupBinary)).toBe(false);
+    expect(fs.existsSync(journal.paths.backupClient)).toBe(false);
+    expect(fs.existsSync(journalPath)).toBe(false);
+    expect(fs.existsSync(applyingMarkerPath)).toBe(false);
+  });
+
+  it("rolls back both Windows artifacts when metadata changes before acknowledgement", () => {
+    const { binaryPath, liveClientPath, journalPath } = prepareBundle();
+    const { applyingMarkerPath } = simulateWindowsApplication(journalPath);
+    const inspection = inspectPendingUpdateBundle({
+      journalPath,
+      applyingMarkerPath,
+      runningMetadata: metadata(),
+    });
+    fs.writeFileSync(
+      path.join(liveClientPath, "build-info.json"),
+      JSON.stringify(metadata("2.0.1", "unexpected-build")),
+      "utf8",
+    );
+
+    expect(() =>
+      acknowledgeUpdateBundle(journalPath, metadata(), {
+        transactionId: inspection.transactionId,
+        applyingMarkerPath,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "version_mismatch" }));
     expect(fs.readFileSync(binaryPath, "utf8")).toBe("old-binary");
     expect(fs.readFileSync(path.join(liveClientPath, "index.html"), "utf8")).toBe(
       "old-client",

--- a/server/tests/supervisor-restart.test.js
+++ b/server/tests/supervisor-restart.test.js
@@ -102,54 +102,17 @@ function setupPendingUpdate(dir) {
   fs.writeFileSync(path.join(dir, ".update-pending"), "pending");
 }
 
-function startExclusiveLocker(targetPath, holdMs = 120000) {
-  const readyPath = `${targetPath}.lock-ready-${Date.now()}-${Math.random()
-    .toString(16)
-    .slice(2)}`;
-  const lockScript = `
-$deadline = (Get-Date).AddSeconds(30)
-while ((Get-Date) -lt $deadline) {
-  $stream = $null
-  try {
-    $stream = [System.IO.File]::Open(
-      $env:ZCP_LOCK_TARGET,
-      [System.IO.FileMode]::Open,
-      [System.IO.FileAccess]::ReadWrite,
-      [System.IO.FileShare]::None
-    )
-    [System.IO.File]::WriteAllText($env:ZCP_LOCK_READY, "locked")
-    Start-Sleep -Milliseconds ([int]$env:ZCP_LOCK_HOLD_MS)
-    exit 0
-  } catch {
-    Start-Sleep -Milliseconds 10
-  } finally {
-    if ($null -ne $stream) { $stream.Dispose() }
-  }
-}
-exit 2
-`;
-  const child = spawn("powershell.exe", ["-NoProfile", "-Command", lockScript], {
-    windowsHide: true,
+function denyDelete(targetPath) {
+  execFileSync("icacls.exe", [targetPath, "/deny", "*S-1-1-0:(D)"], {
     stdio: "ignore",
-    env: {
-      ...process.env,
-      ZCP_LOCK_TARGET: targetPath,
-      ZCP_LOCK_READY: readyPath,
-      ZCP_LOCK_HOLD_MS: String(holdMs),
-    },
   });
-  return { child, readyPath };
 }
 
-function stopProcessTree(child) {
-  if (!child || child.exitCode !== null) return;
-  try {
-    execFileSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
-      stdio: "ignore",
-    });
-  } catch {
-    /* already gone */
-  }
+function allowDelete(targetPath) {
+  if (!fs.existsSync(targetPath)) return;
+  execFileSync("icacls.exe", [targetPath, "/remove:d", "*S-1-1-0"], {
+    stdio: "ignore",
+  });
 }
 
 async function waitForCondition(check, timeoutMs, description) {
@@ -594,41 +557,26 @@ describe.skipIf(!!skipReason)(
         setupStub(dir, [0], [0]);
         setupPendingUpdate(dir);
 
-        const locker = startExclusiveLocker(path.join(dir, ".update-pending"));
-        await waitForCondition(
-          () => fs.existsSync(locker.readyPath),
-          30000,
-          "the pending marker to be exclusively locked",
-        );
-
-        const supervisor = runSupervisor(
-          dir,
-          {
-            PANEL_SUPERVISOR_BACKOFF_SECONDS: "0",
-            PANEL_SUPERVISOR_MAX_CRASHES: "1",
-          },
-          120000,
-        );
-        let failureObserved = false;
+        const markerPath = path.join(dir, ".update-pending");
+        denyDelete(markerPath);
+        let result;
         try {
-          await waitForCondition(
-            () =>
-              /could not move pending marker/i.test(readSupervisorLog(dir)),
-            30000,
-            "the supervisor to report the marker transition failure",
+          result = await runSupervisor(
+            dir,
+            {
+              PANEL_SUPERVISOR_BACKOFF_SECONDS: "0",
+              PANEL_SUPERVISOR_MAX_CRASHES: "1",
+            },
+            120000,
           );
-          failureObserved = true;
-        } catch {
-          /* asserted after the child has been cleaned up */
         } finally {
-          stopProcessTree(locker.child);
+          allowDelete(markerPath);
         }
-        const result = await supervisor;
 
-        expect(failureObserved).toBe(true);
         expect(result.status).toBe(0);
         expect(countLaunches(result.stdout)).toBeGreaterThanOrEqual(1);
         const log = readSupervisorLog(dir);
+        expect(log).toMatch(/could not move pending marker/i);
         expect(log).not.toMatch(/bundle activated; waiting/i);
         expect(fs.existsSync(path.join(dir, "ZomboidControlPanel.exe"))).toBe(true);
         expect(
@@ -639,9 +587,9 @@ describe.skipIf(!!skipReason)(
     );
 
     it(
-      "retains the journal and reports an incomplete rollback when a backup restore is locked",
+      "retains the journal and reports an incomplete rollback when a backup cannot be restored",
       async () => {
-        const dir = freshScenarioDir("locked-backup-restore");
+        const dir = freshScenarioDir("denied-backup-restore");
         await writeStartBatInto(dir);
         setupStub(dir, [7, 0], [5000, 0]);
         setupPendingUpdate(dir);
@@ -650,33 +598,31 @@ describe.skipIf(!!skipReason)(
           dir,
           "ZomboidControlPanel.exe.bundle-previous",
         );
-        const locker = startExclusiveLocker(backupPath);
         const supervisor = runSupervisor(
           dir,
           { PANEL_SUPERVISOR_BACKOFF_SECONDS: "0" },
           120000,
         );
-        let lockObserved = false;
+        let permissionApplied = false;
+        let setupError;
+        let result;
         try {
           await waitForCondition(
-            () => fs.existsSync(locker.readyPath),
+            () => fs.existsSync(backupPath),
             30000,
-            "the binary backup to be exclusively locked",
+            "the binary backup to be created",
           );
-          lockObserved = true;
-          await waitForCondition(
-            () => /rollback incomplete/i.test(readSupervisorLog(dir)),
-            30000,
-            "the supervisor to report an incomplete rollback",
-          );
-        } catch {
-          /* asserted after the child has been cleaned up */
+          denyDelete(backupPath);
+          permissionApplied = true;
+        } catch (error) {
+          setupError = error;
         } finally {
-          stopProcessTree(locker.child);
+          result = await supervisor;
+          allowDelete(backupPath);
         }
-        const result = await supervisor;
 
-        expect(lockObserved).toBe(true);
+        if (setupError) throw setupError;
+        expect(permissionApplied).toBe(true);
         expect(result.status).toBe(1);
         expect(fs.existsSync(path.join(dir, "update-bundle.json"))).toBe(true);
         expect(fs.existsSync(path.join(dir, ".update-applying"))).toBe(true);

--- a/server/tests/supervisor-restart.test.js
+++ b/server/tests/supervisor-restart.test.js
@@ -559,18 +559,25 @@ describe.skipIf(!!skipReason)(
 
         const markerPath = path.join(dir, ".update-pending");
         denyDelete(markerPath);
+        const supervisor = runSupervisor(
+          dir,
+          {
+            PANEL_SUPERVISOR_BACKOFF_SECONDS: "0",
+            PANEL_SUPERVISOR_MAX_CRASHES: "1",
+          },
+          120000,
+        );
         let result;
         try {
-          result = await runSupervisor(
-            dir,
-            {
-              PANEL_SUPERVISOR_BACKOFF_SECONDS: "0",
-              PANEL_SUPERVISOR_MAX_CRASHES: "1",
-            },
-            120000,
+          await waitForCondition(
+            () =>
+              /could not move pending marker/i.test(readSupervisorLog(dir)),
+            30000,
+            "the supervisor to report the marker transition failure",
           );
         } finally {
           allowDelete(markerPath);
+          result = await supervisor;
         }
 
         expect(result.status).toBe(0);

--- a/server/tests/supervisor-restart.test.js
+++ b/server/tests/supervisor-restart.test.js
@@ -68,45 +68,8 @@ class Stub {
 }
 `;
 
-const LOCKER_SOURCE = `
-using System;
-using System.IO;
-using System.Threading;
-
-class FileLocker {
-  static int Main(string[] args) {
-    string target = args[0];
-    string readyPath = args[1];
-    int waitMs = int.Parse(args[2]);
-    int holdMs = int.Parse(args[3]);
-    DateTime deadline = DateTime.UtcNow.AddMilliseconds(waitMs);
-
-    while (DateTime.UtcNow < deadline) {
-      try {
-        using (var stream = new FileStream(
-          target,
-          FileMode.Open,
-          FileAccess.ReadWrite,
-          FileShare.None
-        )) {
-          File.WriteAllText(readyPath, "locked");
-          Thread.Sleep(holdMs);
-          return 0;
-        }
-      } catch (IOException) {
-        Thread.Sleep(10);
-      } catch (UnauthorizedAccessException) {
-        Thread.Sleep(10);
-      }
-    }
-    return 2;
-  }
-}
-`;
-
 let sharedDir;
 let stubExePath;
-let lockerExePath;
 let generateStartBat;
 
 async function writeStartBatInto(dir) {
@@ -122,13 +85,9 @@ function setupStub(dir, exitCodes, sleepMsList) {
   );
 }
 
-function setupPendingUpdate(dir, { invalidStagedBinary = false } = {}) {
+function setupPendingUpdate(dir) {
   const stagedBinaryPath = path.join(dir, "ZomboidControlPanel.exe.new");
-  if (invalidStagedBinary) {
-    fs.writeFileSync(stagedBinaryPath, "not-a-windows-executable");
-  } else {
-    fs.copyFileSync(stubExePath, stagedBinaryPath);
-  }
+  fs.copyFileSync(stubExePath, stagedBinaryPath);
 
   const liveClientPath = path.join(dir, "client", "dist");
   const stagedClientPath = path.join(dir, "client", "dist.new-test");
@@ -147,11 +106,38 @@ function startExclusiveLocker(targetPath, holdMs = 120000) {
   const readyPath = `${targetPath}.lock-ready-${Date.now()}-${Math.random()
     .toString(16)
     .slice(2)}`;
-  const child = spawn(
-    lockerExePath,
-    [targetPath, readyPath, "30000", String(holdMs)],
-    { windowsHide: true, stdio: "ignore" },
-  );
+  const lockScript = `
+$deadline = (Get-Date).AddSeconds(30)
+while ((Get-Date) -lt $deadline) {
+  $stream = $null
+  try {
+    $stream = [System.IO.File]::Open(
+      $env:ZCP_LOCK_TARGET,
+      [System.IO.FileMode]::Open,
+      [System.IO.FileAccess]::ReadWrite,
+      [System.IO.FileShare]::None
+    )
+    [System.IO.File]::WriteAllText($env:ZCP_LOCK_READY, "locked")
+    Start-Sleep -Milliseconds ([int]$env:ZCP_LOCK_HOLD_MS)
+    exit 0
+  } catch {
+    Start-Sleep -Milliseconds 10
+  } finally {
+    if ($null -ne $stream) { $stream.Dispose() }
+  }
+}
+exit 2
+`;
+  const child = spawn("powershell.exe", ["-NoProfile", "-Command", lockScript], {
+    windowsHide: true,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      ZCP_LOCK_TARGET: targetPath,
+      ZCP_LOCK_READY: readyPath,
+      ZCP_LOCK_HOLD_MS: String(holdMs),
+    },
+  });
   return { child, readyPath };
 }
 
@@ -312,14 +298,6 @@ describe.skipIf(!!skipReason)(
         { stdio: "pipe" },
       );
 
-      const lockerSourcePath = path.join(sharedDir, "file-locker.cs");
-      lockerExePath = path.join(sharedDir, "FileLocker.exe");
-      fs.writeFileSync(lockerSourcePath, LOCKER_SOURCE);
-      execFileSync(
-        CSC_PATH,
-        ["-nologo", "-optimize", "-out:" + lockerExePath, lockerSourcePath],
-        { stdio: "pipe" },
-      );
     }, 90000);
 
     afterAll(() => {
@@ -614,7 +592,7 @@ describe.skipIf(!!skipReason)(
         const dir = freshScenarioDir("marker-move-failure");
         await writeStartBatInto(dir);
         setupStub(dir, [0], [0]);
-        setupPendingUpdate(dir, { invalidStagedBinary: true });
+        setupPendingUpdate(dir);
 
         const locker = startExclusiveLocker(path.join(dir, ".update-pending"));
         await waitForCondition(
@@ -665,7 +643,7 @@ describe.skipIf(!!skipReason)(
       async () => {
         const dir = freshScenarioDir("locked-backup-restore");
         await writeStartBatInto(dir);
-        setupStub(dir, [7], [5000]);
+        setupStub(dir, [7, 0], [5000, 0]);
         setupPendingUpdate(dir);
 
         const backupPath = path.join(

--- a/server/tests/supervisor-restart.test.js
+++ b/server/tests/supervisor-restart.test.js
@@ -68,8 +68,45 @@ class Stub {
 }
 `;
 
+const LOCKER_SOURCE = `
+using System;
+using System.IO;
+using System.Threading;
+
+class FileLocker {
+  static int Main(string[] args) {
+    string target = args[0];
+    string readyPath = args[1];
+    int waitMs = int.Parse(args[2]);
+    int holdMs = int.Parse(args[3]);
+    DateTime deadline = DateTime.UtcNow.AddMilliseconds(waitMs);
+
+    while (DateTime.UtcNow < deadline) {
+      try {
+        using (var stream = new FileStream(
+          target,
+          FileMode.Open,
+          FileAccess.ReadWrite,
+          FileShare.None
+        )) {
+          File.WriteAllText(readyPath, "locked");
+          Thread.Sleep(holdMs);
+          return 0;
+        }
+      } catch (IOException) {
+        Thread.Sleep(10);
+      } catch (UnauthorizedAccessException) {
+        Thread.Sleep(10);
+      }
+    }
+    return 2;
+  }
+}
+`;
+
 let sharedDir;
 let stubExePath;
+let lockerExePath;
 let generateStartBat;
 
 async function writeStartBatInto(dir) {
@@ -83,6 +120,59 @@ function setupStub(dir, exitCodes, sleepMsList) {
     path.join(dir, "sleep-ms.txt"),
     (sleepMsList || [0]).join("\n"),
   );
+}
+
+function setupPendingUpdate(dir, { invalidStagedBinary = false } = {}) {
+  const stagedBinaryPath = path.join(dir, "ZomboidControlPanel.exe.new");
+  if (invalidStagedBinary) {
+    fs.writeFileSync(stagedBinaryPath, "not-a-windows-executable");
+  } else {
+    fs.copyFileSync(stubExePath, stagedBinaryPath);
+  }
+
+  const liveClientPath = path.join(dir, "client", "dist");
+  const stagedClientPath = path.join(dir, "client", "dist.new-test");
+  fs.mkdirSync(liveClientPath, { recursive: true });
+  fs.mkdirSync(stagedClientPath, { recursive: true });
+  fs.writeFileSync(path.join(liveClientPath, "index.html"), "old-client");
+  fs.writeFileSync(path.join(stagedClientPath, "index.html"), "new-client");
+  fs.writeFileSync(
+    path.join(dir, "update-bundle.json"),
+    JSON.stringify({ paths: { stagedClient: stagedClientPath } }),
+  );
+  fs.writeFileSync(path.join(dir, ".update-pending"), "pending");
+}
+
+function startExclusiveLocker(targetPath, holdMs = 120000) {
+  const readyPath = `${targetPath}.lock-ready-${Date.now()}-${Math.random()
+    .toString(16)
+    .slice(2)}`;
+  const child = spawn(
+    lockerExePath,
+    [targetPath, readyPath, "30000", String(holdMs)],
+    { windowsHide: true, stdio: "ignore" },
+  );
+  return { child, readyPath };
+}
+
+function stopProcessTree(child) {
+  if (!child || child.exitCode !== null) return;
+  try {
+    execFileSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+    });
+  } catch {
+    /* already gone */
+  }
+}
+
+async function waitForCondition(check, timeoutMs, description) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for ${description}`);
 }
 
 // Async, not spawnSync -- spawnSync's own timeout only SIGTERMs the direct
@@ -219,6 +309,15 @@ describe.skipIf(!!skipReason)(
       execFileSync(
         CSC_PATH,
         ["-nologo", "-optimize", "-out:" + stubExePath, srcPath],
+        { stdio: "pipe" },
+      );
+
+      const lockerSourcePath = path.join(sharedDir, "file-locker.cs");
+      lockerExePath = path.join(sharedDir, "FileLocker.exe");
+      fs.writeFileSync(lockerSourcePath, LOCKER_SOURCE);
+      execFileSync(
+        CSC_PATH,
+        ["-nologo", "-optimize", "-out:" + lockerExePath, lockerSourcePath],
         { stdio: "pipe" },
       );
     }, 90000);
@@ -507,6 +606,109 @@ describe.skipIf(!!skipReason)(
         expect(log).not.toMatch(/Gave up/);
       },
       110000,
+    );
+
+    it(
+      "rolls back instead of launching when the pending marker cannot become the applying marker",
+      async () => {
+        const dir = freshScenarioDir("marker-move-failure");
+        await writeStartBatInto(dir);
+        setupStub(dir, [0], [0]);
+        setupPendingUpdate(dir, { invalidStagedBinary: true });
+
+        const locker = startExclusiveLocker(path.join(dir, ".update-pending"));
+        await waitForCondition(
+          () => fs.existsSync(locker.readyPath),
+          30000,
+          "the pending marker to be exclusively locked",
+        );
+
+        const supervisor = runSupervisor(
+          dir,
+          {
+            PANEL_SUPERVISOR_BACKOFF_SECONDS: "0",
+            PANEL_SUPERVISOR_MAX_CRASHES: "1",
+          },
+          120000,
+        );
+        let failureObserved = false;
+        try {
+          await waitForCondition(
+            () =>
+              /could not move pending marker/i.test(readSupervisorLog(dir)),
+            30000,
+            "the supervisor to report the marker transition failure",
+          );
+          failureObserved = true;
+        } catch {
+          /* asserted after the child has been cleaned up */
+        } finally {
+          stopProcessTree(locker.child);
+        }
+        const result = await supervisor;
+
+        expect(failureObserved).toBe(true);
+        expect(result.status).toBe(0);
+        expect(countLaunches(result.stdout)).toBeGreaterThanOrEqual(1);
+        const log = readSupervisorLog(dir);
+        expect(log).not.toMatch(/bundle activated; waiting/i);
+        expect(fs.existsSync(path.join(dir, "ZomboidControlPanel.exe"))).toBe(true);
+        expect(
+          fs.readFileSync(path.join(dir, "client", "dist", "index.html"), "utf8"),
+        ).toBe("old-client");
+      },
+      135000,
+    );
+
+    it(
+      "retains the journal and reports an incomplete rollback when a backup restore is locked",
+      async () => {
+        const dir = freshScenarioDir("locked-backup-restore");
+        await writeStartBatInto(dir);
+        setupStub(dir, [7], [5000]);
+        setupPendingUpdate(dir);
+
+        const backupPath = path.join(
+          dir,
+          "ZomboidControlPanel.exe.bundle-previous",
+        );
+        const locker = startExclusiveLocker(backupPath);
+        const supervisor = runSupervisor(
+          dir,
+          { PANEL_SUPERVISOR_BACKOFF_SECONDS: "0" },
+          120000,
+        );
+        let lockObserved = false;
+        try {
+          await waitForCondition(
+            () => fs.existsSync(locker.readyPath),
+            30000,
+            "the binary backup to be exclusively locked",
+          );
+          lockObserved = true;
+          await waitForCondition(
+            () => /rollback incomplete/i.test(readSupervisorLog(dir)),
+            30000,
+            "the supervisor to report an incomplete rollback",
+          );
+        } catch {
+          /* asserted after the child has been cleaned up */
+        } finally {
+          stopProcessTree(locker.child);
+        }
+        const result = await supervisor;
+
+        expect(lockObserved).toBe(true);
+        expect(result.status).toBe(1);
+        expect(fs.existsSync(path.join(dir, "update-bundle.json"))).toBe(true);
+        expect(fs.existsSync(path.join(dir, ".update-applying"))).toBe(true);
+        expect(fs.existsSync(backupPath)).toBe(true);
+        const log = readSupervisorLog(dir);
+        expect(log).toMatch(/binary restore failed/i);
+        expect(log).toMatch(/rollback incomplete; journal retained/i);
+        expect(log).not.toMatch(/rollback complete/i);
+      },
+      135000,
     );
 
     it(


### PR DESCRIPTION
## Summary

Activates the packaged panel backend and frontend as one recoverable, versioned update bundle. The Docker image updater remains unchanged.

Relates to #120.

## Root Cause

The packaged updater replaced `client/dist` during download and activated the backend executable separately. A restart, antivirus quarantine, failed swap, or mismatched artifact could therefore leave the browser and API running different releases without a shared compatibility check or a transaction that could restore both sides.

## Changes

- Stage the executable, `client/dist.new-<version>`, and an atomic `update-bundle.json` journal without touching live artifacts during download.
- Embed matching `panelVersion`, `buildSha`, and `apiContractVersion: 1` metadata in the backend, health response, release manifest, and frontend build.
- Gate authentication and socket initialization on frontend/backend compatibility.
- Apply both artifacts as one journaled transaction and retain both backups until the new backend acknowledges metadata validation and a successful HTTP startup.
- Roll back both artifacts after staging validation failures, antivirus quarantine, frontend or binary swap failures, interrupted startup, or metadata mismatch.
- Preserve configuration and database directories outside the artifact transaction.
- Add a Windows packaged-updater CI job that builds the executable, generates the supervisor, exercises transaction tests, and verifies matching artifact metadata.

## Regression Proof

The new regression suite first failed because no bundle transaction existed. It now covers download-time isolation, successful activation and acknowledgement, missing/quarantined binaries, both swap failures, interrupted startup recovery, both frontend/backend mismatch directions, acknowledgement mismatch rollback, backup retention, and configuration/database preservation.

## Test Results

- `npm run lint:server`
- `npm run test:server`
- `cd client && npm run lint`
- `cd client && npx vitest run` (110 files, 2,447 tests)
- `cd client && npm run build`
- `node build.js --linux` (packed executable, generated supervisor, and matching release metadata)
- `git diff --check`
- Windows packaged executable and generated-supervisor validation is enforced by the new `windows-packaged-updater` CI job.

## Risks

- Packaged Windows updates now require the generated supervisor that understands bundle journals; older supervisors receive an explicit refusal instead of using the unsafe single-binary fallback.
- An update remains pending if the new backend cannot acknowledge startup, so the supervisor can restore both backups on the next recovery path.
- The health payload is extended additively; existing fields remain unchanged.

## Rollback

Revert this commit to restore the previous packaged updater. For an in-progress update, the journal and retained `.previous` artifacts allow the generated supervisor to restore both the executable and `client/dist` before cleanup.
