### PR TITLE
fix(api): prevent automatic retries of unsafe mutations

### DIFF
--- a/client/src/lib/__tests__/apiMethodRetrySafety.test.ts
+++ b/client/src/lib/__tests__/apiMethodRetrySafety.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { apiFetch } from "../api";
+import { clearAccessToken, setAccessToken } from "../authToken";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("API retry method safety", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    clearAccessToken();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    clearAccessToken();
+  });
+
+  it.each(["GET", "HEAD", "OPTIONS"])(
+    "retries transient %s requests",
+    async (method) => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse(503, { error: "temporary" }))
+        .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const request = apiFetch("/safe", { method });
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(request).resolves.toMatchObject({ status: 200 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each(["POST", "PUT", "PATCH", "DELETE"])(
+    "sends a %s mutation only once after a server failure",
+    async (method) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse(503, { error: "result is unknown" }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const request = apiFetch("/mutation", { method });
+      await vi.advanceTimersByTimeAsync(20_000);
+      const response = await request;
+
+      expect(response.status).toBe(503);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("does not retry a mutation after a network failure", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = apiFetch("/mutation", { method: "POST" });
+    const rejection = expect(request).rejects.toMatchObject({
+      code: "NETWORK_ERROR",
+    });
+    await vi.advanceTimersByTimeAsync(20_000);
+    await rejection;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a rate-limited safe request but not a rate-limited mutation", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(429, { error: "slow down" }))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }))
+      .mockResolvedValueOnce(jsonResponse(429, { error: "slow down" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const safeRequest = apiFetch("/safe");
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect((await safeRequest).status).toBe(200);
+
+    const mutation = apiFetch("/mutation", { method: "POST" });
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect((await mutation).status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("replays a mutation once when the server explicitly reports TOKEN_EXPIRED", async () => {
+    setAccessToken("expired-token");
+    let targetCalls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/auth/refresh")) {
+        return jsonResponse(200, { accessToken: "fresh-token" });
+      }
+      targetCalls += 1;
+      return targetCalls === 1
+        ? jsonResponse(401, { code: "TOKEN_EXPIRED", error: "expired" })
+        : jsonResponse(200, { ok: true });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await apiFetch("/mutation", { method: "POST" });
+
+    expect(response.status).toBe(200);
+    expect(targetCalls).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not refresh or replay an unrelated 401", async () => {
+    setAccessToken("valid-token");
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(401, { code: "ACCOUNT_DISABLED", error: "disabled" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await apiFetch("/protected");
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a transient failure after the single authentication replay", async () => {
+    setAccessToken("expired-token");
+    let targetCalls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/auth/refresh")) {
+        return jsonResponse(200, { accessToken: "fresh-token" });
+      }
+      targetCalls += 1;
+      return targetCalls === 1
+        ? jsonResponse(401, { code: "TOKEN_EXPIRED", error: "expired" })
+        : jsonResponse(503, { error: "result is unknown" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = apiFetch("/safe");
+    await vi.advanceTimersByTimeAsync(5_000);
+    const response = await request;
+
+    expect(response.status).toBe(503);
+    expect(targetCalls).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/client/src/lib/__tests__/apiRetry401Then5xx.test.ts
+++ b/client/src/lib/__tests__/apiRetry401Then5xx.test.ts
@@ -2,16 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { apiFetch } from '../api'
 import { clearAccessToken, setAccessToken } from '../authToken'
 
-// fetchWithRetry's 401-refresh-then-retry and its own exponential-backoff
-// retry are two separate mechanisms. Before this fix, a response that
-// refreshed the token and retried, then got a TRANSIENT failure (5xx/429)
-// on that retried request, was returned unconditionally -- skipping the
-// backoff-retry loop entirely, unlike every other response in this
-// function. So the unluckiest requests (an expired token AND a transient
-// blip on the very next call) got the LEAST resilience, not the same as
-// everything else. A bare 5xx (no 401 involved) already worked before this
-// fix and would pass either way, so it proves nothing on its own -- these
-// tests specifically exercise the 401-then-5xx sequence.
+// Authentication replay and transport retries are deliberately separate.
+// TOKEN_EXPIRED permits one replay after refresh, but the replay is never
+// followed by another automatic send because the request may be a mutation.
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -20,7 +13,7 @@ function jsonResponse(status: number, body: unknown): Response {
   })
 }
 
-describe('fetchWithRetry: 401-refresh-then-retry does not skip the backoff retry', () => {
+describe('fetchWithRetry: TOKEN_EXPIRED allows exactly one authentication replay', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     setAccessToken('expired-token')
@@ -32,7 +25,7 @@ describe('fetchWithRetry: 401-refresh-then-retry does not skip the backoff retry
     clearAccessToken()
   })
 
-  it('retries a transient 5xx that arrives on the post-refresh retry, instead of returning it immediately', async () => {
+  it('returns a transient 5xx from the post-refresh replay without sending again', async () => {
     let targetCallCount = 0
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString()
@@ -40,7 +33,7 @@ describe('fetchWithRetry: 401-refresh-then-retry does not skip the backoff retry
         return jsonResponse(200, { accessToken: 'fresh-token' })
       }
       targetCallCount++
-      if (targetCallCount === 1) return jsonResponse(401, { error: 'expired' })
+      if (targetCallCount === 1) return jsonResponse(401, { code: 'TOKEN_EXPIRED', error: 'expired' })
       if (targetCallCount === 2) return jsonResponse(503, { error: 'temporarily unavailable' })
       return jsonResponse(200, { ok: true })
     })
@@ -52,11 +45,8 @@ describe('fetchWithRetry: 401-refresh-then-retry does not skip the backoff retry
     await vi.advanceTimersByTimeAsync(3000)
     const response = await promise
 
-    expect(response.status).toBe(200)
-    // 401, then the 503 from the post-refresh retry, then the backoff
-    // retry that finally reaches 200 -- three calls to the target
-    // endpoint, not two. Two would mean the 503 was returned unfixed.
-    expect(targetCallCount).toBe(3)
+    expect(response.status).toBe(503)
+    expect(targetCallCount).toBe(2)
   })
 
   it('still returns a non-retryable status from the post-refresh retry immediately (unchanged behavior)', async () => {
@@ -67,7 +57,7 @@ describe('fetchWithRetry: 401-refresh-then-retry does not skip the backoff retry
         return jsonResponse(200, { accessToken: 'fresh-token' })
       }
       targetCallCount++
-      if (targetCallCount === 1) return jsonResponse(401, { error: 'expired' })
+      if (targetCallCount === 1) return jsonResponse(401, { code: 'TOKEN_EXPIRED', error: 'expired' })
       return jsonResponse(403, { error: 'forbidden' })
     })
     vi.stubGlobal('fetch', fetchMock)
@@ -102,7 +92,7 @@ describe('fetchWithRetry: 401-refresh-then-retry does not skip the backoff retry
         return jsonResponse(200, { accessToken: 'fresh-token' })
       }
       targetCallCount++
-      return jsonResponse(401, { error: 'expired' })
+      return jsonResponse(401, { code: 'TOKEN_EXPIRED', error: 'expired' })
     })
     vi.stubGlobal('fetch', fetchMock)
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -98,6 +98,12 @@ const RETRY_CONFIG = {
   fetchTimeout: 15000, // 15 second timeout for fetch requests
 };
 
+const RETRY_SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+function requestMethod(options?: RequestInit): string {
+  return String(options?.method || "GET").toUpperCase();
+}
+
 // Exponential backoff with jitter
 function getRetryDelay(attempt: number): number {
   const delay = Math.min(
@@ -255,6 +261,24 @@ function buildResponseError(response: Response, payload?: unknown): ApiError {
   });
 }
 
+async function responseHasCode(
+  response: Response,
+  expectedCode: string,
+): Promise<boolean> {
+  if (response.status !== 401) return false;
+  try {
+    const payload = await response.clone().json();
+    return (
+      payload !== null &&
+      typeof payload === "object" &&
+      "code" in payload &&
+      payload.code === expectedCode
+    );
+  } catch {
+    return false;
+  }
+}
+
 async function fetchWithRetry(
   url: string,
   options?: RequestInit & { timeout?: number },
@@ -262,8 +286,11 @@ async function fetchWithRetry(
 ): Promise<Response> {
   let lastError: unknown;
   const effectiveTimeout = options?.timeout || RETRY_CONFIG.fetchTimeout;
+  const method = requestMethod(options);
+  const transportRetries = RETRY_SAFE_METHODS.has(method) ? retries : 0;
+  let authenticationReplayUsed = false;
 
-  for (let attempt = 0; attempt <= retries; attempt++) {
+  for (let attempt = 0; attempt <= transportRetries; attempt++) {
     try {
       // Create AbortController for timeout
       const controller = new AbortController();
@@ -284,18 +311,23 @@ async function fetchWithRetry(
       }
 
       try {
-        let response = await fetch(url, {
+        const response = await fetch(url, {
           ...withAuth(options),
           signal: controller.signal,
         });
         clearTimeout(timeoutId);
 
-        // Handle 401 — try token refresh once, then retry
+        // Authentication replay is separate from transport retries. It is
+        // allowed once, and only when the server explicitly says the access
+        // token expired. This remains safe for mutations because the server
+        // rejected the original request before performing it.
         if (
           response.status === 401 &&
-          attempt === 0 &&
-          !url.includes("/api/auth/")
+          !authenticationReplayUsed &&
+          !url.includes("/api/auth/") &&
+          (await responseHasCode(response, "TOKEN_EXPIRED"))
         ) {
+          authenticationReplayUsed = true;
           const refreshed = await tryRefreshToken();
           if (refreshed) {
             const retryController = new AbortController();
@@ -309,20 +341,13 @@ async function fetchWithRetry(
               signal: retryController.signal,
             }).finally(() => clearTimeout(retryTimeoutId));
             if (retryResponse.status === 401) {
-              // Refreshed token still 401s — nothing left to retry, force
-              // reload to show login.
+              clearAccessToken();
               window.location.reload();
-              return response;
             }
-            // The refresh-retry consumed this attempt's fetch, but a
-            // transient failure (5xx/429) on the RETRIED request still
-            // deserves the same backoff-retry resilience as every other
-            // response. Replace `response` and fall through to the shared
-            // retryable check below instead of returning unconditionally --
-            // returning here unconditionally used to skip fetchWithRetry's
-            // own retry loop entirely for exactly the unluckiest requests:
-            // an expired token AND a transient blip on the very next call.
-            response = retryResponse;
+            // The authentication replay is the final send for this logical
+            // request. A failure here must be surfaced rather than retried,
+            // especially when the request is a mutation.
+            return retryResponse;
           } else {
             // Refresh failed — force reload to show login.
             window.location.reload();
@@ -331,7 +356,10 @@ async function fetchWithRetry(
         }
 
         // If response is not retryable error, return it
-        if (!isRetryableError(null, response) || attempt === retries) {
+        if (
+          !isRetryableError(null, response) ||
+          attempt === transportRetries
+        ) {
           return response;
         }
       } catch (error) {
@@ -347,12 +375,15 @@ async function fetchWithRetry(
       lastError = toApiError(error);
 
       // Don't retry if it's the last attempt or non-retryable
-      if (attempt === retries || !isRetryableError(lastError)) {
+      if (
+        attempt === transportRetries ||
+        !isRetryableError(lastError)
+      ) {
         throw lastError;
       }
 
       reportClientWarning(
-        `Request failed, retrying (${attempt + 1}/${retries})...`,
+        `Request failed, retrying (${attempt + 1}/${transportRetries})...`,
         lastError,
       );
       await new Promise((resolve) =>


### PR DESCRIPTION
## Summary

Restricts automatic transport retries to read-only HTTP methods so an uncertain mutation result is never submitted again without user intent.

## Root Cause

The shared client request helper applied the same 5xx, 429, timeout, and network-error retry loop to every HTTP method. A successful mutation whose response was lost could therefore be repeated, creating duplicate users, jobs, configuration changes, or destructive actions. The same helper also refreshed and replayed every 401, even when the response did not indicate an expired access token.

## Changes

- Retry transport failures only for `GET`, `HEAD`, and `OPTIONS`.
- Send `POST`, `PUT`, `PATCH`, and `DELETE` only once for network failures, timeouts, 408, 429, and 5xx responses.
- Permit one authentication replay only when a non-auth endpoint returns a structured `TOKEN_EXPIRED` 401.
- Treat that authentication replay as the final send, including when it returns a transient failure.
- Preserve the existing concurrent refresh deduplication and token clearing behavior.
- Do not introduce idempotency keys because the backend has no result cache.

## Regression Proof

The new regression suite failed before the implementation because mutations were sent up to four times and unrelated 401 responses triggered refresh requests. It now proves safe-method retries, single-send mutations for every unsafe method, network and rate-limit handling, the explicit token-expiry replay, unrelated 401 behavior, and no retry after the authentication replay.

## Test Results

- `npm run lint:server`
- `npm run test:server`
- `cd client && npm run lint` (66 existing warnings, no errors)
- `cd client && npx tsc -b`
- `cd client && npx vitest run` (110 files, 2,456 tests)
- `cd client && npm run build`
- `git diff --check`

## Risks

- A transient failure on a mutation is now surfaced immediately, so users may need to inspect current state before deciding whether to retry manually.
- Servers that return a bare or differently coded 401 no longer trigger token refresh; the authentication contract must use `TOKEN_EXPIRED` for an expired access token.

## Rollback

Revert this commit to restore method-agnostic retries and broad 401 refresh behavior. No server data migration or configuration change is involved.
