### PR TITLE
fix(mods): select the newest non-expired Steam cookies

### DIFF
--- a/server/tests/browserCookieFreshness.test.js
+++ b/server/tests/browserCookieFreshness.test.js
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeChromiumCookieRow,
+  normalizeFirefoxCookieRow,
+  pickSteamCookies,
+} from "../utils/browserCookies.js";
+
+const CHROMIUM_EPOCH_OFFSET_US = 11644473600000000n;
+
+function chromiumTimestamp(unixMs) {
+  return (BigInt(unixMs) * 1000n + CHROMIUM_EPOCH_OFFSET_US).toString();
+}
+
+function cookie(overrides) {
+  return {
+    name: "sessionid",
+    value: "cookie-value",
+    host: ".steamcommunity.com",
+    profileId: "Default",
+    expiresAt: null,
+    createdAt: 100,
+    lastAccessedAt: 100,
+    ...overrides,
+  };
+}
+
+describe("browser cookie timestamp normalization", () => {
+  it("converts Chromium's 1601-based microsecond timestamps", () => {
+    const row = normalizeChromiumCookieRow(
+      {
+        host_key: ".steamcommunity.com",
+        name: "sessionid",
+        value: "value",
+        expires_utc: chromiumTimestamp(Date.UTC(2030, 0, 2, 3, 4, 5)),
+        creation_utc: chromiumTimestamp(Date.UTC(2026, 1, 3, 4, 5, 6)),
+        last_access_utc: chromiumTimestamp(Date.UTC(2026, 2, 4, 5, 6, 7)),
+        is_persistent: 1,
+      },
+      "Chrome/Default",
+    );
+
+    expect(new Date(row.expiresAt).toISOString()).toBe("2030-01-02T03:04:05.000Z");
+    expect(new Date(row.createdAt).toISOString()).toBe("2026-02-03T04:05:06.000Z");
+    expect(new Date(row.lastAccessedAt).toISOString()).toBe("2026-03-04T05:06:07.000Z");
+    expect(row.profileId).toBe("Chrome/Default");
+  });
+
+  it("converts Firefox expiry seconds and creation/access microseconds", () => {
+    const row = normalizeFirefoxCookieRow(
+      {
+        host: ".steamcommunity.com",
+        name: "steamLoginSecure",
+        value: "value",
+        expiry: Math.floor(Date.UTC(2031, 4, 6, 7, 8, 9) / 1000),
+        creationTime: String(Date.UTC(2026, 5, 7, 8, 9, 10) * 1000),
+        lastAccessed: String(Date.UTC(2026, 6, 8, 9, 10, 11) * 1000),
+      },
+      "Firefox/default-release",
+    );
+
+    expect(new Date(row.expiresAt).toISOString()).toBe("2031-05-06T07:08:09.000Z");
+    expect(new Date(row.createdAt).toISOString()).toBe("2026-06-07T08:09:10.000Z");
+    expect(new Date(row.lastAccessedAt).toISOString()).toBe("2026-07-08T09:10:11.000Z");
+  });
+});
+
+describe("Steam cookie freshness and pairing", () => {
+  const now = 1_000_000;
+
+  it("excludes expired persistent duplicates", () => {
+    const result = pickSteamCookies(
+      "chrome",
+      [
+        cookie({ value: "expired-session", expiresAt: now - 1, lastAccessedAt: 900 }),
+        cookie({ value: "valid-session", expiresAt: now + 10_000, lastAccessedAt: 800 }),
+        cookie({ name: "steamLoginSecure", value: "valid-login", expiresAt: now + 10_000 }),
+      ],
+      [],
+      now,
+    );
+
+    expect(result.sessionid).toBe("valid-session");
+    expect(result.steamLoginSecure).toBe("valid-login");
+  });
+
+  it("retains valid session cookies with no persistent expiry", () => {
+    const result = pickSteamCookies(
+      "firefox",
+      [
+        cookie({ value: "session-cookie", expiresAt: null }),
+        cookie({ name: "steamLoginSecure", value: "login-cookie", expiresAt: null }),
+      ],
+      [],
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("prefers Steam Community over a newer Steam Store pair", () => {
+    const result = pickSteamCookies(
+      "chrome",
+      [
+        cookie({ value: "community-session", lastAccessedAt: 100 }),
+        cookie({ name: "steamLoginSecure", value: "community-login", lastAccessedAt: 100 }),
+        cookie({ host: ".steampowered.com", value: "store-session", lastAccessedAt: 900 }),
+        cookie({ host: ".steampowered.com", name: "steamLoginSecure", value: "store-login", lastAccessedAt: 900 }),
+      ],
+      [],
+      now,
+    );
+
+    expect(result.sessionid).toBe("community-session");
+    expect(result.steamLoginSecure).toBe("community-login");
+  });
+
+  it("uses timestamps rather than cookie length within a domain context", () => {
+    const result = pickSteamCookies(
+      "chrome",
+      [
+        cookie({ value: "very-long-but-stale-session-value", lastAccessedAt: 100 }),
+        cookie({ value: "new", lastAccessedAt: 900 }),
+        cookie({ name: "steamLoginSecure", value: "login", lastAccessedAt: 900 }),
+      ],
+      [],
+      now,
+    );
+
+    expect(result.sessionid).toBe("new");
+  });
+
+  it("prefers a same-domain pair over a cross-domain Community fallback", () => {
+    const result = pickSteamCookies(
+      "chrome",
+      [
+        cookie({ value: "community-session", lastAccessedAt: 900 }),
+        cookie({ host: ".steampowered.com", value: "store-session", lastAccessedAt: 500 }),
+        cookie({ host: ".steampowered.com", name: "steamLoginSecure", value: "store-login", lastAccessedAt: 500 }),
+      ],
+      [],
+      now,
+    );
+
+    expect(result.sessionid).toBe("store-session");
+    expect(result.steamLoginSecure).toBe("store-login");
+    expect(result.notes.join(" ")).not.toMatch(/cross-domain/i);
+  });
+
+  it("prefers cookies from the same browser profile", () => {
+    const result = pickSteamCookies(
+      "chrome",
+      [
+        cookie({ profileId: "Profile 1", value: "profile-one-session", lastAccessedAt: 700 }),
+        cookie({ profileId: "Profile 2", value: "profile-two-session", lastAccessedAt: 900 }),
+        cookie({ profileId: "Profile 1", name: "steamLoginSecure", value: "profile-one-login", lastAccessedAt: 700 }),
+      ],
+      [],
+      now,
+    );
+
+    expect(result.sessionid).toBe("profile-one-session");
+    expect(result.steamLoginSecure).toBe("profile-one-login");
+  });
+
+  it("warns about conflicting values without exposing them", () => {
+    const result = pickSteamCookies(
+      "firefox",
+      [
+        cookie({ value: "secret-old", lastAccessedAt: 100 }),
+        cookie({ value: "secret-new", lastAccessedAt: 900 }),
+        cookie({ name: "steamLoginSecure", value: "login-secret", lastAccessedAt: 900 }),
+      ],
+      [],
+      now,
+    );
+    const warning = result.notes.join(" ");
+
+    expect(warning).toMatch(/conflicting valid sessionid cookies/i);
+    expect(warning).not.toContain("secret-old");
+    expect(warning).not.toContain("secret-new");
+  });
+
+  it("warns when only a cross-domain fallback pair is available", () => {
+    const result = pickSteamCookies(
+      "firefox",
+      [
+        cookie({ value: "community-session" }),
+        cookie({ host: ".steampowered.com", name: "steamLoginSecure", value: "store-login" }),
+      ],
+      [],
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.notes.join(" ")).toMatch(/cross-domain/i);
+  });
+});

--- a/server/utils/browserCookies.js
+++ b/server/utils/browserCookies.js
@@ -41,6 +41,75 @@ const STEAM_HOST_PRIORITY = (host) => {
   if (host === 'store.steampowered.com' || host === '.steampowered.com') return 1;
   return 2;
 };
+const CHROMIUM_EPOCH_OFFSET_US = 11644473600000000n;
+
+function integerTimestamp(value) {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return BigInt(Math.trunc(value));
+  }
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) {
+    return BigInt(value.trim());
+  }
+  return null;
+}
+
+function microsecondsToUnixMs(value, epochOffsetUs = 0n) {
+  const timestamp = integerTimestamp(value);
+  if (timestamp === null || timestamp <= epochOffsetUs) return null;
+  const milliseconds = Number((timestamp - epochOffsetUs) / 1000n);
+  return Number.isSafeInteger(milliseconds) && milliseconds > 0
+    ? milliseconds
+    : null;
+}
+
+function secondsToUnixMs(value) {
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  const milliseconds = Math.trunc(seconds * 1000);
+  return Number.isSafeInteger(milliseconds) ? milliseconds : null;
+}
+
+export function normalizeChromiumCookieRow(row, profileId) {
+  const persistent = Number(row.is_persistent) === 1;
+  return {
+    ...row,
+    host: row.host_key,
+    value: row.value ? String(row.value) : '',
+    profileId,
+    expiresAt: persistent
+      ? microsecondsToUnixMs(row.expires_utc, CHROMIUM_EPOCH_OFFSET_US)
+      : null,
+    createdAt: microsecondsToUnixMs(row.creation_utc, CHROMIUM_EPOCH_OFFSET_US),
+    lastAccessedAt: microsecondsToUnixMs(row.last_access_utc, CHROMIUM_EPOCH_OFFSET_US),
+    isSession: !persistent,
+  };
+}
+
+export function normalizeFirefoxCookieRow(row, profileId) {
+  const expiresAt = secondsToUnixMs(row.expiry);
+  return {
+    ...row,
+    host: row.host,
+    value: row.value ? String(row.value) : '',
+    profileId,
+    expiresAt,
+    createdAt: microsecondsToUnixMs(row.creationTime),
+    lastAccessedAt: microsecondsToUnixMs(row.lastAccessed),
+    isSession: expiresAt === null,
+  };
+}
+
+function steamDomainFamily(host) {
+  const normalized = String(host || '').replace(/^\./, '').toLowerCase();
+  if (normalized === 'steamcommunity.com') return 'community';
+  if (normalized === 'steampowered.com' || normalized === 'store.steampowered.com') return 'store';
+  return normalized || 'unknown';
+}
+
+function cookieFreshness(cookie) {
+  return Number(cookie.lastAccessedAt || cookie.createdAt || 0);
+}
 
 let sqlPromise = null;
 // In-memory cache: master key per browser id. The key never changes for a
@@ -83,8 +152,8 @@ function defaultProfileRoots() {
   return { home, localAppData, roamingAppData };
 }
 
-function chromiumProfileDir(userDataDir) {
-  if (!fs.existsSync(userDataDir)) return null;
+function chromiumProfileDirs(userDataDir) {
+  if (!fs.existsSync(userDataDir)) return [];
   const candidates = ['Default'];
   try {
     const entries = fs.readdirSync(userDataDir);
@@ -93,24 +162,29 @@ function chromiumProfileDir(userDataDir) {
       .sort((a, b) => parseInt(b.match(/\d+/)[0], 10) - parseInt(a.match(/\d+/)[0], 10));
     candidates.push(...numbered);
   } catch { /* ignore */ }
+  const profiles = [];
   for (const c of candidates) {
     const dir = path.join(userDataDir, c);
     const networkPath = path.join(dir, 'Network', 'Cookies');
     const legacyPath = path.join(dir, 'Cookies');
-    if (fs.existsSync(networkPath)) return { profileDir: dir, cookiesPath: networkPath };
-    if (fs.existsSync(legacyPath)) return { profileDir: dir, cookiesPath: legacyPath };
+    if (fs.existsSync(networkPath)) profiles.push({ profileDir: dir, cookiesPath: networkPath });
+    else if (fs.existsSync(legacyPath)) profiles.push({ profileDir: dir, cookiesPath: legacyPath });
   }
-  return null;
+  return profiles;
 }
 
-function firefoxProfilePath() {
+function chromiumProfileDir(userDataDir) {
+  return chromiumProfileDirs(userDataDir)[0] || null;
+}
+
+function firefoxProfilePaths() {
   const { roamingAppData } = defaultProfileRoots();
   const profilesIni = path.join(roamingAppData, 'Mozilla', 'Firefox', 'profiles.ini');
-  if (!fs.existsSync(profilesIni)) return null;
+  if (!fs.existsSync(profilesIni)) return [];
   let ini;
-  try { ini = fs.readFileSync(profilesIni, 'utf-8'); } catch { return null; }
+  try { ini = fs.readFileSync(profilesIni, 'utf-8'); } catch { return []; }
   const blocks = ini.split(/\r?\n\s*\r?\n/);
-  let chosen = null;
+  const profiles = [];
   for (const block of blocks) {
     if (!/^\[Profile/.test(block.trim())) continue;
     const pathMatch = block.match(/^Path=(.+)$/m);
@@ -120,14 +194,21 @@ function firefoxProfilePath() {
     const full = isRel
       ? path.join(roamingAppData, 'Mozilla', 'Firefox', rel)
       : rel;
-    if (/^Default=1/m.test(block)) { chosen = full; break; }
-    if (!chosen && /\.default-release$/.test(rel)) chosen = full;
-    if (!chosen) chosen = full;
+    const cookiesPath = path.join(full, 'cookies.sqlite');
+    if (!fs.existsSync(cookiesPath)) continue;
+    profiles.push({
+      profileDir: full,
+      cookiesPath,
+      priority: /^Default=1/m.test(block) ? 0 : /\.default-release$/.test(rel) ? 1 : 2,
+    });
   }
-  if (!chosen) return null;
-  const cookiesPath = path.join(chosen, 'cookies.sqlite');
-  if (!fs.existsSync(cookiesPath)) return null;
-  return { profileDir: chosen, cookiesPath };
+  return profiles
+    .sort((a, b) => a.priority - b.priority)
+    .map(({ profileDir, cookiesPath }) => ({ profileDir, cookiesPath }));
+}
+
+function firefoxProfilePath() {
+  return firefoxProfilePaths()[0] || null;
 }
 
 const BROWSER_DEFS = [
@@ -136,6 +217,7 @@ const BROWSER_DEFS = [
     label: 'Firefox',
     family: 'firefox',
     find() { return firefoxProfilePath(); },
+    findAll() { return firefoxProfilePaths(); },
   },
   {
     id: 'chrome',
@@ -144,6 +226,10 @@ const BROWSER_DEFS = [
     find() {
       const { localAppData } = defaultProfileRoots();
       return chromiumProfileDir(path.join(localAppData, 'Google', 'Chrome', 'User Data'));
+    },
+    findAll() {
+      const { localAppData } = defaultProfileRoots();
+      return chromiumProfileDirs(path.join(localAppData, 'Google', 'Chrome', 'User Data'));
     },
     localStatePath() {
       const { localAppData } = defaultProfileRoots();
@@ -158,6 +244,10 @@ const BROWSER_DEFS = [
       const { localAppData } = defaultProfileRoots();
       return chromiumProfileDir(path.join(localAppData, 'Microsoft', 'Edge', 'User Data'));
     },
+    findAll() {
+      const { localAppData } = defaultProfileRoots();
+      return chromiumProfileDirs(path.join(localAppData, 'Microsoft', 'Edge', 'User Data'));
+    },
     localStatePath() {
       const { localAppData } = defaultProfileRoots();
       return path.join(localAppData, 'Microsoft', 'Edge', 'User Data', 'Local State');
@@ -170,6 +260,10 @@ const BROWSER_DEFS = [
     find() {
       const { localAppData } = defaultProfileRoots();
       return chromiumProfileDir(path.join(localAppData, 'BraveSoftware', 'Brave-Browser', 'User Data'));
+    },
+    findAll() {
+      const { localAppData } = defaultProfileRoots();
+      return chromiumProfileDirs(path.join(localAppData, 'BraveSoftware', 'Brave-Browser', 'User Data'));
     },
     localStatePath() {
       const { localAppData } = defaultProfileRoots();
@@ -285,7 +379,7 @@ async function readChromiumCookies(cookiesPath) {
     const buf = fs.readFileSync(tmpPath);
     const db = new SQL.Database(new Uint8Array(buf));
     const hostList = STEAM_HOSTS.map((h) => `'${h.replace(/'/g, "''")}'`).join(',');
-    const res = db.exec(`SELECT host_key, name, value, encrypted_value FROM cookies WHERE host_key IN (${hostList})`);
+    const res = db.exec(`SELECT host_key, name, value, encrypted_value, expires_utc, creation_utc, last_access_utc, is_persistent FROM cookies WHERE host_key IN (${hostList})`);
     db.close();
     if (!res || !res[0]) return { ok: true, rows: [] };
     const cols = res[0].columns;
@@ -313,7 +407,7 @@ async function readFirefoxCookies(cookiesPath) {
     const buf = fs.readFileSync(tmpPath);
     const db = new SQL.Database(new Uint8Array(buf));
     const hostList = STEAM_HOSTS.map((h) => `'${h.replace(/'/g, "''")}'`).join(',');
-    const res = db.exec(`SELECT host, name, value FROM moz_cookies WHERE host IN (${hostList})`);
+    const res = db.exec(`SELECT host, name, value, expiry, creationTime, lastAccessed FROM moz_cookies WHERE host IN (${hostList})`);
     db.close();
     if (!res || !res[0]) return { ok: true, rows: [] };
     const cols = res[0].columns;
@@ -412,17 +506,42 @@ export async function extractSteamCookies(browserId) {
   }
   const def = BROWSER_DEFS.find((b) => b.id === browserId);
   if (!def) return { ok: false, browser: browserId, error: 'Unknown browser id' };
-  const profile = def.find();
-  if (!profile) return { ok: false, browser: browserId, error: `${def.label} profile not found on this machine` };
+  const profiles = def.findAll ? def.findAll() : [def.find()].filter(Boolean);
+  if (profiles.length === 0) return { ok: false, browser: browserId, error: `${def.label} profile not found on this machine` };
 
   if (def.family === 'firefox') {
-    const r = await readFirefoxCookies(profile.cookiesPath);
-    if (!r.ok) return { ok: false, browser: browserId, error: r.error };
-    return pickSteamCookies(browserId, r.rows.map((row) => ({ name: row.name, value: row.value, host: row.host })));
+    const cookies = [];
+    const readErrors = [];
+    for (const profile of profiles) {
+      const result = await readFirefoxCookies(profile.cookiesPath);
+      if (!result.ok) {
+        readErrors.push(result.error);
+        continue;
+      }
+      cookies.push(...result.rows.map((row) => normalizeFirefoxCookieRow(row, profile.profileDir)));
+    }
+    if (cookies.length === 0 && readErrors.length === profiles.length) {
+      return { ok: false, browser: browserId, error: readErrors[0] };
+    }
+    const notes = readErrors.length > 0
+      ? [`Could not inspect ${readErrors.length} ${def.label} profile(s); selection used the readable profiles only.`]
+      : [];
+    return pickSteamCookies(browserId, cookies, notes);
   }
 
-  const r = await readChromiumCookies(profile.cookiesPath);
-  if (!r.ok) return { ok: false, browser: browserId, error: r.error };
+  const rowsByProfile = [];
+  const readErrors = [];
+  for (const profile of profiles) {
+    const result = await readChromiumCookies(profile.cookiesPath);
+    if (!result.ok) {
+      readErrors.push(result.error);
+      continue;
+    }
+    rowsByProfile.push(...result.rows.map((row) => ({ row, profileId: profile.profileDir })));
+  }
+  if (rowsByProfile.length === 0 && readErrors.length === profiles.length) {
+    return { ok: false, browser: browserId, error: readErrors[0] };
+  }
 
   let key = masterKeyCache.get(browserId);
   if (!key) {
@@ -436,11 +555,14 @@ export async function extractSteamCookies(browserId) {
   }
 
   const decoded = [];
-  const notes = [];
+  const notes = readErrors.length > 0
+    ? [`Could not inspect ${readErrors.length} ${def.label} profile(s); selection used the readable profiles only.`]
+    : [];
   let appBoundCount = 0;
-  for (const row of r.rows) {
+  for (const { row, profileId } of rowsByProfile) {
+    const normalized = normalizeChromiumCookieRow(row, profileId);
     if (row.value && row.value.length > 0) {
-      decoded.push({ name: row.name, value: String(row.value), host: row.host_key });
+      decoded.push(normalized);
       continue;
     }
     const enc = row.encrypted_value;
@@ -448,7 +570,7 @@ export async function extractSteamCookies(browserId) {
     const buf = Buffer.isBuffer(enc) ? enc : Buffer.from(enc);
     const dec = decryptChromiumValue(buf, key);
     if (dec.ok) {
-      decoded.push({ name: row.name, value: dec.value, host: row.host_key });
+      decoded.push({ ...normalized, value: dec.value });
     } else {
       if (dec.reason && dec.reason.startsWith('app-bound')) appBoundCount += 1;
       log.debug(`Skipped ${row.name}@${row.host_key}: ${dec.reason}`);
@@ -460,23 +582,69 @@ export async function extractSteamCookies(browserId) {
   return pickSteamCookies(browserId, decoded, notes);
 }
 
-function pickSteamCookies(browserId, cookies, notes = []) {
-  const find = (name) => {
-    // Sort matches by host priority (steamcommunity > store), then by value
-    // length descending so we don't accidentally pick an empty/stale cookie
-    // when a populated one is also present.
-    const matches = cookies
-      .filter((c) => c.name === name && c.value)
-      .sort((a, b) => {
-        const pa = STEAM_HOST_PRIORITY(a.host);
-        const pb = STEAM_HOST_PRIORITY(b.host);
-        if (pa !== pb) return pa - pb;
-        return (b.value?.length || 0) - (a.value?.length || 0);
+export function pickSteamCookies(browserId, cookies, notes = [], now = Date.now()) {
+  const outputNotes = [...notes];
+  const valid = cookies.filter((cookie) => {
+    if (!cookie.value || !['sessionid', 'steamLoginSecure'].includes(cookie.name)) {
+      return false;
+    }
+    const noExpiry = cookie.expiresAt === null || cookie.expiresAt === undefined || cookie.expiresAt === 0;
+    const sessionCookie = cookie.isSession === true || (cookie.isSession !== false && noExpiry);
+    return sessionCookie || Number(cookie.expiresAt) > now;
+  });
+  const sessions = valid.filter((cookie) => cookie.name === 'sessionid');
+  const logins = valid.filter((cookie) => cookie.name === 'steamLoginSecure');
+
+  for (const [name, matches] of [['sessionid', sessions], ['steamLoginSecure', logins]]) {
+    if (new Set(matches.map((cookie) => cookie.value)).size > 1) {
+      outputNotes.push(`Conflicting valid ${name} cookies were found; selected the newest compatible pair without exposing cookie values.`);
+    }
+  }
+
+  const pairs = [];
+  for (const session of sessions) {
+    for (const login of logins) {
+      const sessionProfile = session.profileId || browserId;
+      const loginProfile = login.profileId || browserId;
+      const sessionDomain = steamDomainFamily(session.host);
+      const loginDomain = steamDomainFamily(login.host);
+      pairs.push({
+        session,
+        login,
+        sameProfile: sessionProfile === loginProfile,
+        sameDomain: sessionDomain === loginDomain,
+        domainPriority: sessionDomain === loginDomain
+          ? Math.min(STEAM_HOST_PRIORITY(session.host), STEAM_HOST_PRIORITY(login.host))
+          : Math.min(STEAM_HOST_PRIORITY(session.host), STEAM_HOST_PRIORITY(login.host)) + 10,
+        freshness: Math.min(cookieFreshness(session), cookieFreshness(login)),
+        newestMember: Math.max(cookieFreshness(session), cookieFreshness(login)),
       });
-    return matches.length > 0 ? matches[0].value : null;
-  };
-  const sessionid = find('sessionid');
-  const steamLoginSecure = find('steamLoginSecure');
+    }
+  }
+  pairs.sort((a, b) => {
+    if (a.sameProfile !== b.sameProfile) return a.sameProfile ? -1 : 1;
+    if (a.sameDomain !== b.sameDomain) return a.sameDomain ? -1 : 1;
+    if (a.domainPriority !== b.domainPriority) return a.domainPriority - b.domainPriority;
+    if (a.freshness !== b.freshness) return b.freshness - a.freshness;
+    return b.newestMember - a.newestMember;
+  });
+
+  const selected = pairs[0] || null;
+  const newest = (matches) => [...matches].sort((a, b) => {
+    const priority = STEAM_HOST_PRIORITY(a.host) - STEAM_HOST_PRIORITY(b.host);
+    return priority || cookieFreshness(b) - cookieFreshness(a);
+  })[0] || null;
+  const selectedSession = selected?.session || newest(sessions);
+  const selectedLogin = selected?.login || newest(logins);
+  if (selected && !selected.sameProfile) {
+    outputNotes.push('Warning: selected Steam cookies from different browser profiles because no same-profile pair was available.');
+  }
+  if (selected && !selected.sameDomain) {
+    outputNotes.push('Warning: selected a cross-domain Steam cookie fallback pair because no same-domain pair was available.');
+  }
+
+  const sessionid = selectedSession?.value || null;
+  const steamLoginSecure = selectedLogin?.value || null;
   const missing = [];
   if (!sessionid) missing.push('sessionid');
   if (!steamLoginSecure) missing.push('steamLoginSecure');
@@ -486,7 +654,7 @@ function pickSteamCookies(browserId, cookies, notes = []) {
     sessionid: sessionid || null,
     steamLoginSecure: steamLoginSecure || null,
     missing,
-    notes,
+    notes: outputNotes,
     error: missing.length > 0
       ? `Missing ${missing.join(' + ')} — make sure you're logged into Steam in this browser`
       : null,


### PR DESCRIPTION
## Summary

Selects the newest valid Steam authentication cookie pair using browser timestamps, expiry, domain context, and browser profile instead of cookie value length.

## Root Cause

The browser extractor ignored Chromium and Firefox timestamp and expiry columns. It sorted duplicates by domain and value length, so an expired or stale longer value could win. It also inspected only one browser profile and selected each cookie independently, allowing unrelated profile or domain values to be paired without a warning.

## Changes

- Read Chromium `expires_utc`, `creation_utc`, `last_access_utc`, and `is_persistent` values and convert the 1601-based microsecond timestamps.
- Read Firefox `expiry`, `creationTime`, and `lastAccessed` values and convert their Unix seconds/microseconds correctly.
- Inspect every detected profile for the selected browser.
- Exclude expired persistent cookies while retaining session cookies.
- Prefer compatible pairs from the same profile and Steam domain family, then Steam Community, then the newest timestamp within that context.
- Fall back across profiles or domains only when necessary and return a warning.
- Warn when conflicting valid duplicates exist without logging or returning their values in diagnostics.
- Remove cookie length from freshness decisions.

## Regression Proof

All ten new tests failed against the previous extractor because timestamp normalization and pair selection were absent. They now cover both browser schemas, exact timestamp conversions, expired duplicates, session cookies, Community priority, timestamp-over-length freshness, same-domain pairing, same-profile pairing, conflict redaction, and cross-domain fallback warnings.

## Test Results

- `npm run lint:server`
- `npm run test:server`
- `cd client && npm run lint` (66 existing warnings, no errors)
- `cd client && npx tsc -b`
- `cd client && npx vitest run` (109 files, 2,444 tests)
- `cd client && npm run build`
- `git diff --check`

## Risks

- Inspecting multiple profiles performs additional read-only SQLite snapshots and decryption attempts.
- A browser profile that cannot be read is skipped with a value-free warning when another profile remains readable.
- Existing API response fields are unchanged; only `notes` may contain new conflict or fallback diagnostics.

## Rollback

Revert this commit to restore single-profile, domain-and-length-based selection. The extractor remains read-only and no browser or panel data migration is involved.
