### PR TITLE
fix(spawn): keep recent history inside the dialog

### DIFF
--- a/client/src/components/SpawnBrowser.tsx
+++ b/client/src/components/SpawnBrowser.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Search, RefreshCw, Loader2, X, AlertCircle, SearchX, LayoutGrid,
-  Package, Car, User, Sparkles, Minus, Plus, RotateCw, HelpCircle,
+  Package, Car, User, Sparkles, Minus, Plus, RotateCw, HelpCircle, Trash2,
 } from 'lucide-react'
 import {
   Dialog, DialogContent, DialogTitle, DialogDescription,
@@ -64,6 +64,14 @@ function saveRecent(mode: SpawnMode, entries: RecentEntry[]) {
     localStorage.setItem(RECENT_KEY_PREFIX + mode, JSON.stringify(entries.slice(0, MAX_RECENT)))
   } catch {
     // storage quota / disabled — fine, ephemeral fallback
+  }
+}
+
+function clearRecent(mode: SpawnMode) {
+  try {
+    localStorage.removeItem(RECENT_KEY_PREFIX + mode)
+  } catch {
+    // storage disabled — clearing the in-memory state still hides the rail
   }
 }
 
@@ -368,6 +376,7 @@ export function SpawnBrowser({ mode, open, onOpenChange, playerName, onSpawn }: 
       <DialogContent
         className={cn(
           'p-0 gap-0 overflow-hidden border-border/70',
+          'min-w-0',
           'w-[min(1200px,95vw)] max-w-[min(1200px,95vw)]',
           'h-[min(780px,90vh)]',
           'grid grid-rows-[auto_auto_1fr_auto]'
@@ -446,7 +455,7 @@ export function SpawnBrowser({ mode, open, onOpenChange, playerName, onSpawn }: 
         </div>
 
         {/* ========== BODY ========== */}
-        <div className="grid grid-cols-[220px_1fr] min-h-0">
+        <div className="grid grid-cols-[220px_1fr] min-h-0 min-w-0">
           {/* ----- Category sidebar ----- */}
           <aside className="border-r border-border/70 bg-card/40 overflow-y-auto overscroll-contain">
             <div className="sticky top-0 z-10 bg-card/80 backdrop-blur-sm px-3 pt-3 pb-1.5 text-[10px] uppercase tracking-[0.2em] font-semibold text-muted-foreground/60">
@@ -582,45 +591,67 @@ export function SpawnBrowser({ mode, open, onOpenChange, playerName, onSpawn }: 
         </div>
 
         {/* ========== FOOTER / ACTION BAR ========== */}
-        <footer className="border-t border-border/70 bg-card/50 shrink-0">
+        <footer className="min-w-0 border-t border-border/70 bg-card/50 shrink-0">
           {/* Recent rail */}
           {recent.length > 0 && (
-            <div className="flex items-center gap-2 border-b border-border/40 px-4 h-10 overflow-x-auto overscroll-contain">
+            <div
+              role="group"
+              aria-label={t('recent')}
+              className="flex min-w-0 items-center gap-2 border-b border-border/40 px-4 h-10"
+            >
               <span className="text-[10px] uppercase tracking-[0.18em] font-semibold text-muted-foreground/60 shrink-0">
                 {t('recent')}
               </span>
-              <div className="flex items-center gap-1.5 min-w-0">
-                {recent.map(r => (
-                  <button
-                    key={r.id}
-                    type="button"
-                    onClick={() => {
-                      if (isItems) setQty(r.qty)
-                      void handleSpawn(r.id, isItems ? r.qty : undefined)
-                    }}
-                    disabled={spawning || (isItems && !playerName)}
-                    className={cn(
-                      'group flex items-center gap-1.5 h-7 px-2.5 rounded-full border text-[11px] shrink-0',
-                      'border-border/60 bg-background/40 text-foreground/90 hover:bg-primary/10 hover:border-primary/40 hover:text-primary',
-                      'motion-safe:transition-colors duration-100',
-                      'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-background/40 disabled:hover:border-border/60 disabled:hover:text-foreground/90'
-                    )}
-                    // eslint-disable-next-line local/no-dead-disabled-title -- pure hint naming the action ("Spawn X again"); when disabled for the isItems-without-a-player case, the actual reason is already surfaced visibly in this dialog's own hint row below (t('pickPlayerFirst')), so nothing is hidden. Triaged 2026-08-27.
-                    title={isItems ? t('spawnAgainTitleWithQty', { name: r.name, qty: r.qty }) : t('spawnAgainTitle', { name: r.name })}
-                  >
-                    <RotateCw className="w-3 h-3 opacity-50 motion-safe:group-hover:opacity-100 motion-safe:transition-opacity" />
-                    <span className="truncate max-w-[160px]">{r.name}</span>
-                    {isItems && r.qty > 1 && (
-                      <span className="tabular-nums text-muted-foreground/70 group-hover:text-primary/80">× {r.qty}</span>
-                    )}
-                  </button>
-                ))}
+              <div
+                data-slot="recent-history-scroll"
+                className="min-w-0 flex-1 overflow-x-auto overscroll-contain"
+              >
+                <div className="flex w-max items-center gap-1.5 pr-1">
+                  {recent.map(r => (
+                    <button
+                      key={r.id}
+                      type="button"
+                      onClick={() => {
+                        if (isItems) setQty(r.qty)
+                        void handleSpawn(r.id, isItems ? r.qty : undefined)
+                      }}
+                      disabled={spawning || (isItems && !playerName)}
+                      className={cn(
+                        'group flex items-center gap-1.5 h-7 px-2.5 rounded-full border text-[11px] shrink-0',
+                        'border-border/60 bg-background/40 text-foreground/90 hover:bg-primary/10 hover:border-primary/40 hover:text-primary',
+                        'motion-safe:transition-colors duration-100',
+                        'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-background/40 disabled:hover:border-border/60 disabled:hover:text-foreground/90'
+                      )}
+                      // eslint-disable-next-line local/no-dead-disabled-title -- pure hint naming the action ("Spawn X again"); when disabled for the isItems-without-a-player case, the actual reason is already surfaced visibly in this dialog's own hint row below (t('pickPlayerFirst')), so nothing is hidden. Triaged 2026-08-27.
+                      title={isItems ? t('spawnAgainTitleWithQty', { name: r.name, qty: r.qty }) : t('spawnAgainTitle', { name: r.name })}
+                    >
+                      <RotateCw className="w-3 h-3 opacity-50 motion-safe:group-hover:opacity-100 motion-safe:transition-opacity" />
+                      <span className="truncate max-w-[160px]">{r.name}</span>
+                      {isItems && r.qty > 1 && (
+                        <span className="tabular-nums text-muted-foreground/70 group-hover:text-primary/80">× {r.qty}</span>
+                      )}
+                    </button>
+                  ))}
+                </div>
               </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setRecent([])
+                  clearRecent(mode)
+                }}
+                className="flex h-7 shrink-0 items-center gap-1 rounded-sm px-2 text-[11px] text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                aria-label={t('clearRecentAria')}
+                title={t('clearRecentAria')}
+              >
+                <Trash2 className="h-3 w-3" />
+                <span className="hidden sm:inline">{t('clearRecent')}</span>
+              </button>
             </div>
           )}
 
           {/* Action row */}
-          <div className="flex items-center gap-3 px-4 py-3">
+          <div className="flex min-w-0 items-center gap-3 px-4 py-3">
             {/* Selection summary */}
             <div className="flex-1 min-w-0">
               {selectedRow ? (

--- a/client/src/components/__tests__/SpawnBrowser.test.tsx
+++ b/client/src/components/__tests__/SpawnBrowser.test.tsx
@@ -109,6 +109,35 @@ describe('SpawnBrowser -- items (Give)', () => {
     await renderItems({ playerName: '' })
     expect(screen.getByTitle('Spawn Axe × 3 again')).toBeDisabled()
   })
+
+  it('keeps long Recent history in a bounded scroller and can clear only the item history', async () => {
+    const itemHistory = Array.from({ length: 8 }, (_, index) => ({
+      id: `Base.Item${index}`,
+      name: `Very long recent item name ${index}`,
+      qty: index + 1,
+      at: Date.now() - index,
+    }))
+    const vehicleHistory = [{ id: 'Base.CarNormal', name: 'Générique Berline', qty: 1, at: Date.now() }]
+    localStorage.setItem('pz-spawn-recent-items', JSON.stringify(itemHistory))
+    localStorage.setItem('pz-spawn-recent-vehicles', JSON.stringify(vehicleHistory))
+
+    await renderItems({ playerName: 'Aurélie' })
+
+    expect(screen.getByRole('dialog')).toHaveClass('min-w-0')
+    const recentGroup = screen.getByRole('group', { name: 'Recent' })
+    expect(recentGroup).toHaveClass('min-w-0')
+    expect(recentGroup.querySelector('[data-slot="recent-history-scroll"]')).toHaveClass(
+      'min-w-0',
+      'flex-1',
+      'overflow-x-auto',
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear recent history' }))
+
+    expect(screen.queryByRole('group', { name: 'Recent' })).not.toBeInTheDocument()
+    expect(localStorage.getItem('pz-spawn-recent-items')).toBeNull()
+    expect(JSON.parse(localStorage.getItem('pz-spawn-recent-vehicles')!)).toEqual(vehicleHistory)
+  })
 })
 
 describe('SpawnBrowser -- vehicles (Spawn)', () => {
@@ -121,5 +150,18 @@ describe('SpawnBrowser -- vehicles (Spawn)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Spawn' }))
 
     await waitFor(() => expect(onSpawn).toHaveBeenCalledWith('Base.CarNormal', undefined))
+  })
+
+  it('clears the vehicle Recent history from its own storage key', async () => {
+    localStorage.setItem('pz-spawn-recent-vehicles', JSON.stringify([
+      { id: 'Base.CarNormal', name: 'Générique Berline', qty: 1, at: Date.now() },
+    ]))
+    render(<SpawnBrowser mode="vehicles" open onOpenChange={vi.fn()} playerName="" onSpawn={vi.fn()} />)
+    await screen.findByText('Générique Berline')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear recent history' }))
+
+    expect(screen.queryByRole('group', { name: 'Recent' })).not.toBeInTheDocument()
+    expect(localStorage.getItem('pz-spawn-recent-vehicles')).toBeNull()
   })
 })

--- a/client/src/locales/de/spawnBrowser.json
+++ b/client/src/locales/de/spawnBrowser.json
@@ -28,6 +28,8 @@
   "noResults": "Keine Ergebnisse",
   "searchAcrossAllCategories": "Alle Kategorien durchsuchen",
   "recent": "Zuletzt",
+  "clearRecent": "Leeren",
+  "clearRecentAria": "Verlauf der zuletzt verwendeten Einträge leeren",
   "spawnAgainTitle": "{{name}} erneut spawnen",
   "spawnAgainTitleWithQty": "{{name}} × {{qty}} erneut spawnen",
   "selected": "Ausgewählt",

--- a/client/src/locales/en/spawnBrowser.json
+++ b/client/src/locales/en/spawnBrowser.json
@@ -28,6 +28,8 @@
   "noResults": "No results",
   "searchAcrossAllCategories": "Search across all categories",
   "recent": "Recent",
+  "clearRecent": "Clear",
+  "clearRecentAria": "Clear recent history",
   "spawnAgainTitle": "Spawn {{name}} again",
   "spawnAgainTitleWithQty": "Spawn {{name}} × {{qty}} again",
   "selected": "Selected",

--- a/client/src/locales/es/spawnBrowser.json
+++ b/client/src/locales/es/spawnBrowser.json
@@ -28,6 +28,8 @@
   "noResults": "Sin resultados",
   "searchAcrossAllCategories": "Buscar en todas las categorías",
   "recent": "Reciente",
+  "clearRecent": "Borrar",
+  "clearRecentAria": "Borrar historial reciente",
   "spawnAgainTitle": "Generar {{name}} de nuevo",
   "spawnAgainTitleWithQty": "Generar {{name}} × {{qty}} de nuevo",
   "selected": "Seleccionado",

--- a/client/src/locales/fr/spawnBrowser.json
+++ b/client/src/locales/fr/spawnBrowser.json
@@ -28,6 +28,8 @@
   "noResults": "Aucun résultat",
   "searchAcrossAllCategories": "Rechercher dans toutes les catégories",
   "recent": "Récents",
+  "clearRecent": "Effacer",
+  "clearRecentAria": "Effacer l’historique récent",
   "spawnAgainTitle": "Générer {{name}} à nouveau",
   "spawnAgainTitleWithQty": "Générer {{name}} × {{qty}} à nouveau",
   "selected": "Sélectionné",

--- a/client/src/locales/ht/spawnBrowser.json
+++ b/client/src/locales/ht/spawnBrowser.json
@@ -28,6 +28,8 @@
   "noResults": "Pa gen rezilta",
   "searchAcrossAllCategories": "Chèche nan tout kategori",
   "recent": "Resan",
+  "clearRecent": "Efase",
+  "clearRecentAria": "Efase istwa resan",
   "spawnAgainTitle": "Fè {{name}} parèt ankò",
   "spawnAgainTitleWithQty": "Fè {{name}} × {{qty}} parèt ankò",
   "selected": "Chwazi",

--- a/client/src/locales/zh-CN/spawnBrowser.json
+++ b/client/src/locales/zh-CN/spawnBrowser.json
@@ -28,6 +28,8 @@
   "noResults": "无结果",
   "searchAcrossAllCategories": "搜索所有分类",
   "recent": "最近",
+  "clearRecent": "清除",
+  "clearRecentAria": "清除最近记录",
   "spawnAgainTitle": "再次生成 {{name}}",
   "spawnAgainTitleWithQty": "再次生成 {{name}} × {{qty}}",
   "selected": "已选择",


### PR DESCRIPTION
## Summary

Keep the Give Items and Spawn Vehicle dialogs within their viewport when the Recent history contains several long entries, while preserving the useful repeat-action history.

## Root Cause

The Recent chips contributed their full min-content width to the dialog footer's grid sizing. As the history grew, that width expanded the dialog beyond its viewport constraint and pushed the quantity controls and Give/Spawn button outside the visible popup.

## Changes

- Bound the dialog body, footer, and action row with `min-width: 0` semantics.
- Move Recent chips into a dedicated flex child with horizontal scrolling so their content cannot resize the dialog.
- Add a pinned Clear control that removes only the active item or vehicle history from memory and local storage.
- Add localized Clear labels in every supported locale.

## Regression Proof

The new item regression test failed before the product change because the dialog lacked the width constraint and the history scroller. The clear-history tests also failed because no Clear control existed. Both item and vehicle scenarios pass after the fix.

The UI was additionally exercised with multiple intentionally long Recent entries at a 1234 x 810 viewport. The history stayed inside its horizontal scroller, Clear remained visible, and the Give button remained fully inside the dialog.

## Test Results

- `npm run lint` (passes with 66 pre-existing warnings, 0 errors)
- `tsc -b --pretty false`
- `npx vitest run --testTimeout=15000` (110 files, 2,458 tests passed)
- `npm run build`
- `npm run lint:server`
- `npm run test:server` (257 files passed, 2 skipped; 2,689 tests passed, 14 skipped)
- `git diff --check`

## Risks

Low. The change is limited to dialog sizing and client-side Recent-history controls. Existing repeat-spawn behavior and the separate item/vehicle storage keys are preserved.

## Rollback

Revert commit `2146046` to restore the previous Recent rail and footer layout.
