### PR TITLE
feat(server-config): complete localized labels and bilingual search

### DIFF
--- a/client/src/lib/__tests__/serverConfigSchema.i18n.test.ts
+++ b/client/src/lib/__tests__/serverConfigSchema.i18n.test.ts
@@ -15,6 +15,7 @@ import {
   getSandboxSettingLabel,
   getSandboxSettingDescription,
   getSandboxSettingSearchText,
+  formatRawConfigValue,
 } from '../serverConfigSchema'
 
 // The first cases keep a small synthetic German bundle so the accessor key
@@ -99,6 +100,14 @@ describe('serverConfigSchema translated accessors (proof: rcon category)', () =>
     expect(getIniCategoryLabel(INI_CATEGORIES.find((category) => category.id === 'general')!)).toBe('常规')
     expect(getIniCategoryGroupLabel(INI_CATEGORY_GROUPS.find((group) => group.id === 'identity')!)).toBe('身份与基本信息')
     expect(getSandboxSettingLabel(DAY_LENGTH)).toBe('一天长度')
+  })
+
+  it('keeps boolean configuration values as raw true/false literals', () => {
+    expect(formatRawConfigValue(true)).toBe('true')
+    expect(formatRawConfigValue(false)).toBe('false')
+    expect(formatRawConfigValue('true')).toBe('true')
+    expect(formatRawConfigValue('false')).toBe('false')
+    expect(formatRawConfigValue(15)).toBe('15')
   })
 
   it('translates sandbox purpose text without replacing it with ranges or option tables', async () => {

--- a/client/src/lib/__tests__/serverConfigSchema.i18n.test.ts
+++ b/client/src/lib/__tests__/serverConfigSchema.i18n.test.ts
@@ -2,23 +2,31 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import i18n from '@/i18n'
 import {
   INI_SCHEMA,
+  INI_CATEGORIES,
+  INI_CATEGORY_GROUPS,
+  SANDBOX_SCHEMA,
+  SANDBOX_CATEGORIES,
+  SANDBOX_CATEGORY_GROUPS,
   getIniSettingLabel,
   getIniSettingDescription,
+  getIniSettingSearchText,
+  getIniCategoryLabel,
+  getIniCategoryGroupLabel,
+  getSandboxSettingLabel,
+  getSandboxSettingDescription,
+  getSandboxSettingSearchText,
 } from '../serverConfigSchema'
 
-// Proof-of-mechanism for the serverConfigSchema.ts translation plan: the
-// smallest real INI category ("rcon", 2 settings) wired end to end.
-//
-// This does NOT touch any committed locale file. Adding iniSettings.* keys
-// to the real de/serverconfig.json is out of scope for this investigation
-// (a key-set change across locales is a floor-wide gate, sequenced
-// separately) -- so the proof injects a synthetic resource bundle at
-// runtime via i18next's own addResourceBundle API, the same mechanism a
-// real translated locale file would populate through the normal JSON
-// loader in client/src/i18n/index.ts. The KEY SHAPE below is exactly what
-// a real de/serverconfig.json addition would contain.
+// The first cases keep a small synthetic German bundle so the accessor key
+// shape remains explicit and independently tested. The later cases exercise
+// the committed Chinese serverconfig bundle through the normal JSON loader in
+// client/src/i18n/index.ts, including the complete schema coverage contract.
 const RCON_PORT = INI_SCHEMA.find((s) => s.key === 'RCONPort')!
 const RCON_PASSWORD = INI_SCHEMA.find((s) => s.key === 'RCONPassword')!
+const PUBLIC_NAME = INI_SCHEMA.find((s) => s.key === 'PublicName')!
+const DAY_LENGTH = SANDBOX_SCHEMA.find((s) => s.key === 'DayLength' && s.section === 'settings')!
+const ZOMBIE_STRENGTH = SANDBOX_SCHEMA.find((s) => s.key === 'Strength' && s.section === 'ZombieLore')!
+const FARMING_XP = SANDBOX_SCHEMA.find((s) => s.key === 'Farming' && s.section === 'MultiplierConfig')!
 
 const DE_PROOF_BUNDLE = {
   iniSettings: {
@@ -82,5 +90,78 @@ describe('serverConfigSchema translated accessors (proof: rcon category)', () =>
     // getIniSettingLabel/Description shows up as a clear key-path mismatch.
     expect(`iniSettings.${RCON_PORT.category}.${RCON_PORT.key}.label`).toBe('iniSettings.rcon.RCONPort.label')
     expect(`iniSettings.${RCON_PASSWORD.category}.${RCON_PASSWORD.key}.description`).toBe('iniSettings.rcon.RCONPassword.description')
+  })
+
+  it('renders the real Chinese field and rail translations', async () => {
+    await i18n.changeLanguage('zh-CN')
+    expect(getIniSettingLabel(PUBLIC_NAME)).toBe('服务器公开名称')
+    expect(getIniSettingDescription(PUBLIC_NAME)).toContain('Steam 服务器浏览器')
+    expect(getIniCategoryLabel(INI_CATEGORIES.find((category) => category.id === 'general')!)).toBe('常规')
+    expect(getIniCategoryGroupLabel(INI_CATEGORY_GROUPS.find((group) => group.id === 'identity')!)).toBe('身份与基本信息')
+    expect(getSandboxSettingLabel(DAY_LENGTH)).toBe('一天长度')
+  })
+
+  it('translates sandbox purpose text without replacing it with ranges or option tables', async () => {
+    await i18n.changeLanguage('zh-CN')
+    expect(getSandboxSettingDescription(DAY_LENGTH)).toBe('一天在现实时间中持续多久。')
+    expect(getSandboxSettingDescription(DAY_LENGTH)).not.toMatch(/1\s*=|15\s*分钟|范围/)
+    expect(getSandboxSettingDescription(ZOMBIE_STRENGTH)).toBe('僵尸每次攻击造成的伤害。')
+    expect(getSandboxSettingDescription(ZOMBIE_STRENGTH)).not.toContain('技能')
+    expect(getSandboxSettingDescription(FARMING_XP)).toBe('耕作技能的经验获取倍率。')
+
+    const misplacedValueTables = SANDBOX_SCHEMA.flatMap((setting) => {
+      const description = getSandboxSettingDescription(setting)
+      const valueMappings = description.match(/\d+(?:\.\d+)?\s*=/g) ?? []
+      const isBareRange = /^\s*[\d.]+\s*(?:~|～|-)\s*[\d.]+\s*$/.test(description)
+      return valueMappings.length > 1 || isBareRange
+        ? [`${setting.section || 'settings'}.${setting.key}`]
+        : []
+    })
+    expect(misplacedValueTables).toEqual([])
+  })
+
+  it('search text keeps raw keys and English alongside the active Chinese translation', async () => {
+    await i18n.changeLanguage('zh-CN')
+    const iniSearch = getIniSettingSearchText(PUBLIC_NAME)
+    expect(iniSearch).toContain('PublicName')
+    expect(iniSearch).toContain('Server Name')
+    expect(iniSearch).toContain('服务器公开名称')
+
+    const sandboxSearch = getSandboxSettingSearchText(DAY_LENGTH)
+    expect(sandboxSearch).toContain('settings.DayLength')
+    expect(sandboxSearch).toContain('Day Length')
+    expect(sandboxSearch).toContain('一天长度')
+    expect(sandboxSearch).toContain('2 Hours')
+    expect(sandboxSearch).toContain('2 小时')
+  })
+
+  it('ships a Chinese locale key for every current field, option, category, and group', async () => {
+    await i18n.changeLanguage('zh-CN')
+    const missing: string[] = []
+    for (const setting of INI_SCHEMA) {
+      const base = `iniSettings.${setting.category}.${setting.key}`
+      if (!i18n.exists(`${base}.label`, { ns: 'serverconfig' })) missing.push(`${base}.label`)
+      if (!i18n.exists(`${base}.description`, { ns: 'serverconfig' })) missing.push(`${base}.description`)
+      for (const option of setting.options ?? []) {
+        if (!i18n.exists(`${base}.options.${option.value}.label`, { ns: 'serverconfig' })) {
+          missing.push(`${base}.options.${option.value}.label`)
+        }
+      }
+    }
+    for (const setting of SANDBOX_SCHEMA) {
+      const base = `sandboxSettings.${setting.category}.${setting.key}`
+      if (!i18n.exists(`${base}.label`, { ns: 'serverconfig' })) missing.push(`${base}.label`)
+      if (!i18n.exists(`${base}.description`, { ns: 'serverconfig' })) missing.push(`${base}.description`)
+      for (const option of setting.options ?? []) {
+        if (!i18n.exists(`${base}.options.${option.value}.label`, { ns: 'serverconfig' })) {
+          missing.push(`${base}.options.${option.value}.label`)
+        }
+      }
+    }
+    for (const category of INI_CATEGORIES) if (!i18n.exists(`iniCategories.${category.id}.label`, { ns: 'serverconfig' })) missing.push(`iniCategories.${category.id}.label`)
+    for (const group of INI_CATEGORY_GROUPS) if (!i18n.exists(`iniCategoryGroups.${group.id}.label`, { ns: 'serverconfig' })) missing.push(`iniCategoryGroups.${group.id}.label`)
+    for (const category of SANDBOX_CATEGORIES) if (!i18n.exists(`sandboxCategories.${category.id}.label`, { ns: 'serverconfig' })) missing.push(`sandboxCategories.${category.id}.label`)
+    for (const group of SANDBOX_CATEGORY_GROUPS) if (!i18n.exists(`sandboxCategoryGroups.${group.id}.label`, { ns: 'serverconfig' })) missing.push(`sandboxCategoryGroups.${group.id}.label`)
+    expect(missing).toEqual([])
   })
 })

--- a/client/src/lib/serverConfigSchema.ts
+++ b/client/src/lib/serverConfigSchema.ts
@@ -19,6 +19,17 @@ export interface IniSetting {
   fileExtensions?: string[]
 }
 
+/**
+ * Format a stored configuration value without translating its data meaning.
+ * Project Zomboid's boolean literals are part of the INI/sandbox contract and
+ * must remain the portable `true` / `false` strings in defaults and reset UI.
+ */
+export function formatRawConfigValue(value: unknown): string {
+  if (value === true) return 'true'
+  if (value === false) return 'false'
+  return String(value ?? '')
+}
+
 export interface NumericSettingBounds {
   min?: number
   max?: number
@@ -4778,7 +4789,7 @@ function translatedSandboxLabel(key: string, fallback: string): string {
   // unchanged fallback as absent so the official PZ label remains available
   // through sandboxPz for those languages (and for zh-TW) without being
   // shadowed by the parity skeleton.
-  if (serverConfigValue !== undefined && serverConfigValue !== fallback) return serverConfigValue
+  if (serverConfigValue !== null && serverConfigValue !== fallback) return serverConfigValue
   return resolveRegisteredTranslation('sandboxPz', key, undefined) ?? serverConfigValue ?? fallback
 }
 

--- a/client/src/lib/serverConfigSchema.ts
+++ b/client/src/lib/serverConfigSchema.ts
@@ -4729,12 +4729,10 @@ export function getSandboxSetting(key: string, section?: string): SandboxSetting
 //
 // The schema arrays above are DATA, not JSX -- t() can't be sprinkled into a
 // literal string in a const array the way it can into a template. Every
-// label/description/option-label here doubles as the English fallback text,
-// so there is nothing to keep in sync: a locale that has no entry for a key
-// falls straight through to the schema's own string, byte-for-byte identical
-// to today's rendering. English therefore never needs a locale entry for any
-// of these ~1,400 strings; only fr/es/zh-CN/de do, once a translation pass
-// actually adds them.
+// label/description/option-label here doubles as the runtime English fallback.
+// The same strings are mirrored into en/serverconfig.json because localeParity
+// uses English as its source of truth; other locale files carry either an
+// authored translation or an explicit English fallback until one is available.
 //
 // Keys are derived mechanically from data already on each entry:
 //   serverconfig.iniSettings.<category>.<key>.label / .description
@@ -4753,9 +4751,9 @@ export function getSandboxSetting(key: string, section?: string): SandboxSetting
 // today's two schemas happen not to (that invariant lives in
 // serverConfigSchema.test.ts and is about schema ownership, not i18n).
 //
-// A generator script can walk INI_SCHEMA/SANDBOX_SCHEMA/*_CATEGORIES/
-// *_CATEGORY_GROUPS with these exact same derivations to emit a complete,
-// exhaustive locale skeleton per language -- nobody hand-writes these keys.
+// A schema-driven extraction pass can walk INI_SCHEMA/SANDBOX_SCHEMA and the
+// category/group arrays with these exact same derivations to audit coverage;
+// nobody should invent a second key shape by hand.
 
 function translatedOrFallback(key: string, fallback: string): string {
   return resolveRegisteredTranslation('serverconfig', key, undefined) ?? fallback
@@ -4767,18 +4765,21 @@ function translatedOrFallback(key: string, fallback: string): string {
 // extracted verbatim from the game's Sandbox.json language files -- so an
 // operator setting "Meta Events" here sees the exact same word their game
 // client shows, rather than a differently-worded (even if accurate)
-// translation authored independently of PZ's own vocabulary. A hand-authored
-// override placed directly in serverconfig.json still wins if one is ever
-// added -- this only fills the gap when neither exists.
+// translation authored independently of PZ's own vocabulary. A hand-authored,
+// non-fallback override placed directly in serverconfig.json still wins --
+// this only fills the gap when no such override exists.
 // Descriptions are deliberately NOT wired to this: PZ's own tooltips were
 // written for its in-game options screen, ours were written for this panel,
 // and they are not automatically the same job.
 function translatedSandboxLabel(key: string, fallback: string): string {
-  return (
-    resolveRegisteredTranslation('serverconfig', `sandboxSettings.${key}`, undefined) ??
-    resolveRegisteredTranslation('sandboxPz', key, undefined) ??
-    fallback
-  )
+  const serverConfigValue = resolveRegisteredTranslation('serverconfig', `sandboxSettings.${key}`, undefined)
+  // Schema-generated locale entries intentionally keep the English fallback
+  // in languages that have not authored a panel-specific label yet. Treat an
+  // unchanged fallback as absent so the official PZ label remains available
+  // through sandboxPz for those languages (and for zh-TW) without being
+  // shadowed by the parity skeleton.
+  if (serverConfigValue !== undefined && serverConfigValue !== fallback) return serverConfigValue
+  return resolveRegisteredTranslation('sandboxPz', key, undefined) ?? serverConfigValue ?? fallback
 }
 
 export function getIniSettingLabel(setting: IniSetting): string {
@@ -4792,6 +4793,33 @@ export function getIniSettingDescription(setting: IniSetting): string {
 export function getIniSettingOptionLabel(setting: IniSetting, value: string): string {
   const fallback = setting.options?.find(o => o.value === value)?.label ?? value
   return translatedOrFallback(`iniSettings.${setting.category}.${setting.key}.options.${value}.label`, fallback)
+}
+
+/**
+ * Search text intentionally includes both schema English and the active
+ * locale. Operators often copy the literal key from an INI file, while the
+ * translated UI makes Chinese searches much more natural. Keeping this
+ * assembled here prevents each page from inventing a different search scope.
+ */
+export function getIniSettingSearchText(setting: IniSetting): string {
+  const category = INI_CATEGORIES.find(item => item.id === setting.category)
+  const group = category && INI_CATEGORY_GROUPS.find(item => item.id === category.group)
+  return [
+    setting.key,
+    setting.label,
+    setting.description,
+    getIniSettingLabel(setting),
+    getIniSettingDescription(setting),
+    ...(setting.options ?? []).flatMap(option => [
+      option.label,
+      getIniSettingOptionLabel(setting, option.value),
+      String(option.value),
+    ]),
+    category?.label,
+    category && getIniCategoryLabel(category),
+    group?.label,
+    group && getIniCategoryGroupLabel(group),
+  ].filter(Boolean).join(' ')
 }
 
 export function getIniCategoryLabel(category: { id: string; label: string }): string {
@@ -4813,6 +4841,29 @@ export function getSandboxSettingDescription(setting: SandboxSetting): string {
 export function getSandboxSettingOptionLabel(setting: SandboxSetting, value: number): string {
   const fallback = setting.options?.find(o => o.value === value)?.label ?? String(value)
   return translatedSandboxLabel(`${setting.category}.${setting.key}.options.${value}.label`, fallback)
+}
+
+export function getSandboxSettingSearchText(setting: SandboxSetting): string {
+  const category = SANDBOX_CATEGORIES.find(item => item.id === setting.category)
+  const group = category && SANDBOX_CATEGORY_GROUPS.find(item => item.id === category.group)
+  const qualifiedKey = `${setting.section || 'settings'}.${setting.key}`
+  return [
+    setting.key,
+    qualifiedKey,
+    setting.label,
+    setting.description,
+    getSandboxSettingLabel(setting),
+    getSandboxSettingDescription(setting),
+    ...(setting.options ?? []).flatMap(option => [
+      option.label,
+      getSandboxSettingOptionLabel(setting, option.value),
+      String(option.value),
+    ]),
+    category?.label,
+    category && getSandboxCategoryLabel(category),
+    group?.label,
+    group && getSandboxCategoryGroupLabel(group),
+  ].filter(Boolean).join(' ')
 }
 
 // Runtime belt-and-braces for the class of bug the enum audit found (a live

--- a/client/src/locales/de/serverconfig.json
+++ b/client/src/locales/de/serverconfig.json
@@ -386,5 +386,3651 @@
     "title": "Dieses Backup wiederherstellen?",
     "description": "Die aktuelle Datei ersetzen durch: „{{filename}}“? Nicht gespeicherte Änderungen an der aktiven Konfiguration gehen verloren.",
     "confirmLabel": "Wiederherstellen"
+  },
+  "iniSettings": {
+    "general": {
+      "PublicName": {
+        "label": "Server Name",
+        "description": "Your server name as shown to the public."
+      },
+      "PublicDescription": {
+        "label": "Server Description",
+        "description": "The description that people can see while browsing your server."
+      },
+      "Public": {
+        "label": "Public Server",
+        "description": "Can your server be seen on Steam server browser."
+      },
+      "Open": {
+        "label": "Open (No Whitelist)",
+        "description": "Open to all players without requiring whitelist."
+      },
+      "Password": {
+        "label": "Server Password",
+        "description": "Password required to join the server. Leave empty for no password."
+      },
+      "MaxPlayers": {
+        "label": "Max Players",
+        "description": "Maximum allowed number of players."
+      },
+      "PauseEmpty": {
+        "label": "Pause When Empty",
+        "description": "The server will pause when no players are logged in."
+      },
+      "ServerWelcomeMessage": {
+        "label": "Welcome Message",
+        "description": "The welcome message displayed to players after connecting. Use <LINE> for new lines."
+      },
+      "Map": {
+        "label": "Map",
+        "description": "The map you're playing on. Default is Muldraugh, KY."
+      },
+      "SaveWorldEveryMinutes": {
+        "label": "Auto-Save Interval",
+        "description": "Auto-save world every X minutes. 0 = never."
+      },
+      "AnnounceDeath": {
+        "label": "Announce Deaths",
+        "description": "Server-wide announcement when a character dies."
+      },
+      "AnnounceAnimalDeath": {
+        "label": "Announce Animal Deaths",
+        "description": "Display a global chat message when an animal dies."
+      },
+      "Seed": {
+        "label": "World Seed",
+        "description": "The worldgen seed used to generate the world. Changing this requires deleting map_worldgen.bin."
+      }
+    },
+    "network": {
+      "DefaultPort": {
+        "label": "Game Port",
+        "description": "The port players will use to connect to your server. Must be open on your router."
+      },
+      "UPnP": {
+        "label": "Enable UPnP",
+        "description": "Enable UPnP for automatic port forwarding."
+      },
+      "PingFrequency": {
+        "label": "Ping Frequency",
+        "description": "How often the server checks connection to players (seconds)."
+      },
+      "PingLimit": {
+        "label": "Ping Limit",
+        "description": "Ping limit before being kicked (milliseconds). 100 to disable."
+      },
+      "DenyLoginOnOverloadedServer": {
+        "label": "Deny Login When Overloaded",
+        "description": "Prevent new connections when server is overloaded."
+      },
+      "SpeedLimit": {
+        "label": "Speed Limit",
+        "description": "Maximum movement speed allowed."
+      },
+      "UseTCPForMapDownloads": {
+        "label": "Use TCP for Map Downloads",
+        "description": "Use TCP instead of UDP for map downloads."
+      },
+      "MaxPacketsPerSecond": {
+        "label": "Max Packets Per Second",
+        "description": "Cap on packets per second sent to a connected client. Higher values increase bandwidth use; lower values may cause stutter under load."
+      },
+      "UDPPort": {
+        "label": "UDP Port",
+        "description": "Second port used for UDP connections."
+      },
+      "LoginQueueEnabled": {
+        "label": "Login Queue",
+        "description": "Enable a login queue when the server is full."
+      },
+      "LoginQueueConnectTimeout": {
+        "label": "Login Queue Timeout",
+        "description": "Seconds before a queued connection times out."
+      },
+      "server_browser_announced_ip": {
+        "label": "Announced IP",
+        "description": "IP address broadcast to the server browser. For multi-IP setups like server farms."
+      },
+      "MultiplayerStatisticsPeriod": {
+        "label": "Statistics Period",
+        "description": "Multiplayer statistics update period in seconds. 0 = disabled."
+      }
+    },
+    "pvp": {
+      "PVP": {
+        "label": "Enable PvP",
+        "description": "Allow player vs player combat (each player can still toggle their own PvP)."
+      },
+      "SafetySystem": {
+        "label": "Safety System",
+        "description": "If PvP is enabled, allows players to toggle their own PvP on/off."
+      },
+      "ShowSafety": {
+        "label": "Show Safety Status",
+        "description": "Show skull icon for players with safety off."
+      },
+      "SafetyToggleTimer": {
+        "label": "Safety Toggle Timer",
+        "description": "Time in seconds to switch between PvP on and off."
+      },
+      "SafetyCooldownTimer": {
+        "label": "Safety Cooldown Timer",
+        "description": "Time in seconds before you can toggle safety again."
+      },
+      "PVPMeleeWhileHitReaction": {
+        "label": "Melee While Hit Reaction",
+        "description": "Allow melee attacks during hit reaction in PvP."
+      },
+      "PVPMeleeDamageModifier": {
+        "label": "PvP Melee Damage %",
+        "description": "Melee damage modifier for PvP (percentage)."
+      },
+      "PVPFirearmDamageModifier": {
+        "label": "PvP Firearm Damage %",
+        "description": "Firearm damage modifier for PvP (percentage)."
+      },
+      "PlayerBumpPlayer": {
+        "label": "Player Collision",
+        "description": "Players can bump into each other."
+      },
+      "PVPLogToolChat": {
+        "label": "Log PvP to Chat",
+        "description": "PvP events are logged to admin chat."
+      },
+      "PVPLogToolFile": {
+        "label": "Log PvP to File",
+        "description": "PvP events are logged to a file."
+      },
+      "SafetyDisconnectDelay": {
+        "label": "Safety Disconnect Delay",
+        "description": "Seconds before PvP safety mode resets on disconnect."
+      }
+    },
+    "chat": {
+      "GlobalChat": {
+        "label": "Enable Global Chat",
+        "description": "Enable /all command for server-wide chat."
+      },
+      "ChatStreams": {
+        "label": "Chat Streams",
+        "description": "Enabled chat streams: s=say, r=radio, a=admin, w=whisper, y=yell, sh=safehouse, f=faction, all=global."
+      },
+      "DisplayUserName": {
+        "label": "Display Usernames",
+        "description": "Show player usernames above their heads and in chat."
+      },
+      "ShowFirstAndLastName": {
+        "label": "Show Character Names",
+        "description": "Display character first and last name instead of username."
+      },
+      "MouseOverToSeeDisplayName": {
+        "label": "Mouse Over for Name",
+        "description": "Require mouse hover to see player names."
+      },
+      "HidePlayersBehindYou": {
+        "label": "Hide Players Behind You",
+        "description": "Hide player names for players behind your character."
+      },
+      "AllowNonAsciiUsername": {
+        "label": "Allow Non-ASCII Usernames",
+        "description": "Allow usernames with non-ASCII characters."
+      },
+      "BanKickGlobalSound": {
+        "label": "Ban/Kick Sound",
+        "description": "Play global sound when a player is banned or kicked."
+      },
+      "UsernameDisguises": {
+        "label": "Username Disguises",
+        "description": "Allow players to disguise their username."
+      },
+      "HideDisguisedUserName": {
+        "label": "Hide Disguised Names",
+        "description": "Hide the real username of disguised players."
+      },
+      "ChatMessageCharacterLimit": {
+        "label": "Chat Character Limit",
+        "description": "Maximum characters per chat message."
+      },
+      "ChatMessageSlowModeTime": {
+        "label": "Chat Slow Mode",
+        "description": "Seconds between allowed chat messages per player."
+      }
+    },
+    "players": {
+      "MaxAccountsPerUser": {
+        "label": "Max Accounts Per User",
+        "description": "Limit accounts per Steam user. 0 = unlimited."
+      },
+      "DropOffWhiteListAfterDeath": {
+        "label": "Remove From Whitelist On Death",
+        "description": "Remove player from whitelist if their character dies."
+      },
+      "KickFastPlayers": {
+        "label": "Kick Speed Hackers",
+        "description": "Kick players moving faster than possible. May be buggy."
+      },
+      "SpawnPoint": {
+        "label": "Spawn Point",
+        "description": "Custom spawn point coordinates (X,Y,Z). 0,0,0 for default."
+      },
+      "SpawnItems": {
+        "label": "Spawn Items",
+        "description": "Items new characters spawn with (comma-separated, e.g., Base.BaseballBat,Base.WaterBottleFull)."
+      },
+      "SleepAllowed": {
+        "label": "Allow Sleep",
+        "description": "Whether sleeping is allowed."
+      },
+      "SleepNeeded": {
+        "label": "Sleep Required",
+        "description": "Whether players need to sleep when exhausted."
+      },
+      "PlayerRespawnWithSelf": {
+        "label": "Respawn at Death Location",
+        "description": "Allow respawning at death location."
+      },
+      "PlayerRespawnWithOther": {
+        "label": "Respawn with Partner",
+        "description": "Enable spawning at splitscreen partner location."
+      },
+      "PlayerSaveOnDamage": {
+        "label": "Save on Damage",
+        "description": "Save player state when they take damage."
+      },
+      "Faction": {
+        "label": "Enable Factions",
+        "description": "Allow creation and use of factions."
+      },
+      "FactionDaySurvivedToCreate": {
+        "label": "Days to Create Faction",
+        "description": "Days a player must survive to create a faction."
+      },
+      "FactionPlayersRequiredForTag": {
+        "label": "Players for Faction Tag",
+        "description": "Players required in faction to show tag."
+      },
+      "AllowTradeUI": {
+        "label": "Allow Trading",
+        "description": "Allow players to directly trade with one another."
+      },
+      "AllowCoop": {
+        "label": "Allow Co-op",
+        "description": "Allow co-op/splitscreen players to join."
+      },
+      "KnockedDownAllowed": {
+        "label": "Knocked Down",
+        "description": "Allow players to be knocked down. WIP: may cause visual desync."
+      },
+      "SneakModeHideFromOtherPlayers": {
+        "label": "Sneak Hides From Players",
+        "description": "Players in sneak mode are hidden from other players."
+      },
+      "MapRemotePlayerVisibility": {
+        "label": "Map Player Visibility",
+        "description": "Who can see other players on the in-game map.",
+        "options": {
+          "1": {
+            "label": "Hidden"
+          },
+          "2": {
+            "label": "Friends Only"
+          },
+          "3": {
+            "label": "Friends and Nearby Players"
+          },
+          "4": {
+            "label": "Everyone"
+          }
+        }
+      },
+      "DisableScoreboard": {
+        "label": "Disable Scoreboard",
+        "description": "Disable the in-game scoreboard."
+      },
+      "HideAdminsInPlayerList": {
+        "label": "Hide Admins in Player List",
+        "description": "Hide admin accounts from the player list."
+      }
+    },
+    "safehouse": {
+      "PlayerSafehouse": {
+        "label": "Enable Safehouses",
+        "description": "Allow players to claim safehouses."
+      },
+      "AdminSafehouse": {
+        "label": "Admin Safehouses",
+        "description": "Allow admins to have safehouses."
+      },
+      "SafehouseAllowTrepass": {
+        "label": "Allow Trespass",
+        "description": "Allow non-members to enter safehouses without invite."
+      },
+      "SafehouseAllowFire": {
+        "label": "Allow Fire Damage",
+        "description": "Allow fire to damage safehouses."
+      },
+      "SafehouseAllowLoot": {
+        "label": "Allow Looting",
+        "description": "Allow non-members to take items from safehouses."
+      },
+      "SafehouseAllowRespawn": {
+        "label": "Allow Safehouse Respawn",
+        "description": "Players can respawn in their safehouse."
+      },
+      "SafehouseDaySurvivedToClaim": {
+        "label": "Days to Claim Safehouse",
+        "description": "Days a player must survive before claiming a safehouse."
+      },
+      "SafeHouseRemovalTime": {
+        "label": "Safehouse Removal Time",
+        "description": "Real-time hours of inactivity before removal from safehouse."
+      },
+      "DisableSafehouseWhenOwnerConnected": {
+        "label": "Disable When Owner Online",
+        "description": "Disable safehouse protection when the owner is connected. (Renamed from DisableSafehouseWhenPlayerConnected in the Dec 2025 MP patch.)"
+      },
+      "SafehouseAllowNonResidential": {
+        "label": "Allow Non-Residential",
+        "description": "Allow players to claim non-residential buildings as safehouses."
+      },
+      "SafehouseDisableDisguises": {
+        "label": "Disable Disguises in Safehouse",
+        "description": "Disable username disguises inside safehouses."
+      },
+      "MaxSafezoneSize": {
+        "label": "Max Safezone Size",
+        "description": "Maximum tile size for safezones."
+      }
+    },
+    "loot": {
+      "ItemNumbersLimitPerContainer": {
+        "label": "Container Item Limit",
+        "description": "Max items per container. 0 = unlimited."
+      },
+      "TrashDeleteAll": {
+        "label": "Delete All Trash",
+        "description": "Delete all items when placed in trash."
+      },
+      "RemovePlayerCorpsesOnCorpseRemoval": {
+        "label": "Remove Player Corpses",
+        "description": "Remove player corpses when corpse removal runs."
+      },
+      "AllowDestructionBySledgehammer": {
+        "label": "Sledgehammer Destruction",
+        "description": "Allow players to destroy world objects with sledgehammer."
+      },
+      "NoFire": {
+        "label": "Disable Fire",
+        "description": "Disable all fires except campfires."
+      },
+      "SafehousePreventsLootRespawn": {
+        "label": "Safehouse Blocks Loot Respawn",
+        "description": "Items will not respawn in buildings claimed as safehouses."
+      },
+      "SledgehammerOnlyInSafehouse": {
+        "label": "Sledgehammer Only in Safehouse",
+        "description": "Restrict sledgehammer destruction to safehouses only. Requires Sledgehammer Destruction enabled."
+      }
+    },
+    "mods": {
+      "Mods": {
+        "label": "Mods",
+        "description": "List of installed mod IDs (semicolon-separated)."
+      },
+      "WorkshopItems": {
+        "label": "Workshop Items",
+        "description": "Steam Workshop item IDs to download (semicolon-separated)."
+      },
+      "DoLuaChecksum": {
+        "label": "Lua Checksum",
+        "description": "Verify client Lua matches server. Must be disabled when using PanelBridge — the mod modifies server-side Lua files, which causes checksum mismatches and prevents players from connecting."
+      }
+    },
+    "steam": {
+      "SteamPort1": {
+        "label": "Steam Port 1",
+        "description": "First Steam port."
+      },
+      "SteamPort2": {
+        "label": "Steam Port 2",
+        "description": "Second Steam port."
+      },
+      "SteamScoreboard": {
+        "label": "Steam Scoreboard",
+        "description": "Show Steam usernames and avatars. true/false/admin.",
+        "options": {
+          "true": {
+            "label": "Everyone"
+          },
+          "false": {
+            "label": "No One"
+          },
+          "admin": {
+            "label": "Admins Only"
+          }
+        }
+      },
+      "SteamVAC": {
+        "label": "VAC Ban Check",
+        "description": "Check if connecting players have VAC bans."
+      }
+    },
+    "voice": {
+      "VoiceEnable": {
+        "label": "Enable Voice Chat",
+        "description": "Enable in-game voice chat."
+      },
+      "Voice3D": {
+        "label": "3D Voice",
+        "description": "Enable 3D positional voice chat."
+      },
+      "VoiceMinDistance": {
+        "label": "Voice Min Distance",
+        "description": "Minimum voice distance."
+      },
+      "VoiceMaxDistance": {
+        "label": "Voice Max Distance",
+        "description": "Maximum voice distance."
+      }
+    },
+    "discord": {
+      "DiscordEnable": {
+        "label": "Enable Discord",
+        "description": "Enable built-in Discord integration."
+      },
+      "DiscordToken": {
+        "label": "Discord Token",
+        "description": "Discord bot token."
+      },
+      "DiscordChannel": {
+        "label": "Discord Channel",
+        "description": "Discord channel name."
+      },
+      "DiscordChannelID": {
+        "label": "Discord Channel ID",
+        "description": "Discord channel ID."
+      },
+      "DiscordChatChannel": {
+        "label": "Discord Chat Channel",
+        "description": "The Discord channel name for game chat."
+      },
+      "DiscordLogChannel": {
+        "label": "Discord Log Channel",
+        "description": "The Discord channel name for server logs."
+      },
+      "DiscordCommandChannel": {
+        "label": "Discord Command Channel",
+        "description": "The Discord channel name for commands."
+      },
+      "WebhookAddress": {
+        "label": "Webhook URL",
+        "description": "Slack/Discord incoming webhook URL for notifications."
+      }
+    },
+    "rcon": {
+      "RCONPort": {
+        "label": "RCON Port",
+        "description": "Port for RCON connections."
+      },
+      "RCONPassword": {
+        "label": "RCON Password",
+        "description": "Password for RCON connections."
+      }
+    },
+    "advanced": {
+      "ResetID": {
+        "label": "Reset ID",
+        "description": "Removing this resets zombies and loot (not time)."
+      },
+      "ServerPlayerID": {
+        "label": "Server Player ID",
+        "description": "Identifies if character is from another server."
+      },
+      "PhysicsDelay": {
+        "label": "Physics Delay",
+        "description": "Physics update delay in milliseconds."
+      },
+      "FastForwardMultiplier": {
+        "label": "Fast Forward Multiplier",
+        "description": "Speed multiplier when fast-forwarding."
+      },
+      "CarEngineAttractionModifier": {
+        "label": "Car Engine Attraction",
+        "description": "Modifier for zombie attraction to car engines."
+      },
+      "ZombieUpdateMaxHighPriority": {
+        "label": "Zombie High Priority Updates",
+        "description": "Max high priority zombie updates per tick."
+      },
+      "ZombieUpdateDelta": {
+        "label": "Zombie Update Delta",
+        "description": "Zombie update time delta."
+      },
+      "SwitchZombiesOwnershipEachUpdate": {
+        "label": "Switch Zombie Ownership",
+        "description": "Switch zombie ownership between players each update tick."
+      },
+      "UltraSpeedDoesnotAffectToAnimals": {
+        "label": "Ultra Speed Ignores Animals",
+        "description": "Ultra speed mode does not affect animal simulation."
+      },
+      "UsePhysicsHitReaction": {
+        "label": "Physics Hit Reaction",
+        "description": "Use physics-based hit reactions."
+      }
+    },
+    "war": {
+      "War": {
+        "label": "Enable Faction War",
+        "description": "Enable faction war system. (Disabled by default since the Dec 2025 MP patch.)"
+      },
+      "WarStartDelay": {
+        "label": "War Start Delay",
+        "description": "Seconds before war starts after being declared."
+      },
+      "WarDuration": {
+        "label": "War Duration",
+        "description": "War duration in seconds."
+      },
+      "WarSafehouseHitPoints": {
+        "label": "War Safehouse Hit Points",
+        "description": "Safehouse hit points during faction war."
+      }
+    },
+    "radio": {
+      "DisableRadioStaff": {
+        "label": "Disable Radio for Staff",
+        "description": "Disable radio transmissions from staff access level."
+      },
+      "DisableRadioAdmin": {
+        "label": "Disable Radio for Admins",
+        "description": "Disable radio transmissions from admin access level."
+      },
+      "DisableRadioGM": {
+        "label": "Disable Radio for GMs",
+        "description": "Disable radio transmissions from GM access level."
+      },
+      "DisableRadioOverseer": {
+        "label": "Disable Radio for Overseers",
+        "description": "Disable radio transmissions from overseer access level."
+      },
+      "DisableRadioModerator": {
+        "label": "Disable Radio for Moderators",
+        "description": "Disable radio transmissions from moderator access level."
+      },
+      "DisableRadioInvisible": {
+        "label": "Disable Radio for Invisible",
+        "description": "Disable radio transmissions from invisible players."
+      }
+    },
+    "backups": {
+      "BackupsCount": {
+        "label": "Backup Count",
+        "description": "Number of backup copies to keep."
+      },
+      "BackupsOnStart": {
+        "label": "Backup on Start",
+        "description": "Create a backup when the server starts."
+      },
+      "BackupsOnVersionChange": {
+        "label": "Backup on Version Change",
+        "description": "Create a backup when the game version changes."
+      },
+      "BackupsPeriod": {
+        "label": "Backup Period",
+        "description": "Minutes between automatic backups. 0 = disabled."
+      }
+    },
+    "vehicles": {
+      "DisableVehicleTowing": {
+        "label": "Disable Vehicle Towing",
+        "description": "Disable vehicle towing."
+      },
+      "DisableTrailerTowing": {
+        "label": "Disable Trailer Towing",
+        "description": "Disable trailer towing."
+      },
+      "DisableBurntTowing": {
+        "label": "Disable Burnt Vehicle Towing",
+        "description": "Disable towing of burnt vehicles."
+      }
+    },
+    "moderation": {
+      "BadWordListFile": {
+        "label": "Bad Word List File",
+        "description": "Path to file with prohibited words, one per line."
+      },
+      "GoodWordListFile": {
+        "label": "Good Word List File",
+        "description": "Path to file with allowed words that may contain bad words, one per line."
+      },
+      "BadWordPolicy": {
+        "label": "Bad Word Policy",
+        "description": "Action taken when a bad word is detected in chat.",
+        "options": {
+          "1": {
+            "label": "Ban"
+          },
+          "2": {
+            "label": "Kick"
+          },
+          "3": {
+            "label": "Record Violation"
+          },
+          "4": {
+            "label": "Mute"
+          }
+        }
+      },
+      "BadWordReplacement": {
+        "label": "Bad Word Replacement",
+        "description": "Text that replaces bad words in chat."
+      }
+    },
+    "anticheat": {
+      "AntiCheatSafety": {
+        "label": "Safety",
+        "description": "Anti-cheat protection for the safety system.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSpeed": {
+        "label": "Speed",
+        "description": "Anti-cheat protection for player speed.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatNoClip": {
+        "label": "No Clip",
+        "description": "Anti-cheat protection against moving through solid objects.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatHit": {
+        "label": "Hit Detection",
+        "description": "Anti-cheat protection for character hits.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPacketException": {
+        "label": "Packet Exceptions",
+        "description": "Anti-cheat protection for invalid network packets.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPermission": {
+        "label": "Permissions",
+        "description": "Anti-cheat protection for player permissions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatXP": {
+        "label": "XP Validation",
+        "description": "Anti-cheat protection for player XP.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSafeHouse": {
+        "label": "Safehouse Protection",
+        "description": "Anti-cheat protection for safehouses.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPlayer": {
+        "label": "Player Validation",
+        "description": "Anti-cheat protection for player actions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatChecksum": {
+        "label": "Checksum Validation",
+        "description": "Anti-cheat protection for file checksums.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      }
+    },
+    "logging": {
+      "ClientCommandFilter": {
+        "label": "Command Log Filter",
+        "description": "Semicolon-separated list of commands to exclude from cmd.txt log. Use -vehicle.* to exclude all vehicle, +vehicle.installPart to include specific."
+      },
+      "ClientActionLogs": {
+        "label": "Client Action Logs",
+        "description": "Semicolon-separated list of actions written to ClientActionLogs.txt."
+      },
+      "PerkLogs": {
+        "label": "Perk Level Logging",
+        "description": "Track changes in player perk levels in PerkLog.txt."
+      }
+    }
+  },
+  "sandboxSettings": {
+    "time": {
+      "DayLength": {
+        "label": "Tageslänge:",
+        "description": "How long a day lasts.",
+        "options": {
+          "1": {
+            "label": "15 Minuten"
+          },
+          "2": {
+            "label": "30 Minuten"
+          },
+          "3": {
+            "label": "1 Stunde"
+          },
+          "4": {
+            "label": "1 Stunde, 30 Minuten"
+          },
+          "5": {
+            "label": "2 Stunden"
+          },
+          "6": {
+            "label": "3 Stunden"
+          },
+          "7": {
+            "label": "4 Stunden"
+          },
+          "8": {
+            "label": "5 Stunden"
+          },
+          "9": {
+            "label": "12 Stunden"
+          },
+          "10": {
+            "label": "Echtzeit"
+          },
+          "11": {
+            "label": "8 stunden"
+          },
+          "12": {
+            "label": "9 stunden"
+          },
+          "13": {
+            "label": "10 stunden"
+          },
+          "14": {
+            "label": "11 stunden"
+          },
+          "15": {
+            "label": "12 stunden"
+          },
+          "16": {
+            "label": "13 stunden"
+          },
+          "17": {
+            "label": "14 stunden"
+          },
+          "18": {
+            "label": "15 stunden"
+          },
+          "19": {
+            "label": "16 stunden"
+          },
+          "20": {
+            "label": "17 stunden"
+          },
+          "21": {
+            "label": "18 stunden"
+          },
+          "22": {
+            "label": "19 stunden"
+          },
+          "23": {
+            "label": "20 stunden"
+          },
+          "24": {
+            "label": "21 stunden"
+          },
+          "25": {
+            "label": "22 stunden"
+          },
+          "26": {
+            "label": "23 stunden"
+          },
+          "27": {
+            "label": "Echtzeit"
+          }
+        }
+      },
+      "StartYear": {
+        "label": "Startjahr:",
+        "description": "Which year the game starts in."
+      },
+      "StartMonth": {
+        "label": "Startmonat:",
+        "description": "Which month the game starts in (1=Jan, 12=Dec).",
+        "options": {
+          "1": {
+            "label": "Januar"
+          },
+          "2": {
+            "label": "Februar"
+          },
+          "3": {
+            "label": "März"
+          },
+          "4": {
+            "label": "April"
+          },
+          "5": {
+            "label": "Mai"
+          },
+          "6": {
+            "label": "Juni"
+          },
+          "7": {
+            "label": "Juli"
+          },
+          "8": {
+            "label": "August"
+          },
+          "9": {
+            "label": "September"
+          },
+          "10": {
+            "label": "Oktober"
+          },
+          "11": {
+            "label": "November"
+          },
+          "12": {
+            "label": "Dezember"
+          }
+        }
+      },
+      "StartDay": {
+        "label": "Starttag:",
+        "description": "Which day of the month the game starts on."
+      },
+      "StartTime": {
+        "label": "Startzeit:",
+        "description": "What time of day the game starts.",
+        "options": {
+          "1": {
+            "label": "7 Uhr"
+          },
+          "2": {
+            "label": "9 Uhr"
+          },
+          "3": {
+            "label": "12 Uhr"
+          },
+          "4": {
+            "label": "13 Uhr"
+          },
+          "5": {
+            "label": "15 Uhr"
+          },
+          "6": {
+            "label": "21 Uhr"
+          },
+          "7": {
+            "label": "0 Uhr"
+          },
+          "8": {
+            "label": "2 Uhr"
+          },
+          "9": {
+            "label": "5 Uhr"
+          }
+        }
+      }
+    },
+    "population": {
+      "Zombies": {
+        "label": "Zombie Anzahl:",
+        "description": "Initial zombie population level. Also sets Population Multiplier in Advanced Zombie Options.",
+        "options": {
+          "1": {
+            "label": "Verrückt"
+          },
+          "2": {
+            "label": "Sehr Viele"
+          },
+          "3": {
+            "label": "Viele"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Wenige"
+          },
+          "6": {
+            "label": "Keine"
+          }
+        }
+      },
+      "Distribution": {
+        "label": "Zombie Verteilung:",
+        "description": "How zombies are distributed across the map.",
+        "options": {
+          "1": {
+            "label": "Mehr in Städten"
+          },
+          "2": {
+            "label": "Gleichmäßig"
+          }
+        }
+      },
+      "ZombieVoronoiNoise": {
+        "label": "Randomize Distribution",
+        "description": "Apply randomization to zombie distribution."
+      },
+      "ZombieRespawn": {
+        "label": "Zombie Rückkehr Zeitraum:",
+        "description": "How frequently new zombies are added to the world.",
+        "options": {
+          "1": {
+            "label": "Oft"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Keine"
+          }
+        }
+      },
+      "ZombieMigrate": {
+        "label": "Zombie-Migration",
+        "description": "Zombies can migrate to empty cells."
+      }
+    },
+    "loot": {
+      "LootItemRemovalList": {
+        "label": "Entfernungsliste von Beutegegenständen",
+        "description": "Comma-separated item types removed from the world by the loot cleanup system."
+      },
+      "FoodLootNew": {
+        "label": "Verderbliche Lebensmittel",
+        "description": "Any food that can rot or spoil."
+      },
+      "CannedFoodLootNew": {
+        "label": "Nicht verderbliche Lebensmittel",
+        "description": "Canned and dried food, beverages."
+      },
+      "LiteratureLootNew": {
+        "label": "Literatur",
+        "description": "All readable items including books, fliers, and newspapers."
+      },
+      "SkillBookLoot": {
+        "label": "Skill Book Loot",
+        "description": "Books that provide skill XP multipliers."
+      },
+      "RecipeResourceLoot": {
+        "label": "Recipe Loot",
+        "description": "Items that teach recipes."
+      },
+      "MedicalLootNew": {
+        "label": "Medizin",
+        "description": "Medicine, bandages, and first aid tools."
+      },
+      "SurvivalGearsLootNew": {
+        "label": "Überlebensausrüstung",
+        "description": "Fishing rods, tents, camping gear."
+      },
+      "WeaponLootNew": {
+        "label": "Nahkampfwaffen",
+        "description": "Weapons that are not tools in other categories."
+      },
+      "RangedWeaponLootNew": {
+        "label": "Schusswaffen",
+        "description": "Ranged weapons and weapon attachments."
+      },
+      "AmmoLootNew": {
+        "label": "Munition",
+        "description": "Loose ammo, boxes, and magazines."
+      },
+      "MechanicsLootNew": {
+        "label": "Kfz-Mechanik",
+        "description": "Vehicle parts and installation tools."
+      },
+      "ClothingLootNew": {
+        "label": "Kleidung",
+        "description": "All wearable items that are not containers."
+      },
+      "ContainerLootNew": {
+        "label": "Taschen",
+        "description": "Backpacks and wearable/equippable containers."
+      },
+      "KeyLootNew": {
+        "label": "Schlüssel",
+        "description": "Keys for buildings/cars, key rings, and locks."
+      },
+      "MediaLootNew": {
+        "label": "Medien",
+        "description": "VHS tapes and CDs."
+      },
+      "MementoLootNew": {
+        "label": "Andenken",
+        "description": "Spiffo items, plushies, and collectible keepsakes."
+      },
+      "CookwareLootNew": {
+        "label": "Kochen",
+        "description": "Cooking items including those that can be weapons. Does not include food."
+      },
+      "MaterialLootNew": {
+        "label": "Material",
+        "description": "Crafting and building materials."
+      },
+      "FarmingLootNew": {
+        "label": "Landwirtschaft",
+        "description": "Seeds, trowels, shovels, and agriculture tools."
+      },
+      "ToolLootNew": {
+        "label": "Werkzeuge",
+        "description": "Tools not in other categories like Mechanics or Farming."
+      },
+      "OtherLootNew": {
+        "label": "Andere",
+        "description": "Everything else. Also affects foraging in Town/Road zones."
+      },
+      "RollsMultiplier": {
+        "label": "Wurf-Multiplikator [!]",
+        "description": "Multiplier for loot table rolls. Higher values may affect performance. NOT recommended to change."
+      },
+      "RemoveStoryLoot": {
+        "label": "Ungewollte Geschichten-Beute entfernen",
+        "description": "Items on the removal list will not spawn in world stories."
+      },
+      "RemoveZombieLoot": {
+        "label": "Ungewollte Zombie-Beute entfernen",
+        "description": "Items on the removal list will not spawn on zombies."
+      },
+      "ZombiePopLootEffect": {
+        "label": "Beuteeffekt durch Zombie-Population",
+        "description": "If > 0, loot increases relative to nearby zombies, multiplied by this value."
+      },
+      "HoursForLootRespawn": {
+        "label": "Stunden für wiederkehrende Beute",
+        "description": "Hours after which containers respawn loot. 0 = never."
+      },
+      "MaxItemsForLootRespawn": {
+        "label": "Maximale Gegenstandsanzahl für wiederkehrende Beute",
+        "description": "Containers with this many items or more will not respawn loot."
+      },
+      "ConstructionPreventsLootRespawn": {
+        "label": "Bau verhindert Beute-Respawn",
+        "description": "Player constructions near containers prevent loot respawn."
+      },
+      "SeenHoursPreventLootRespawn": {
+        "label": "Beute-Gesehen-Verhinderungszeit:",
+        "description": "Hours a zone must be unvisited before loot respawns. 0 = disabled."
+      }
+    },
+    "lootRarity": {
+      "InsaneLootFactor": {
+        "label": "Beutefaktor unfassbar selten",
+        "description": "Spawn rate for Insane rarity items."
+      },
+      "ExtremeLootFactor": {
+        "label": "Beutefaktor extrem selten",
+        "description": "Spawn rate for Extreme rarity items."
+      },
+      "RareLootFactor": {
+        "label": "Beutefaktor selten",
+        "description": "Spawn rate for Rare rarity items."
+      },
+      "NormalLootFactor": {
+        "label": "Beutefaktor normal",
+        "description": "Spawn rate for Normal rarity items."
+      },
+      "CommonLootFactor": {
+        "label": "Beutefaktor häufig",
+        "description": "Spawn rate for Common rarity items."
+      },
+      "AbundantLootFactor": {
+        "label": "Beutefaktor reichlich",
+        "description": "Spawn rate for Abundant rarity items."
+      },
+      "MaximumLooted": {
+        "label": "Maximale Chance auf bereits geplünderter Häuser",
+        "description": "Chance that any building is already looted when found."
+      },
+      "DaysUntilMaximumLooted": {
+        "label": "Tage bis Chance auf geplünderter Häuser",
+        "description": "Days before Maximum Looted Building Chance is reached."
+      },
+      "RuralLooted": {
+        "label": "Wahrscheinlichkeit geplünderter Häuser auf dem Land",
+        "description": "Chance that any rural building is already looted."
+      },
+      "MaximumDiminishedLoot": {
+        "label": "Prozentsatz maximal verringerter Beute",
+        "description": "Maximum loot that won't spawn when diminished days reached."
+      },
+      "DaysUntilMaximumDiminishedLoot": {
+        "label": "Tage bis zur maximal verringerten Beute",
+        "description": "Days before Maximum Diminished Loot is reached."
+      },
+      "MaximumLootedBuildingRooms": {
+        "label": "Maximale Anzahl geplünderter Räume",
+        "description": "Buildings with more than this many rooms will not be auto-looted."
+      }
+    },
+    "environment": {
+      "DayNightCycle": {
+        "label": "Day/Night Cycle",
+        "description": "Whether time of day changes naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Endless Day"
+          },
+          "3": {
+            "label": "Endless Night"
+          }
+        }
+      },
+      "ClimateCycle": {
+        "label": "Weather Cycle",
+        "description": "Whether weather changes or remains fixed.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "No Weather"
+          },
+          "3": {
+            "label": "Endless Rain"
+          },
+          "4": {
+            "label": "Endless Storm"
+          },
+          "5": {
+            "label": "Endless Snow"
+          },
+          "6": {
+            "label": "Endless Blizzard"
+          }
+        }
+      },
+      "FogCycle": {
+        "label": "Fog Cycle",
+        "description": "Whether fog occurs naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "No Fog"
+          },
+          "3": {
+            "label": "Endless Fog"
+          }
+        }
+      },
+      "WaterShut": {
+        "label": "Wasserausfall:",
+        "description": "When plumbing fixtures stop being infinite water sources.",
+        "options": {
+          "1": {
+            "label": "Sofort"
+          },
+          "2": {
+            "label": "0-30 Tage"
+          },
+          "3": {
+            "label": "0-2 Monate"
+          },
+          "4": {
+            "label": "0-6 Monate"
+          },
+          "5": {
+            "label": "0-1 Jahr"
+          },
+          "6": {
+            "label": "0-5 Jahre"
+          },
+          "7": {
+            "label": "2-6 Monate"
+          },
+          "8": {
+            "label": "6-12 Monate"
+          },
+          "9": {
+            "label": "Deaktiviert"
+          }
+        }
+      },
+      "ElecShut": {
+        "label": "Stromausfall:",
+        "description": "When the world's electricity turns off.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "14 - 30 Days"
+          },
+          "3": {
+            "label": "14 Days - 2 Months"
+          },
+          "4": {
+            "label": "14 Days - 6 Months"
+          },
+          "5": {
+            "label": "14 Days - 1 Year"
+          },
+          "6": {
+            "label": "14 Days - 5 Years"
+          },
+          "7": {
+            "label": "2 - 6 Months"
+          },
+          "8": {
+            "label": "6 - 12 Months"
+          },
+          "9": {
+            "label": "Disabled"
+          }
+        }
+      },
+      "AlarmDecay": {
+        "label": "Alarmbatterie-Abnutzung",
+        "description": "How long alarm batteries last after power shuts off.",
+        "options": {
+          "1": {
+            "label": "Sofort"
+          },
+          "2": {
+            "label": "0-30 Tage"
+          },
+          "3": {
+            "label": "0-2 Monate"
+          },
+          "4": {
+            "label": "0-6 Monate"
+          },
+          "5": {
+            "label": "0-1 Jahr"
+          },
+          "6": {
+            "label": "0-5 Jahre"
+          },
+          "7": {
+            "label": "2-6 Monate"
+          },
+          "8": {
+            "label": "6-12 Monate"
+          },
+          "9": {
+            "label": "Deaktiviert"
+          }
+        }
+      },
+      "WaterShutModifier": {
+        "label": "Water Shutoff Modifier",
+        "description": "Fine-tune water shutoff timing in days."
+      },
+      "ElecShutModifier": {
+        "label": "Electricity Shutoff Modifier",
+        "description": "Fine-tune electricity shutoff timing in days."
+      },
+      "AlarmDecayModifier": {
+        "label": "Alarm Decay Modifier",
+        "description": "Fine-tune alarm battery decay timing in days."
+      },
+      "Temperature": {
+        "label": "Temperatur:",
+        "description": "Global temperature setting.",
+        "options": {
+          "1": {
+            "label": "Sehr kalt"
+          },
+          "2": {
+            "label": "Kalt"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Heiß"
+          },
+          "5": {
+            "label": "Sehr heiß"
+          }
+        }
+      },
+      "Rain": {
+        "label": "Regen:",
+        "description": "How often it rains.",
+        "options": {
+          "1": {
+            "label": "Sehr trocken"
+          },
+          "2": {
+            "label": "Trocken"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Regnerisch"
+          },
+          "5": {
+            "label": "Sehr regnerisch"
+          }
+        }
+      },
+      "ErosionSpeed": {
+        "label": "Erosionsgeschwindigkeit:",
+        "description": "How fast nature reclaims the world.",
+        "options": {
+          "1": {
+            "label": "Sehr schnell (20 Tage)"
+          },
+          "2": {
+            "label": "Schnell (50 Tage)"
+          },
+          "3": {
+            "label": "Normal (100 Tage)"
+          },
+          "4": {
+            "label": "Langsam (200 Tage)"
+          },
+          "5": {
+            "label": "Sehr langsam (500 Tage)"
+          }
+        }
+      },
+      "ErosionDays": {
+        "label": "Erosionstage:",
+        "description": "Custom erosion days. 0 = use Erosion Speed option."
+      },
+      "MaxFogIntensity": {
+        "label": "Maximale Nebelintensität:",
+        "description": "Maximum intensity of fog.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Mäßig"
+          },
+          "3": {
+            "label": "Niedrig"
+          },
+          "4": {
+            "label": "Keine"
+          }
+        }
+      },
+      "MaxRainFxIntensity": {
+        "label": "Maximale Regeneffekt Intensität:",
+        "description": "Maximum intensity of rain effects.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Mäßig"
+          },
+          "3": {
+            "label": "Niedrig"
+          }
+        }
+      },
+      "EnableSnowOnGround": {
+        "label": "Schnee auf dem Boden:",
+        "description": "Whether snow accumulates on the ground."
+      },
+      "NightDarkness": {
+        "label": "Dunkelheit während der Nacht:",
+        "description": "Ambient lighting level at night.",
+        "options": {
+          "1": {
+            "label": "Pechschwarz"
+          },
+          "2": {
+            "label": "Dunkel"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hell"
+          }
+        }
+      },
+      "NightLength": {
+        "label": "Länge der Nächte",
+        "description": "Duration from dusk to dawn.",
+        "options": {
+          "1": {
+            "label": "Immer Nacht"
+          },
+          "2": {
+            "label": "Lang"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Kurz"
+          },
+          "5": {
+            "label": "Immer Tag"
+          }
+        }
+      },
+      "TimeSinceApo": {
+        "label": "Vergangene Monate seit Beginn der Apokalypse:",
+        "description": "How long after the apocalypse the game begins. Affects erosion and food spoilage.",
+        "options": {
+          "1": {
+            "label": "0"
+          },
+          "2": {
+            "label": "1"
+          },
+          "3": {
+            "label": "2"
+          },
+          "4": {
+            "label": "3"
+          },
+          "5": {
+            "label": "4"
+          },
+          "6": {
+            "label": "5"
+          },
+          "7": {
+            "label": "6"
+          },
+          "8": {
+            "label": "7"
+          },
+          "9": {
+            "label": "8"
+          },
+          "10": {
+            "label": "9"
+          },
+          "11": {
+            "label": "10"
+          },
+          "12": {
+            "label": "11"
+          },
+          "13": {
+            "label": "12"
+          }
+        }
+      },
+      "FireSpread": {
+        "label": "Brandausbreitung",
+        "description": "Whether fires spread when started."
+      }
+    },
+    "survival": {
+      "StatsDecrease": {
+        "label": "Lebensmittelverderb:",
+        "description": "How fast hunger, thirst, and fatigue decrease.",
+        "options": {
+          "1": {
+            "label": "Sehr schnell"
+          },
+          "2": {
+            "label": "Schnell"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Langsam"
+          },
+          "5": {
+            "label": "Sehr langsam"
+          }
+        }
+      },
+      "Nutrition": {
+        "label": "Ernährung:",
+        "description": "Food nutrition affects player weight and condition."
+      },
+      "FoodRotSpeed": {
+        "label": "Lebensmittelverderb:",
+        "description": "How fast food spoils.",
+        "options": {
+          "1": {
+            "label": "Sehr schnell"
+          },
+          "2": {
+            "label": "Schnell"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Langsam"
+          },
+          "5": {
+            "label": "Sehr langsam"
+          }
+        }
+      },
+      "FridgeFactor": {
+        "label": "Kühlwirkung:",
+        "description": "How effective fridges are at preserving food.",
+        "options": {
+          "1": {
+            "label": "Sehr wenig"
+          },
+          "2": {
+            "label": "Wenig"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hoch"
+          },
+          "5": {
+            "label": "Sehr hoch"
+          },
+          "6": {
+            "label": "Kein Verfall"
+          }
+        }
+      },
+      "StarterKit": {
+        "label": "Startausrüstung:",
+        "description": "Spawn with chips, water bottle, backpack, bat, and hammer."
+      },
+      "CharacterFreePoints": {
+        "label": "Freie Eigenschaftspunkte:",
+        "description": "Extra free points during character creation."
+      },
+      "BoneFracture": {
+        "label": "Knochenbruch:",
+        "description": "Survivors can get broken limbs from impacts, falls, etc."
+      },
+      "InjurySeverity": {
+        "label": "Verletzungsgrad:",
+        "description": "Impact of injuries and healing time.",
+        "options": {
+          "1": {
+            "label": "Niedrig"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Hoch"
+          }
+        }
+      },
+      "EndRegen": {
+        "label": "Lebensmittelverderb:",
+        "description": "Recovery from tiredness after actions.",
+        "options": {
+          "1": {
+            "label": "Sehr schnell"
+          },
+          "2": {
+            "label": "Schnell"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Langsam"
+          },
+          "5": {
+            "label": "Sehr langsam"
+          }
+        }
+      },
+      "HoursForCorpseRemoval": {
+        "label": "Entfernungszeit der Leichen:",
+        "description": "Hours before zombie corpses disappear. 0 = no maggots spawn."
+      },
+      "DecayingCorpseHealthImpact": {
+        "label": "Gesundheitswirkung verfaulender Leichen:",
+        "description": "Impact of nearby decaying bodies on health/emotions.",
+        "options": {
+          "1": {
+            "label": "Keine"
+          },
+          "2": {
+            "label": "Niedrig"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hoch"
+          },
+          "5": {
+            "label": "Verrückt"
+          }
+        }
+      },
+      "ZombieHealthImpact": {
+        "label": "Auswirkungen von Zombies auf die Gesundheit",
+        "description": "Whether living zombies also affect player health/emotions."
+      },
+      "BloodLevel": {
+        "label": "Blutstärke",
+        "description": "How much blood sprays on surfaces.",
+        "options": {
+          "1": {
+            "label": "Keine"
+          },
+          "2": {
+            "label": "Niedrig"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hoch"
+          },
+          "5": {
+            "label": "Blutregen"
+          }
+        }
+      },
+      "ClothingDegradation": {
+        "label": "Kleiderabnutzung",
+        "description": "How quickly clothing degrades and gets dirty.",
+        "options": {
+          "1": {
+            "label": "Deaktiviert"
+          },
+          "2": {
+            "label": "Langsam"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Schnell"
+          }
+        }
+      },
+      "DaysForRottenFoodRemoval": {
+        "label": "Verdorbene-Nahrungsmittel-Entfernung:",
+        "description": "Days before rotten food is removed. -1 = never."
+      },
+      "AllClothesUnlocked": {
+        "label": "Alle Kleidungsstücke freigeschaltet",
+        "description": "Select from every clothing item during character creation."
+      },
+      "EnableTaintedWaterText": {
+        "label": "Aktivieren Sie den Tooltip „Verdorbenes Wasser“.",
+        "description": "Show warning marking tainted water."
+      },
+      "EnablePoisoning": {
+        "label": "Vergiftung aktivieren",
+        "description": "Whether poison can be added to food.",
+        "options": {
+          "1": {
+            "label": "Richtig"
+          },
+          "2": {
+            "label": "Falsch"
+          },
+          "3": {
+            "label": "Nur die Bleichmittelvergiftung ist deaktiviert"
+          }
+        }
+      },
+      "MaggotSpawn": {
+        "label": "Leichenmaden-Spawn",
+        "description": "When maggots spawn in corpses.",
+        "options": {
+          "1": {
+            "label": "In und um Körper"
+          },
+          "2": {
+            "label": "Nur in Körpern"
+          },
+          "3": {
+            "label": "Niemals"
+          }
+        }
+      },
+      "MuscleStrainFactor": {
+        "label": "Muskelverspannungsfaktor",
+        "description": "Multiplier for muscle strain from swinging weapons or carrying heavy loads."
+      },
+      "DiscomfortFactor": {
+        "label": "Unwohlsein Faktor",
+        "description": "Multiplier for discomfort from worn items."
+      },
+      "WoundInfectionFactor": {
+        "label": "Schaden durch Wundinfektion",
+        "description": "Damage from serious wound infections. 0 = disabled."
+      },
+      "NoBlackClothes": {
+        "label": "Keine schwarze Kleidung",
+        "description": "Prevent randomized clothing from becoming near-black."
+      },
+      "EasyClimbing": {
+        "label": "Leichtes Klettern",
+        "description": "Disable failure chances when climbing sheet ropes or walls."
+      },
+      "NegativeTraitsPenalty": {
+        "label": "Strafe auf negative Eigenschaften",
+        "description": "Diminishing returns on bonus points from negative traits.",
+        "options": {
+          "1": {
+            "label": "Keine"
+          },
+          "2": {
+            "label": "1 Punkt Strafe pro 3 gewählte negative Eigenschaften"
+          },
+          "3": {
+            "label": "1 Punkt Strafe pro 2 gewählte negative Eigenschaften"
+          },
+          "4": {
+            "label": "1 Punkt Strafe für jede gewählte negative Eigenschaft nach der ersten"
+          }
+        }
+      },
+      "MinutesPerPage": {
+        "label": "Minuten pro Buchseite",
+        "description": "In-game minutes to read one page of a skill book."
+      },
+      "LiteratureCooldown": {
+        "label": "Literatur-Abklingzeit in Tagen",
+        "description": "Days before previously read literature can benefit again."
+      },
+      "LevelForMediaXPCutoff": {
+        "label": "Höchststufe Medien-EP",
+        "description": "Skill level at which TV/VHS/media no longer provides XP."
+      },
+      "LevelForDismantleXPCutoff": {
+        "label": "Höchststufe für Zerlegen-EP",
+        "description": "Skill level at which scrapping furniture gives no XP."
+      },
+      "BloodSplatLifespanDays": {
+        "label": "Blutspritzer-Lebensdauer",
+        "description": "Days before blood splats disappear. 0 = never."
+      },
+      "MetaKnowledge": {
+        "label": "Medien-Metawissen",
+        "description": "How unseen/unread media is displayed.",
+        "options": {
+          "1": {
+            "label": "Vollständig angezeigt"
+          },
+          "2": {
+            "label": "Als ??? angezeigt"
+          },
+          "3": {
+            "label": "Komplett ausgeblendet"
+          }
+        }
+      },
+      "SeeNotLearntRecipe": {
+        "label": "Sichtbarkeit unbekannter Rezepte",
+        "description": "See station recipes even if not yet learned."
+      },
+      "LightBulbLifespan": {
+        "label": "Lebensdauer der Glühbirne",
+        "description": "Higher = bulbs last longer. 0 = never break."
+      },
+      "MaximumFireFuelHours": {
+        "label": "Maximale Menge an Brennstoff",
+        "description": "Max hours of fuel for campfires, wood stoves, etc."
+      },
+      "Alarm": {
+        "label": "Hausalarm:",
+        "description": "Frequency of residential alarms.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Extrem selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          }
+        }
+      },
+      "LockedHouses": {
+        "label": "Hausalarm:",
+        "description": "Frequency of locked houses.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Extrem selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          }
+        }
+      },
+      "Helicopter": {
+        "label": "Helikopter:",
+        "description": "Helicopter frequency.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Einmal"
+          },
+          "3": {
+            "label": "Manchmal"
+          },
+          "4": {
+            "label": "Oft"
+          }
+        }
+      },
+      "MetaEvent": {
+        "label": "Meta-Event:",
+        "description": "Distant gunshots, screams, etc.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Manchmal"
+          },
+          "3": {
+            "label": "Oft"
+          }
+        }
+      },
+      "SleepingEvent": {
+        "label": "Schlaf-Event:",
+        "description": "Events that happen while sleeping.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Manchmal"
+          },
+          "3": {
+            "label": "Oft"
+          }
+        }
+      },
+      "NatureAbundance": {
+        "label": "Ernteertrag",
+        "description": "Governs abundance of wild foods, medicinal plants, etc.",
+        "options": {
+          "1": {
+            "label": "Sehr schlecht"
+          },
+          "2": {
+            "label": "Schlecht"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Reichlich"
+          },
+          "5": {
+            "label": "Sehr reichlich"
+          }
+        }
+      },
+      "FishAbundance": {
+        "label": "Ernteertrag",
+        "description": "Governs abundance of fish.",
+        "options": {
+          "1": {
+            "label": "Sehr schlecht"
+          },
+          "2": {
+            "label": "Schlecht"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Reichlich"
+          },
+          "5": {
+            "label": "Sehr reichlich"
+          }
+        }
+      },
+      "AnnotatedMapChance": {
+        "label": "Kommentierte Karten:",
+        "description": "Chance of finding maps annotated with local features.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Extrem selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          }
+        }
+      },
+      "ConstructionBonusPoints": {
+        "label": "Spieler-Baukonstruktions-Stärke:",
+        "description": "Extra points for carpentry/metalworking constructions."
+      },
+      "GeneratorSpawning": {
+        "label": "Generator-Spawn:",
+        "description": "How many generators spawn in the world.",
+        "options": {
+          "1": {
+            "label": "Extrem selten"
+          },
+          "2": {
+            "label": "Selten"
+          },
+          "3": {
+            "label": "Manchmal"
+          },
+          "4": {
+            "label": "Oft"
+          },
+          "5": {
+            "label": "Sehr oft"
+          },
+          "6": {
+            "label": "Häufig"
+          },
+          "7": {
+            "label": "Reichlich"
+          }
+        }
+      },
+      "GeneratorFuelConsumption": {
+        "label": "Generator-Krafstoffverbrauch:",
+        "description": "How fast generators consume fuel."
+      },
+      "AllowExteriorGenerator": {
+        "label": "Generatoren im Außenbereich:",
+        "description": "Generators can be placed outdoors and inside tents."
+      },
+      "GeneratorTileRange": {
+        "label": "Generator Tile Range",
+        "description": "Horizontal range of generators in tiles."
+      },
+      "GeneratorVerticalPowerRange": {
+        "label": "Generator Vertical Range",
+        "description": "Vertical range of generators in floors."
+      },
+      "CompostTime": {
+        "label": "Kompostzeit:",
+        "description": "How long composting takes.",
+        "options": {
+          "1": {
+            "label": "1 Woche"
+          },
+          "2": {
+            "label": "2 Wochen"
+          },
+          "3": {
+            "label": "3 Wochen"
+          },
+          "4": {
+            "label": "4 Wochen"
+          },
+          "5": {
+            "label": "6 Wochen"
+          },
+          "6": {
+            "label": "8 Wochen"
+          },
+          "7": {
+            "label": "10 Wochen"
+          },
+          "8": {
+            "label": "12 Wochen"
+          }
+        }
+      },
+      "AttackBlockMovements": {
+        "label": "Nahkampf Bewegungsunterbrechung:",
+        "description": "Player can't move while performing melee attacks."
+      },
+      "WorldItemRemovalList": {
+        "label": "Lösch-Liste für Items in Spielwelt",
+        "description": "Types of items removed from world (comma separated, e.g. Base.Vest)."
+      },
+      "HoursForWorldItemRemoval": {
+        "label": "Stunden für die Lösch-Liste",
+        "description": "Hours before listed items disappear from world. 0 = disabled."
+      },
+      "ItemRemovalListBlacklistToggle": {
+        "label": "Entfernungsliste als Whitelist",
+        "description": "If true, removal list acts as blacklist (remove everything except listed). Default is whitelist."
+      }
+    },
+    "combat": {
+      "MultiHitZombies": {
+        "label": "Waffen Mehrfachtreffer:",
+        "description": "A melee weapon can hit multiple zombies in one swing."
+      },
+      "RearVulnerability": {
+        "label": "Rückseiten Verwundbarkeit:",
+        "description": "Zombies take more damage when attacked from behind.",
+        "options": {
+          "1": {
+            "label": "Niedrig"
+          },
+          "2": {
+            "label": "Mittel"
+          },
+          "3": {
+            "label": "Hoch"
+          }
+        }
+      },
+      "FirearmUseDamageChance": {
+        "label": "Schaden-Wahrscheinlichkeit bei Waffennutzung",
+        "description": "Chance of weapon condition loss per use. 0 = never."
+      },
+      "FirearmNoiseMultiplier": {
+        "label": "Schusswaffenlautstärke-Multiplikator",
+        "description": "Multiplier for gun noise attracting zombies."
+      },
+      "FirearmJamMultiplier": {
+        "label": "Multiplikator für klemmende Schusswaffen",
+        "description": "Multiplier for jamming chance."
+      },
+      "FirearmMoodleMultiplier": {
+        "label": "Schusswaffen-Moodle-Multiplikator",
+        "description": "Multiplier for panic/stress from gun use."
+      },
+      "FirearmWeatherMultiplier": {
+        "label": "Schusswaffen-Wetter-Multiplikator",
+        "description": "Multiplier for rain affecting gun condition."
+      },
+      "FirearmHeadGearEffect": {
+        "label": "Schusswaffen-Kopfbedeckungseffekt",
+        "description": "How much head-covering gear like helmets affects firearm aim/shoulder."
+      }
+    },
+    "vehicles": {
+      "EnableVehicles": {
+        "label": "Fahrzeuge aktivieren:",
+        "description": "Whether vehicles spawn and can be used."
+      },
+      "CarSpawnRate": {
+        "label": "Fahrzeug-Spawn Rate:",
+        "description": "How many vehicles spawn.",
+        "options": {
+          "1": {
+            "label": "Keine"
+          },
+          "2": {
+            "label": "Sehr wenig"
+          },
+          "3": {
+            "label": "Wenig"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Hoch"
+          }
+        }
+      },
+      "VehicleEasyUse": {
+        "label": "Einfache Fahrzeugbedienung",
+        "description": "All vehicles are automatic and easy to start."
+      },
+      "InitialGas": {
+        "label": "Start-Tankfüllung:",
+        "description": "How full the gas tank of discovered vehicles will be.",
+        "options": {
+          "1": {
+            "label": "Sehr niedrig"
+          },
+          "2": {
+            "label": "Niedrig"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hoch"
+          },
+          "5": {
+            "label": "Sehr hoch"
+          },
+          "6": {
+            "label": "Voll"
+          }
+        }
+      },
+      "FuelStationGasInfinite": {
+        "label": "Zapfsäulen sind unendlich",
+        "description": "If enabled, gas pumps will never run out of fuel."
+      },
+      "FuelStationGasMin": {
+        "label": "Anfängliche Mindestmenge Benzin in Zapfsäulen",
+        "description": "The minimum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasMax": {
+        "label": "Anfängliche Höchstmenge Benzin in Zapfsäulen",
+        "description": "The maximum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasEmptyChance": {
+        "label": "Wahrscheinlichkeit, dass eine Zapfsäule beim Start leer ist",
+        "description": "The chance, as a percentage, that individual gas pumps will initially have no fuel."
+      },
+      "LockedCar": {
+        "label": "Abgesperrte Fahrzeuge:",
+        "description": "Chance of vehicle doors being locked.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Extrem selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          }
+        }
+      },
+      "CarGasConsumption": {
+        "label": "Benzinverbrauch:",
+        "description": "Rate of fuel consumption in vehicles."
+      },
+      "CarGeneralCondition": {
+        "label": "Allgemeinzustand:",
+        "description": "Initial condition of discovered vehicles.",
+        "options": {
+          "1": {
+            "label": "Sehr niedrig"
+          },
+          "2": {
+            "label": "Niedrig"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hoch"
+          },
+          "5": {
+            "label": "Sehr hoch"
+          }
+        }
+      },
+      "CarDamageOnImpact": {
+        "label": "Beschädigungen bei Aufprall:",
+        "description": "Damage vehicles take from collisions.",
+        "options": {
+          "1": {
+            "label": "Sehr niedrig"
+          },
+          "2": {
+            "label": "Niedrig"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hoch"
+          },
+          "5": {
+            "label": "Sehr hoch"
+          }
+        }
+      },
+      "DamageToPlayerFromHitByACar": {
+        "label": "Schaden am Spieler durch einen Autounfall:",
+        "description": "How much damage players receive from vehicle impacts.",
+        "options": {
+          "1": {
+            "label": "Keine"
+          },
+          "2": {
+            "label": "Niedrig"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hoch"
+          },
+          "5": {
+            "label": "Sehr hoch"
+          }
+        }
+      },
+      "TrafficJam": {
+        "label": "Fahrzeugwracks:",
+        "description": "Whether traffic jams spawn on roads."
+      },
+      "CarAlarm": {
+        "label": "Autoalarm:",
+        "description": "Chance of vehicles having active alarms.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Extrem selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          }
+        }
+      },
+      "PlayerDamageFromCrash": {
+        "label": "Spielerschaden durch Unfall:",
+        "description": "If the player can get injured from being in a car accident."
+      },
+      "SirenShutoffHours": {
+        "label": "Sirenenabschaltzeit:",
+        "description": "Hours before vehicle siren batteries die. 0 = instant."
+      },
+      "ChanceHasGas": {
+        "label": "Kraftstoff-Chance:",
+        "description": "The chance of finding a vehicle with gas in its tank.",
+        "options": {
+          "1": {
+            "label": "Niedrig"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Hoch"
+          }
+        }
+      },
+      "RecentlySurvivorVehicles": {
+        "label": "Fahrzeuge kürzlich Überlebender",
+        "description": "Whether a player can discover a car that has been cared for after the Knox infection struck.",
+        "options": {
+          "1": {
+            "label": "Keine"
+          },
+          "2": {
+            "label": "Niedrig"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hoch"
+          }
+        }
+      },
+      "ZombieAttractionMultiplier": {
+        "label": "Zombie Anziehungskraft-Multiplikator",
+        "description": "Multiplier for vehicle sounds attracting zombies."
+      },
+      "SirenEffectsZombies": {
+        "label": "Fahrzeugsirenen ziehen Zombies an",
+        "description": "If zombies will head towards the sound of vehicle sirens."
+      }
+    },
+    "animals": {
+      "AnimalStatsModifier": {
+        "label": "Geschwingdigkeit der Wertabnahme",
+        "description": "Speed at which animal stats (hunger, thirst etc.) reduce.",
+        "options": {
+          "1": {
+            "label": "Ultra schnell"
+          },
+          "2": {
+            "label": "Sehr schnell"
+          },
+          "3": {
+            "label": "Schnell"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Langsam"
+          },
+          "6": {
+            "label": "Sehr langsam"
+          }
+        }
+      },
+      "AnimalMetaStatsModifier": {
+        "label": "Tempo der Meta-Statistikabnahme",
+        "description": "Speed at which animal stats reduce while in meta (overworld).",
+        "options": {
+          "1": {
+            "label": "Ultra schnell"
+          },
+          "2": {
+            "label": "Sehr schnell"
+          },
+          "3": {
+            "label": "Schnell"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Langsam"
+          },
+          "6": {
+            "label": "Sehr langsam"
+          }
+        }
+      },
+      "AnimalPregnancyTime": {
+        "label": "Trächtigkeitsdauer",
+        "description": "How long animals will be pregnant for before giving birth.",
+        "options": {
+          "1": {
+            "label": "Ultra schnell"
+          },
+          "2": {
+            "label": "Sehr schnell"
+          },
+          "3": {
+            "label": "Schnell"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Langsam"
+          },
+          "6": {
+            "label": "Sehr langsam"
+          }
+        }
+      },
+      "AnimalAgeModifier": {
+        "label": "Alterungsmodifikator",
+        "description": "Speed at which animals age.",
+        "options": {
+          "1": {
+            "label": "Sehr schnell"
+          },
+          "2": {
+            "label": "Schnell"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalMilkIncModifier": {
+        "label": "Milchproduktion",
+        "description": "Speed of milk production.",
+        "options": {
+          "1": {
+            "label": "Ultra schnell"
+          },
+          "2": {
+            "label": "Sehr schnell"
+          },
+          "3": {
+            "label": "Schnell"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Langsam"
+          },
+          "6": {
+            "label": "Sehr langsam"
+          }
+        }
+      },
+      "AnimalWoolIncModifier": {
+        "label": "Wollproduktion",
+        "description": "Speed of wool production.",
+        "options": {
+          "1": {
+            "label": "Ultra schnell"
+          },
+          "2": {
+            "label": "Sehr schnell"
+          },
+          "3": {
+            "label": "Schnell"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Langsam"
+          },
+          "6": {
+            "label": "Sehr langsam"
+          }
+        }
+      },
+      "AnimalRanchChance": {
+        "label": "Wahrscheinlichkeit von Tier-Spawns",
+        "description": "The chance of finding animals in farms.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Extrem selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          },
+          "7": {
+            "label": "Immer"
+          }
+        }
+      },
+      "AnimalGrassRegrowTime": {
+        "label": "Graswachstum",
+        "description": "The number of hours grass will regrow after being eaten by an animal or cut by the player."
+      },
+      "AnimalMetaPredator": {
+        "label": "Meta-Raubtier",
+        "description": "If a meta fox may attack your chickens if the hutch door is left open at night."
+      },
+      "AnimalMatingSeason": {
+        "label": "Brutsaison",
+        "description": "Restrict mating to spring/early summer or allow year-round."
+      },
+      "AnimalEggHatch": {
+        "label": "Eier-Schlüpfzeit",
+        "description": "How long before baby animals will hatch from eggs.",
+        "options": {
+          "1": {
+            "label": "Ultra schnell"
+          },
+          "2": {
+            "label": "Sehr schnell"
+          },
+          "3": {
+            "label": "Schnell"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Langsam"
+          },
+          "6": {
+            "label": "Sehr langsam"
+          }
+        }
+      },
+      "AnimalSoundAttractZombies": {
+        "label": "Tiere ziehen Zombies an",
+        "description": "If true, animal calls will attract nearby zombies."
+      },
+      "AnimalTrackChance": {
+        "label": "Animal Track Chance",
+        "description": "The chance of animals leaving tracks.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Extrem selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          }
+        }
+      },
+      "AnimalPathChance": {
+        "label": "Animal Path Chance",
+        "description": "The chance of creating a path for animals to be hunted.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Extrem selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          }
+        }
+      },
+      "MaximumRatIndex": {
+        "label": "Maximale Ungezieferdichte",
+        "description": "Maximum rat infestation level. 0 = no rats."
+      },
+      "DaysUntilMaximumRatIndex": {
+        "label": "Tage bis zur maximalen Ungezieferdichte",
+        "description": "How many days until rat population peaks."
+      },
+      "Farming": {
+        "label": "Landwirtschaft-Multiplikator",
+        "description": "Rate at which Agriculture skill levels up.",
+        "options": {
+          "1": {
+            "label": "Sehr niedrig"
+          },
+          "2": {
+            "label": "Niedrig"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hoch"
+          },
+          "5": {
+            "label": "Sehr hoch"
+          }
+        }
+      },
+      "PlantResilience": {
+        "label": "Pflanzen Belastbarkeit:",
+        "description": "How tough crops are.",
+        "options": {
+          "1": {
+            "label": "Sehr hoch"
+          },
+          "2": {
+            "label": "Hoch"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Niedrig"
+          },
+          "5": {
+            "label": "Sehr niedrig"
+          }
+        }
+      },
+      "PlantAbundance": {
+        "label": "Landwirtschaftlicher Ertrag",
+        "description": "How much food crops produce.",
+        "options": {
+          "1": {
+            "label": "Sehr schlecht"
+          },
+          "2": {
+            "label": "Schlecht"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Reichlich"
+          },
+          "5": {
+            "label": "Sehr reichlich"
+          }
+        }
+      },
+      "KillInsideCrops": {
+        "label": "Nutzpflanzen sterben in Innenräumen",
+        "description": "Whether stepping on indoor crops destroys them."
+      },
+      "PlantGrowingSeasons": {
+        "label": "Nutzpflanzen Jahreszeit",
+        "description": "Restrict crop growth to appropriate seasons."
+      },
+      "PlaceDirtAboveground": {
+        "label": "Farmen nicht auf Bodenebene [!]",
+        "description": "Allow placing dirt on built floors above ground."
+      },
+      "FarmingSpeedNew": {
+        "label": "Wachstumsrate",
+        "description": "Growth speed multiplier. Lower = faster."
+      },
+      "FarmingAmountNew": {
+        "label": "Ernteertrag",
+        "description": "Multiplier for number of crops harvested."
+      },
+      "ClayLakeChance": {
+        "label": "Clay Lake Chance",
+        "description": "Chance of finding clay when digging near lakes."
+      },
+      "ClayRiverChance": {
+        "label": "Clay River Chance",
+        "description": "Chance of finding clay when digging near rivers."
+      }
+    },
+    "world": {
+      "SurvivorHouseChance": {
+        "label": "Generierte Häuser:",
+        "description": "Chance of finding survivor-modified houses.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Extrem selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          },
+          "7": {
+            "label": "Immer versuchen"
+          }
+        }
+      },
+      "VehicleStoryChance": {
+        "label": "Zufällige Fahrzeug Geschichten Chance:",
+        "description": "Chance of finding story-decorated vehicles.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Extrem selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          }
+        }
+      },
+      "ZoneStoryChance": {
+        "label": "Randomisierte Zone-Story Chance",
+        "description": "Chance of encountering zone-based story setups.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Extrem selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          }
+        }
+      }
+    },
+    "zombieLore": {
+      "Speed": {
+        "label": "Geschwindigkeit:",
+        "description": "How fast zombies move.",
+        "options": {
+          "1": {
+            "label": "Sprinter"
+          },
+          "2": {
+            "label": "Schnelle Schlurfer"
+          },
+          "3": {
+            "label": "Schlurfer"
+          },
+          "4": {
+            "label": "zufällig"
+          }
+        }
+      },
+      "Strength": {
+        "label": "Stärke-Multiplikator",
+        "description": "How strong zombies are.",
+        "options": {
+          "1": {
+            "label": "Übermenschlich"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Schwach"
+          },
+          "4": {
+            "label": "zufällig"
+          }
+        }
+      },
+      "Toughness": {
+        "label": "Härte:",
+        "description": "How tough zombies are to kill.",
+        "options": {
+          "1": {
+            "label": "Zäh"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Zerbrechlich"
+          },
+          "4": {
+            "label": "zufällig"
+          }
+        }
+      },
+      "Transmission": {
+        "label": "Übertragungswege:",
+        "description": "How the zombie infection spreads.",
+        "options": {
+          "1": {
+            "label": "Blut + Speichel"
+          },
+          "2": {
+            "label": "Nur Speichel"
+          },
+          "3": {
+            "label": "Jeder ist Infiziert"
+          },
+          "4": {
+            "label": "Keine"
+          }
+        }
+      },
+      "Mortality": {
+        "label": "Infektions-Sterblichkeit:",
+        "description": "How deadly the infection is.",
+        "options": {
+          "1": {
+            "label": "Sofort"
+          },
+          "2": {
+            "label": "0-30 Sekunden"
+          },
+          "3": {
+            "label": "0-1 Minute"
+          },
+          "4": {
+            "label": "0-12 Stunden"
+          },
+          "5": {
+            "label": "2-3 Tage"
+          },
+          "6": {
+            "label": "1-2 Wochen"
+          },
+          "7": {
+            "label": "Nie"
+          }
+        }
+      },
+      "Cognition": {
+        "label": "Kenntnisse:",
+        "description": "What zombies can interact with.",
+        "options": {
+          "1": {
+            "label": "Navigieren + Verwendung von Türen"
+          },
+          "2": {
+            "label": "Navigieren"
+          },
+          "3": {
+            "label": "Einfache Navigation"
+          },
+          "4": {
+            "label": "zufällig"
+          }
+        }
+      },
+      "Memory": {
+        "label": "Gedächtnis:",
+        "description": "How long zombies remember where they last saw a target.",
+        "options": {
+          "1": {
+            "label": "Lang"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Kurz"
+          },
+          "4": {
+            "label": "Keine"
+          },
+          "5": {
+            "label": "Zufällig"
+          },
+          "6": {
+            "label": "Zufällig zwischen Normal und Keine"
+          }
+        }
+      },
+      "Sight": {
+        "label": "Sicht:",
+        "description": "How far zombies can see targets.",
+        "options": {
+          "1": {
+            "label": "Adleraugen"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Schlecht"
+          },
+          "4": {
+            "label": "Zufällig"
+          },
+          "5": {
+            "label": "Zufällig zwischen Normal und Schlecht"
+          }
+        }
+      },
+      "Hearing": {
+        "label": "Hören:",
+        "description": "How well zombies can hear sounds.",
+        "options": {
+          "1": {
+            "label": "Sehr gut"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Schlecht"
+          },
+          "4": {
+            "label": "Zufällig"
+          },
+          "5": {
+            "label": "Zufällig zwischen Normal und Schlecht"
+          }
+        }
+      },
+      "SpottedLogic": {
+        "label": "Neues Tarnungssystem",
+        "description": "How zombies decide to chase their targets."
+      },
+      "ThumpNoChasing": {
+        "label": "Angriff auf Umwelt",
+        "description": "Zombies that weren't chasing a player will not thump constructions."
+      },
+      "ThumpOnConstruction": {
+        "label": "Schaden an Konstruktionen:",
+        "description": "Zombies thump player-built structures."
+      },
+      "ActiveOnly": {
+        "label": "Tag/Nacht Aktivität:",
+        "description": "Zombies active during specific times.",
+        "options": {
+          "1": {
+            "label": "Beides"
+          },
+          "2": {
+            "label": "Nacht"
+          },
+          "3": {
+            "label": "Tag"
+          }
+        }
+      },
+      "TriggerHouseAlarm": {
+        "label": "Zombie-Hausalarm-Auslösen:",
+        "description": "Whether zombies can randomly trigger house alarms."
+      },
+      "ZombiesDragDown": {
+        "label": "Herunterziehen:",
+        "description": "Multiple zombies can pull player to ground."
+      },
+      "ZombiesCrawlersDragDown": {
+        "label": "Herunterziehen (Kriecher)",
+        "description": "Crawlers can drag players down."
+      },
+      "ZombiesFenceLunge": {
+        "label": "Zaun Attacken",
+        "description": "Zombies can lunge at you over fences."
+      },
+      "ZombiesArmorFactor": {
+        "label": "Zombie-Rüstungsfaktor",
+        "description": "Multiplier for zombie armor from clothing. Higher = harder to kill."
+      },
+      "ZombiesMaxDefense": {
+        "label": "Maximale Verteidigungskraft von Zombierüstung",
+        "description": "Maximum defense value zombies can have."
+      },
+      "ChanceOfAttachedWeapon": {
+        "label": "Chance auf eine angebrachte Waffe",
+        "description": "Chance a zombie has a weapon stuck in them."
+      },
+      "ZombiesFallDamage": {
+        "label": "Schadensmultiplikator für fallende Zombies",
+        "description": "Whether zombies can die from falling."
+      },
+      "DisableFakeDead": {
+        "label": "Reanimation von vorgetäuschten toten Zombies",
+        "description": "No zombies will pretend to be dead.",
+        "options": {
+          "1": {
+            "label": "Einige Zombies auf der Welt werden vorgeben, tot zu sein"
+          },
+          "2": {
+            "label": "Einige Zombies auf der Welt, sowie einige, die Sie „töten“, können vorgeben, tot zu sein"
+          },
+          "3": {
+            "label": "Zombies werden niemals vorgeben, tot zu sein"
+          }
+        }
+      },
+      "PlayerSpawnZombieRemoval": {
+        "label": "Spawn Zone Clear",
+        "description": "Distance around spawn points cleared of zombies.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Small"
+          },
+          "3": {
+            "label": "Medium"
+          },
+          "4": {
+            "label": "Large"
+          },
+          "5": {
+            "label": "Very Large"
+          }
+        }
+      },
+      "FenceThumpersRequired": {
+        "label": "Zombies To Damage Fences",
+        "description": "Minimum zombies needed to damage a fence."
+      },
+      "FenceDamageMultiplier": {
+        "label": "Fence Damage Multiplier",
+        "description": "Multiplier for damage zombies do to fences."
+      },
+      "DoorOpeningPercentage": {
+        "label": "Random Door Opening Amount",
+        "description": "Percentage of zombies that can open doors when cognition allows it."
+      },
+      "CrawlUnderVehicle": {
+        "label": "Unter Fahrzeuge durchkriechen",
+        "description": "Crawler zombies can crawl under vehicles.",
+        "options": {
+          "1": {
+            "label": "Nie"
+          },
+          "2": {
+            "label": "Sehr selten"
+          },
+          "3": {
+            "label": "Selten"
+          },
+          "4": {
+            "label": "Manchmal"
+          },
+          "5": {
+            "label": "Oft"
+          },
+          "6": {
+            "label": "Sehr oft"
+          },
+          "7": {
+            "label": "Immer"
+          }
+        }
+      },
+      "SprinterPercentage": {
+        "label": "Random Sprinter Amount",
+        "description": "Percentage of sprinter zombies when Speed is set to Random."
+      },
+      "Reanimate": {
+        "label": "Reanimierungszeit:",
+        "description": "Dead zombies can get back up after being killed.",
+        "options": {
+          "1": {
+            "label": "Sofort"
+          },
+          "2": {
+            "label": "0-30 Sekunden"
+          },
+          "3": {
+            "label": "0-1 Minute"
+          },
+          "4": {
+            "label": "0-12 Stunden"
+          },
+          "5": {
+            "label": "2-3 Tage"
+          },
+          "6": {
+            "label": "1-2 Wochen"
+          }
+        }
+      }
+    },
+    "zombiePopulation": {
+      "PopulationMultiplier": {
+        "label": "Bevölkerungsdichte Multiplikator",
+        "description": "Overall zombie population multiplier."
+      },
+      "PopulationStartMultiplier": {
+        "label": "Bevölkerungsdichte Start-Multiplikator",
+        "description": "Zombie population at game start."
+      },
+      "PopulationPeakMultiplier": {
+        "label": "Bevölkerungsdichte Höhepunkt-Multiplikator",
+        "description": "Zombie population at peak day."
+      },
+      "PopulationPeakDay": {
+        "label": "Bevölkerungsdichte Höhepunkt-Tag",
+        "description": "Day when zombie population peaks."
+      },
+      "RespawnHours": {
+        "label": "Wiedererschein-Stunden",
+        "description": "Hours before zombies respawn. 0 = disabled."
+      },
+      "RespawnUnseenHours": {
+        "label": "Wiedererschein-Ungesehen-Stunden",
+        "description": "Hours a chunk must be unseen before respawn."
+      },
+      "RespawnMultiplier": {
+        "label": "Wiedererschein-Multiplikator",
+        "description": "Fraction of population that respawns."
+      },
+      "RedistributeHours": {
+        "label": "Umverteilungs-Stunden",
+        "description": "Hours between zombie redistribution across the map."
+      },
+      "FollowSoundDistance": {
+        "label": "Folge-Geräusch-Abstand",
+        "description": "How far zombies will follow sounds in cells."
+      },
+      "RallyGroupSize": {
+        "label": "Gruppengröße",
+        "description": "Base number of zombies in rally groups."
+      },
+      "RallyGroupSizeVariance": {
+        "label": "Gruppengrößen-Varianz",
+        "description": "The amount, as a percentage, that zombie groups can vary in size from the default (both larger and smaller)."
+      },
+      "RallyTravelDistance": {
+        "label": "Reise Distanz",
+        "description": "How far rally groups travel in cells."
+      },
+      "RallyGroupSeparation": {
+        "label": "Gruppen Distanz",
+        "description": "Minimum distance between rally groups."
+      },
+      "RallyGroupRadius": {
+        "label": "Gruppen Radius",
+        "description": "Radius of area a rally group spreads across."
+      },
+      "ZombiesCountBeforeDelete": {
+        "label": "Zombie-Anzahl bevor Löschung",
+        "description": "Minimum zombie count in a cell before deletion can occur."
+      }
+    },
+    "xpMultipliers": {
+      "Global": {
+        "label": "Globaler Multiplikator",
+        "description": "The rate at which all skills level up."
+      },
+      "GlobalToggle": {
+        "label": "Globalen Multiplikator anwenden",
+        "description": "When enabled, all skills will use the Global Multiplier instead of individual values."
+      },
+      "Sprinting": {
+        "label": "Sprint-Multiplikator",
+        "description": "XP multiplier for Sprinting skill."
+      },
+      "Lightfoot": {
+        "label": "Leichtfüßig-Multiplikator",
+        "description": "XP multiplier for Lightfoot skill."
+      },
+      "Nimble": {
+        "label": "Flink-Multiplikator",
+        "description": "XP multiplier for Nimble skill."
+      },
+      "Sneak": {
+        "label": "Schleichen-Multiplikator",
+        "description": "XP multiplier for Sneaking skill."
+      },
+      "Axe": {
+        "label": "Axt-Multiplikator",
+        "description": "XP multiplier for Axe skill."
+      },
+      "Blunt": {
+        "label": "Stumpfwaffe-Multiplikator",
+        "description": "XP multiplier for Blunt skill."
+      },
+      "SmallBlade": {
+        "label": "Kurze-Klingenwaffe-Multiplikator",
+        "description": "XP multiplier for Small Blade skill."
+      },
+      "LongBlade": {
+        "label": "Lange-Klingenwaffe-Multiplikator",
+        "description": "XP multiplier for Long Blade skill."
+      },
+      "SmallBlunt": {
+        "label": "Kurze-Stumpfwaffe-Multiplikator",
+        "description": "XP multiplier for Small Blunt skill."
+      },
+      "Aiming": {
+        "label": "Zielen-Multiplikator",
+        "description": "XP multiplier for Aiming skill."
+      },
+      "Reloading": {
+        "label": "Nachladen-Multiplikator",
+        "description": "XP multiplier for Reloading skill."
+      },
+      "Fishing": {
+        "label": "Angel-Multiplikator",
+        "description": "XP multiplier for Fishing skill."
+      },
+      "Trapping": {
+        "label": "Fallenstellen-Multiplikator",
+        "description": "XP multiplier for Trapping skill."
+      },
+      "Woodwork": {
+        "label": "Tischlerei-Multiplikator",
+        "description": "XP multiplier for Carpentry skill."
+      },
+      "Cooking": {
+        "label": "Kochen-Multiplikator",
+        "description": "XP multiplier for Cooking skill."
+      },
+      "Farming": {
+        "label": "Landwirtschaft-Multiplikator",
+        "description": "XP multiplier for Farming skill."
+      },
+      "Doctor": {
+        "label": "Erste-Hilfe-Multiplikator",
+        "description": "XP multiplier for First Aid skill."
+      },
+      "Electricity": {
+        "label": "Elektrotechnik-Multiplikator",
+        "description": "XP multiplier for Electricity skill."
+      },
+      "MetalWelding": {
+        "label": "Schweißen-Multiplikator",
+        "description": "XP multiplier for Metalworking skill."
+      },
+      "Mechanics": {
+        "label": "Kfz-Mechanik-Multiplikator",
+        "description": "XP multiplier for Mechanics skill."
+      },
+      "Tailoring": {
+        "label": "Schneidern-Multiplikator",
+        "description": "XP multiplier for Tailoring skill."
+      },
+      "Maintenance": {
+        "label": "Instandhaltung-Multiplikator",
+        "description": "XP multiplier for Maintenance skill."
+      },
+      "PlantScavenging": {
+        "label": "Nahrungssuche-Multiplikator",
+        "description": "XP multiplier for Foraging skill."
+      },
+      "Fitness": {
+        "label": "Fitness-Multiplikator:",
+        "description": "XP multiplier for Fitness skill."
+      },
+      "Strength": {
+        "label": "Stärke-Multiplikator",
+        "description": "XP multiplier for Strength skill."
+      },
+      "FlintKnapping": {
+        "label": "Feuersteinbearbeitung-Multiplikator",
+        "description": "XP multiplier for Knapping skill."
+      },
+      "Carving": {
+        "label": "Schnitzen-Multiplikator",
+        "description": "XP multiplier for Carving skill."
+      },
+      "Tracking": {
+        "label": "Spurensuche-Multiplikator",
+        "description": "XP multiplier for Tracking skill."
+      },
+      "Butchering": {
+        "label": "Schlachtung-Multiplikator",
+        "description": "XP multiplier for Butchering skill."
+      },
+      "Glassmaking": {
+        "label": "Glassmaking XP",
+        "description": "XP multiplier for Glassmaking skill."
+      },
+      "Husbandry": {
+        "label": "Tierpflege-Multiplikator",
+        "description": "XP multiplier for Animal Husbandry skill."
+      },
+      "Spear": {
+        "label": "Speer-Multiplikator",
+        "description": "XP multiplier for Spear skill."
+      },
+      "Masonry": {
+        "label": "Maurerei-Multiplikator",
+        "description": "XP multiplier for Masonry skill."
+      },
+      "Pottery": {
+        "label": "Töpferei-Multiplikator",
+        "description": "XP multiplier for Pottery skill."
+      },
+      "Blacksmith": {
+        "label": "Metallbearbeitung-Multiplikator",
+        "description": "XP multiplier for Blacksmith skill."
+      }
+    },
+    "map": {
+      "AllowMiniMap": {
+        "label": "Minikarte zulassen",
+        "description": "Whether the in-game mini map is available."
+      },
+      "AllowWorldMap": {
+        "label": "Weltkarte zulassen",
+        "description": "Whether the in-game world map is available."
+      },
+      "MapAllKnown": {
+        "label": "Alles beim Start bekannt",
+        "description": "The entire map is revealed from the start."
+      },
+      "MapNeedsLight": {
+        "label": "Zum Lesen der Karte wird Licht benötigt",
+        "description": "Map can only be used when there is enough light."
+      }
+    },
+    "basement": {
+      "SpawnFrequency": {
+        "label": "Basement Spawn Frequency",
+        "description": "How often basements appear in buildings.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Very Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      }
+    }
+  },
+  "iniCategories": {
+    "general": {
+      "label": "General"
+    },
+    "network": {
+      "label": "Network & Ports"
+    },
+    "steam": {
+      "label": "Steam Integration"
+    },
+    "discord": {
+      "label": "Discord"
+    },
+    "rcon": {
+      "label": "RCON"
+    },
+    "voice": {
+      "label": "Voice Chat"
+    },
+    "players": {
+      "label": "Players & Accounts"
+    },
+    "safehouse": {
+      "label": "Safehouses"
+    },
+    "chat": {
+      "label": "Chat & Communication"
+    },
+    "pvp": {
+      "label": "PvP & Safety"
+    },
+    "moderation": {
+      "label": "Moderation"
+    },
+    "anticheat": {
+      "label": "Anti-Cheat"
+    },
+    "loot": {
+      "label": "Loot & Items"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "mods": {
+      "label": "Mods & Workshop"
+    },
+    "radio": {
+      "label": "Radio"
+    },
+    "war": {
+      "label": "Faction War"
+    },
+    "backups": {
+      "label": "Backups"
+    },
+    "logging": {
+      "label": "Logging"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
+  },
+  "iniCategoryGroups": {
+    "identity": {
+      "label": "Identity"
+    },
+    "connectivity": {
+      "label": "Connectivity"
+    },
+    "players": {
+      "label": "Players"
+    },
+    "gameplay": {
+      "label": "Gameplay"
+    },
+    "ops": {
+      "label": "Ops"
+    }
+  },
+  "sandboxCategories": {
+    "time": {
+      "label": "Time & Season"
+    },
+    "environment": {
+      "label": "Environment & Weather"
+    },
+    "world": {
+      "label": "World & Stories"
+    },
+    "map": {
+      "label": "Map & Navigation"
+    },
+    "zombieLore": {
+      "label": "Zombie Behavior"
+    },
+    "zombiePopulation": {
+      "label": "Zombie Population"
+    },
+    "population": {
+      "label": "Population & Distribution"
+    },
+    "survival": {
+      "label": "Survival & Health"
+    },
+    "combat": {
+      "label": "Combat & Firearms"
+    },
+    "loot": {
+      "label": "Loot & Resources"
+    },
+    "lootRarity": {
+      "label": "Loot Rarity"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "animals": {
+      "label": "Animals & Farming"
+    },
+    "xpMultipliers": {
+      "label": "XP Multipliers"
+    },
+    "basement": {
+      "label": "Basements"
+    }
+  },
+  "sandboxCategoryGroups": {
+    "world": {
+      "label": "World"
+    },
+    "zombies": {
+      "label": "Zombies"
+    },
+    "survival": {
+      "label": "Survival"
+    },
+    "resources": {
+      "label": "Resources"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
   }
 }

--- a/client/src/locales/en/serverconfig.json
+++ b/client/src/locales/en/serverconfig.json
@@ -386,5 +386,3651 @@
     "deletedTitle": "Deleted",
     "templateDeletedDesc": "Saved config \"{{name}}\" deleted",
     "deleteTemplateFailed": "Failed to delete saved config."
+  },
+  "iniSettings": {
+    "general": {
+      "PublicName": {
+        "label": "Server Name",
+        "description": "Your server name as shown to the public."
+      },
+      "PublicDescription": {
+        "label": "Server Description",
+        "description": "The description that people can see while browsing your server."
+      },
+      "Public": {
+        "label": "Public Server",
+        "description": "Can your server be seen on Steam server browser."
+      },
+      "Open": {
+        "label": "Open (No Whitelist)",
+        "description": "Open to all players without requiring whitelist."
+      },
+      "Password": {
+        "label": "Server Password",
+        "description": "Password required to join the server. Leave empty for no password."
+      },
+      "MaxPlayers": {
+        "label": "Max Players",
+        "description": "Maximum allowed number of players."
+      },
+      "PauseEmpty": {
+        "label": "Pause When Empty",
+        "description": "The server will pause when no players are logged in."
+      },
+      "ServerWelcomeMessage": {
+        "label": "Welcome Message",
+        "description": "The welcome message displayed to players after connecting. Use <LINE> for new lines."
+      },
+      "Map": {
+        "label": "Map",
+        "description": "The map you're playing on. Default is Muldraugh, KY."
+      },
+      "SaveWorldEveryMinutes": {
+        "label": "Auto-Save Interval",
+        "description": "Auto-save world every X minutes. 0 = never."
+      },
+      "AnnounceDeath": {
+        "label": "Announce Deaths",
+        "description": "Server-wide announcement when a character dies."
+      },
+      "AnnounceAnimalDeath": {
+        "label": "Announce Animal Deaths",
+        "description": "Display a global chat message when an animal dies."
+      },
+      "Seed": {
+        "label": "World Seed",
+        "description": "The worldgen seed used to generate the world. Changing this requires deleting map_worldgen.bin."
+      }
+    },
+    "network": {
+      "DefaultPort": {
+        "label": "Game Port",
+        "description": "The port players will use to connect to your server. Must be open on your router."
+      },
+      "UPnP": {
+        "label": "Enable UPnP",
+        "description": "Enable UPnP for automatic port forwarding."
+      },
+      "PingFrequency": {
+        "label": "Ping Frequency",
+        "description": "How often the server checks connection to players (seconds)."
+      },
+      "PingLimit": {
+        "label": "Ping Limit",
+        "description": "Ping limit before being kicked (milliseconds). 100 to disable."
+      },
+      "DenyLoginOnOverloadedServer": {
+        "label": "Deny Login When Overloaded",
+        "description": "Prevent new connections when server is overloaded."
+      },
+      "SpeedLimit": {
+        "label": "Speed Limit",
+        "description": "Maximum movement speed allowed."
+      },
+      "UseTCPForMapDownloads": {
+        "label": "Use TCP for Map Downloads",
+        "description": "Use TCP instead of UDP for map downloads."
+      },
+      "MaxPacketsPerSecond": {
+        "label": "Max Packets Per Second",
+        "description": "Cap on packets per second sent to a connected client. Higher values increase bandwidth use; lower values may cause stutter under load."
+      },
+      "UDPPort": {
+        "label": "UDP Port",
+        "description": "Second port used for UDP connections."
+      },
+      "LoginQueueEnabled": {
+        "label": "Login Queue",
+        "description": "Enable a login queue when the server is full."
+      },
+      "LoginQueueConnectTimeout": {
+        "label": "Login Queue Timeout",
+        "description": "Seconds before a queued connection times out."
+      },
+      "server_browser_announced_ip": {
+        "label": "Announced IP",
+        "description": "IP address broadcast to the server browser. For multi-IP setups like server farms."
+      },
+      "MultiplayerStatisticsPeriod": {
+        "label": "Statistics Period",
+        "description": "Multiplayer statistics update period in seconds. 0 = disabled."
+      }
+    },
+    "pvp": {
+      "PVP": {
+        "label": "Enable PvP",
+        "description": "Allow player vs player combat (each player can still toggle their own PvP)."
+      },
+      "SafetySystem": {
+        "label": "Safety System",
+        "description": "If PvP is enabled, allows players to toggle their own PvP on/off."
+      },
+      "ShowSafety": {
+        "label": "Show Safety Status",
+        "description": "Show skull icon for players with safety off."
+      },
+      "SafetyToggleTimer": {
+        "label": "Safety Toggle Timer",
+        "description": "Time in seconds to switch between PvP on and off."
+      },
+      "SafetyCooldownTimer": {
+        "label": "Safety Cooldown Timer",
+        "description": "Time in seconds before you can toggle safety again."
+      },
+      "PVPMeleeWhileHitReaction": {
+        "label": "Melee While Hit Reaction",
+        "description": "Allow melee attacks during hit reaction in PvP."
+      },
+      "PVPMeleeDamageModifier": {
+        "label": "PvP Melee Damage %",
+        "description": "Melee damage modifier for PvP (percentage)."
+      },
+      "PVPFirearmDamageModifier": {
+        "label": "PvP Firearm Damage %",
+        "description": "Firearm damage modifier for PvP (percentage)."
+      },
+      "PlayerBumpPlayer": {
+        "label": "Player Collision",
+        "description": "Players can bump into each other."
+      },
+      "PVPLogToolChat": {
+        "label": "Log PvP to Chat",
+        "description": "PvP events are logged to admin chat."
+      },
+      "PVPLogToolFile": {
+        "label": "Log PvP to File",
+        "description": "PvP events are logged to a file."
+      },
+      "SafetyDisconnectDelay": {
+        "label": "Safety Disconnect Delay",
+        "description": "Seconds before PvP safety mode resets on disconnect."
+      }
+    },
+    "chat": {
+      "GlobalChat": {
+        "label": "Enable Global Chat",
+        "description": "Enable /all command for server-wide chat."
+      },
+      "ChatStreams": {
+        "label": "Chat Streams",
+        "description": "Enabled chat streams: s=say, r=radio, a=admin, w=whisper, y=yell, sh=safehouse, f=faction, all=global."
+      },
+      "DisplayUserName": {
+        "label": "Display Usernames",
+        "description": "Show player usernames above their heads and in chat."
+      },
+      "ShowFirstAndLastName": {
+        "label": "Show Character Names",
+        "description": "Display character first and last name instead of username."
+      },
+      "MouseOverToSeeDisplayName": {
+        "label": "Mouse Over for Name",
+        "description": "Require mouse hover to see player names."
+      },
+      "HidePlayersBehindYou": {
+        "label": "Hide Players Behind You",
+        "description": "Hide player names for players behind your character."
+      },
+      "AllowNonAsciiUsername": {
+        "label": "Allow Non-ASCII Usernames",
+        "description": "Allow usernames with non-ASCII characters."
+      },
+      "BanKickGlobalSound": {
+        "label": "Ban/Kick Sound",
+        "description": "Play global sound when a player is banned or kicked."
+      },
+      "UsernameDisguises": {
+        "label": "Username Disguises",
+        "description": "Allow players to disguise their username."
+      },
+      "HideDisguisedUserName": {
+        "label": "Hide Disguised Names",
+        "description": "Hide the real username of disguised players."
+      },
+      "ChatMessageCharacterLimit": {
+        "label": "Chat Character Limit",
+        "description": "Maximum characters per chat message."
+      },
+      "ChatMessageSlowModeTime": {
+        "label": "Chat Slow Mode",
+        "description": "Seconds between allowed chat messages per player."
+      }
+    },
+    "players": {
+      "MaxAccountsPerUser": {
+        "label": "Max Accounts Per User",
+        "description": "Limit accounts per Steam user. 0 = unlimited."
+      },
+      "DropOffWhiteListAfterDeath": {
+        "label": "Remove From Whitelist On Death",
+        "description": "Remove player from whitelist if their character dies."
+      },
+      "KickFastPlayers": {
+        "label": "Kick Speed Hackers",
+        "description": "Kick players moving faster than possible. May be buggy."
+      },
+      "SpawnPoint": {
+        "label": "Spawn Point",
+        "description": "Custom spawn point coordinates (X,Y,Z). 0,0,0 for default."
+      },
+      "SpawnItems": {
+        "label": "Spawn Items",
+        "description": "Items new characters spawn with (comma-separated, e.g., Base.BaseballBat,Base.WaterBottleFull)."
+      },
+      "SleepAllowed": {
+        "label": "Allow Sleep",
+        "description": "Whether sleeping is allowed."
+      },
+      "SleepNeeded": {
+        "label": "Sleep Required",
+        "description": "Whether players need to sleep when exhausted."
+      },
+      "PlayerRespawnWithSelf": {
+        "label": "Respawn at Death Location",
+        "description": "Allow respawning at death location."
+      },
+      "PlayerRespawnWithOther": {
+        "label": "Respawn with Partner",
+        "description": "Enable spawning at splitscreen partner location."
+      },
+      "PlayerSaveOnDamage": {
+        "label": "Save on Damage",
+        "description": "Save player state when they take damage."
+      },
+      "Faction": {
+        "label": "Enable Factions",
+        "description": "Allow creation and use of factions."
+      },
+      "FactionDaySurvivedToCreate": {
+        "label": "Days to Create Faction",
+        "description": "Days a player must survive to create a faction."
+      },
+      "FactionPlayersRequiredForTag": {
+        "label": "Players for Faction Tag",
+        "description": "Players required in faction to show tag."
+      },
+      "AllowTradeUI": {
+        "label": "Allow Trading",
+        "description": "Allow players to directly trade with one another."
+      },
+      "AllowCoop": {
+        "label": "Allow Co-op",
+        "description": "Allow co-op/splitscreen players to join."
+      },
+      "KnockedDownAllowed": {
+        "label": "Knocked Down",
+        "description": "Allow players to be knocked down. WIP: may cause visual desync."
+      },
+      "SneakModeHideFromOtherPlayers": {
+        "label": "Sneak Hides From Players",
+        "description": "Players in sneak mode are hidden from other players."
+      },
+      "MapRemotePlayerVisibility": {
+        "label": "Map Player Visibility",
+        "description": "Who can see other players on the in-game map.",
+        "options": {
+          "1": {
+            "label": "Hidden"
+          },
+          "2": {
+            "label": "Friends Only"
+          },
+          "3": {
+            "label": "Friends and Nearby Players"
+          },
+          "4": {
+            "label": "Everyone"
+          }
+        }
+      },
+      "DisableScoreboard": {
+        "label": "Disable Scoreboard",
+        "description": "Disable the in-game scoreboard."
+      },
+      "HideAdminsInPlayerList": {
+        "label": "Hide Admins in Player List",
+        "description": "Hide admin accounts from the player list."
+      }
+    },
+    "safehouse": {
+      "PlayerSafehouse": {
+        "label": "Enable Safehouses",
+        "description": "Allow players to claim safehouses."
+      },
+      "AdminSafehouse": {
+        "label": "Admin Safehouses",
+        "description": "Allow admins to have safehouses."
+      },
+      "SafehouseAllowTrepass": {
+        "label": "Allow Trespass",
+        "description": "Allow non-members to enter safehouses without invite."
+      },
+      "SafehouseAllowFire": {
+        "label": "Allow Fire Damage",
+        "description": "Allow fire to damage safehouses."
+      },
+      "SafehouseAllowLoot": {
+        "label": "Allow Looting",
+        "description": "Allow non-members to take items from safehouses."
+      },
+      "SafehouseAllowRespawn": {
+        "label": "Allow Safehouse Respawn",
+        "description": "Players can respawn in their safehouse."
+      },
+      "SafehouseDaySurvivedToClaim": {
+        "label": "Days to Claim Safehouse",
+        "description": "Days a player must survive before claiming a safehouse."
+      },
+      "SafeHouseRemovalTime": {
+        "label": "Safehouse Removal Time",
+        "description": "Real-time hours of inactivity before removal from safehouse."
+      },
+      "DisableSafehouseWhenOwnerConnected": {
+        "label": "Disable When Owner Online",
+        "description": "Disable safehouse protection when the owner is connected. (Renamed from DisableSafehouseWhenPlayerConnected in the Dec 2025 MP patch.)"
+      },
+      "SafehouseAllowNonResidential": {
+        "label": "Allow Non-Residential",
+        "description": "Allow players to claim non-residential buildings as safehouses."
+      },
+      "SafehouseDisableDisguises": {
+        "label": "Disable Disguises in Safehouse",
+        "description": "Disable username disguises inside safehouses."
+      },
+      "MaxSafezoneSize": {
+        "label": "Max Safezone Size",
+        "description": "Maximum tile size for safezones."
+      }
+    },
+    "loot": {
+      "ItemNumbersLimitPerContainer": {
+        "label": "Container Item Limit",
+        "description": "Max items per container. 0 = unlimited."
+      },
+      "TrashDeleteAll": {
+        "label": "Delete All Trash",
+        "description": "Delete all items when placed in trash."
+      },
+      "RemovePlayerCorpsesOnCorpseRemoval": {
+        "label": "Remove Player Corpses",
+        "description": "Remove player corpses when corpse removal runs."
+      },
+      "AllowDestructionBySledgehammer": {
+        "label": "Sledgehammer Destruction",
+        "description": "Allow players to destroy world objects with sledgehammer."
+      },
+      "NoFire": {
+        "label": "Disable Fire",
+        "description": "Disable all fires except campfires."
+      },
+      "SafehousePreventsLootRespawn": {
+        "label": "Safehouse Blocks Loot Respawn",
+        "description": "Items will not respawn in buildings claimed as safehouses."
+      },
+      "SledgehammerOnlyInSafehouse": {
+        "label": "Sledgehammer Only in Safehouse",
+        "description": "Restrict sledgehammer destruction to safehouses only. Requires Sledgehammer Destruction enabled."
+      }
+    },
+    "mods": {
+      "Mods": {
+        "label": "Mods",
+        "description": "List of installed mod IDs (semicolon-separated)."
+      },
+      "WorkshopItems": {
+        "label": "Workshop Items",
+        "description": "Steam Workshop item IDs to download (semicolon-separated)."
+      },
+      "DoLuaChecksum": {
+        "label": "Lua Checksum",
+        "description": "Verify client Lua matches server. Must be disabled when using PanelBridge — the mod modifies server-side Lua files, which causes checksum mismatches and prevents players from connecting."
+      }
+    },
+    "steam": {
+      "SteamPort1": {
+        "label": "Steam Port 1",
+        "description": "First Steam port."
+      },
+      "SteamPort2": {
+        "label": "Steam Port 2",
+        "description": "Second Steam port."
+      },
+      "SteamScoreboard": {
+        "label": "Steam Scoreboard",
+        "description": "Show Steam usernames and avatars. true/false/admin.",
+        "options": {
+          "true": {
+            "label": "Everyone"
+          },
+          "false": {
+            "label": "No One"
+          },
+          "admin": {
+            "label": "Admins Only"
+          }
+        }
+      },
+      "SteamVAC": {
+        "label": "VAC Ban Check",
+        "description": "Check if connecting players have VAC bans."
+      }
+    },
+    "voice": {
+      "VoiceEnable": {
+        "label": "Enable Voice Chat",
+        "description": "Enable in-game voice chat."
+      },
+      "Voice3D": {
+        "label": "3D Voice",
+        "description": "Enable 3D positional voice chat."
+      },
+      "VoiceMinDistance": {
+        "label": "Voice Min Distance",
+        "description": "Minimum voice distance."
+      },
+      "VoiceMaxDistance": {
+        "label": "Voice Max Distance",
+        "description": "Maximum voice distance."
+      }
+    },
+    "discord": {
+      "DiscordEnable": {
+        "label": "Enable Discord",
+        "description": "Enable built-in Discord integration."
+      },
+      "DiscordToken": {
+        "label": "Discord Token",
+        "description": "Discord bot token."
+      },
+      "DiscordChannel": {
+        "label": "Discord Channel",
+        "description": "Discord channel name."
+      },
+      "DiscordChannelID": {
+        "label": "Discord Channel ID",
+        "description": "Discord channel ID."
+      },
+      "DiscordChatChannel": {
+        "label": "Discord Chat Channel",
+        "description": "The Discord channel name for game chat."
+      },
+      "DiscordLogChannel": {
+        "label": "Discord Log Channel",
+        "description": "The Discord channel name for server logs."
+      },
+      "DiscordCommandChannel": {
+        "label": "Discord Command Channel",
+        "description": "The Discord channel name for commands."
+      },
+      "WebhookAddress": {
+        "label": "Webhook URL",
+        "description": "Slack/Discord incoming webhook URL for notifications."
+      }
+    },
+    "rcon": {
+      "RCONPort": {
+        "label": "RCON Port",
+        "description": "Port for RCON connections."
+      },
+      "RCONPassword": {
+        "label": "RCON Password",
+        "description": "Password for RCON connections."
+      }
+    },
+    "advanced": {
+      "ResetID": {
+        "label": "Reset ID",
+        "description": "Removing this resets zombies and loot (not time)."
+      },
+      "ServerPlayerID": {
+        "label": "Server Player ID",
+        "description": "Identifies if character is from another server."
+      },
+      "PhysicsDelay": {
+        "label": "Physics Delay",
+        "description": "Physics update delay in milliseconds."
+      },
+      "FastForwardMultiplier": {
+        "label": "Fast Forward Multiplier",
+        "description": "Speed multiplier when fast-forwarding."
+      },
+      "CarEngineAttractionModifier": {
+        "label": "Car Engine Attraction",
+        "description": "Modifier for zombie attraction to car engines."
+      },
+      "ZombieUpdateMaxHighPriority": {
+        "label": "Zombie High Priority Updates",
+        "description": "Max high priority zombie updates per tick."
+      },
+      "ZombieUpdateDelta": {
+        "label": "Zombie Update Delta",
+        "description": "Zombie update time delta."
+      },
+      "SwitchZombiesOwnershipEachUpdate": {
+        "label": "Switch Zombie Ownership",
+        "description": "Switch zombie ownership between players each update tick."
+      },
+      "UltraSpeedDoesnotAffectToAnimals": {
+        "label": "Ultra Speed Ignores Animals",
+        "description": "Ultra speed mode does not affect animal simulation."
+      },
+      "UsePhysicsHitReaction": {
+        "label": "Physics Hit Reaction",
+        "description": "Use physics-based hit reactions."
+      }
+    },
+    "war": {
+      "War": {
+        "label": "Enable Faction War",
+        "description": "Enable faction war system. (Disabled by default since the Dec 2025 MP patch.)"
+      },
+      "WarStartDelay": {
+        "label": "War Start Delay",
+        "description": "Seconds before war starts after being declared."
+      },
+      "WarDuration": {
+        "label": "War Duration",
+        "description": "War duration in seconds."
+      },
+      "WarSafehouseHitPoints": {
+        "label": "War Safehouse Hit Points",
+        "description": "Safehouse hit points during faction war."
+      }
+    },
+    "radio": {
+      "DisableRadioStaff": {
+        "label": "Disable Radio for Staff",
+        "description": "Disable radio transmissions from staff access level."
+      },
+      "DisableRadioAdmin": {
+        "label": "Disable Radio for Admins",
+        "description": "Disable radio transmissions from admin access level."
+      },
+      "DisableRadioGM": {
+        "label": "Disable Radio for GMs",
+        "description": "Disable radio transmissions from GM access level."
+      },
+      "DisableRadioOverseer": {
+        "label": "Disable Radio for Overseers",
+        "description": "Disable radio transmissions from overseer access level."
+      },
+      "DisableRadioModerator": {
+        "label": "Disable Radio for Moderators",
+        "description": "Disable radio transmissions from moderator access level."
+      },
+      "DisableRadioInvisible": {
+        "label": "Disable Radio for Invisible",
+        "description": "Disable radio transmissions from invisible players."
+      }
+    },
+    "backups": {
+      "BackupsCount": {
+        "label": "Backup Count",
+        "description": "Number of backup copies to keep."
+      },
+      "BackupsOnStart": {
+        "label": "Backup on Start",
+        "description": "Create a backup when the server starts."
+      },
+      "BackupsOnVersionChange": {
+        "label": "Backup on Version Change",
+        "description": "Create a backup when the game version changes."
+      },
+      "BackupsPeriod": {
+        "label": "Backup Period",
+        "description": "Minutes between automatic backups. 0 = disabled."
+      }
+    },
+    "vehicles": {
+      "DisableVehicleTowing": {
+        "label": "Disable Vehicle Towing",
+        "description": "Disable vehicle towing."
+      },
+      "DisableTrailerTowing": {
+        "label": "Disable Trailer Towing",
+        "description": "Disable trailer towing."
+      },
+      "DisableBurntTowing": {
+        "label": "Disable Burnt Vehicle Towing",
+        "description": "Disable towing of burnt vehicles."
+      }
+    },
+    "moderation": {
+      "BadWordListFile": {
+        "label": "Bad Word List File",
+        "description": "Path to file with prohibited words, one per line."
+      },
+      "GoodWordListFile": {
+        "label": "Good Word List File",
+        "description": "Path to file with allowed words that may contain bad words, one per line."
+      },
+      "BadWordPolicy": {
+        "label": "Bad Word Policy",
+        "description": "Action taken when a bad word is detected in chat.",
+        "options": {
+          "1": {
+            "label": "Ban"
+          },
+          "2": {
+            "label": "Kick"
+          },
+          "3": {
+            "label": "Record Violation"
+          },
+          "4": {
+            "label": "Mute"
+          }
+        }
+      },
+      "BadWordReplacement": {
+        "label": "Bad Word Replacement",
+        "description": "Text that replaces bad words in chat."
+      }
+    },
+    "anticheat": {
+      "AntiCheatSafety": {
+        "label": "Safety",
+        "description": "Anti-cheat protection for the safety system.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSpeed": {
+        "label": "Speed",
+        "description": "Anti-cheat protection for player speed.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatNoClip": {
+        "label": "No Clip",
+        "description": "Anti-cheat protection against moving through solid objects.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatHit": {
+        "label": "Hit Detection",
+        "description": "Anti-cheat protection for character hits.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPacketException": {
+        "label": "Packet Exceptions",
+        "description": "Anti-cheat protection for invalid network packets.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPermission": {
+        "label": "Permissions",
+        "description": "Anti-cheat protection for player permissions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatXP": {
+        "label": "XP Validation",
+        "description": "Anti-cheat protection for player XP.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSafeHouse": {
+        "label": "Safehouse Protection",
+        "description": "Anti-cheat protection for safehouses.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPlayer": {
+        "label": "Player Validation",
+        "description": "Anti-cheat protection for player actions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatChecksum": {
+        "label": "Checksum Validation",
+        "description": "Anti-cheat protection for file checksums.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      }
+    },
+    "logging": {
+      "ClientCommandFilter": {
+        "label": "Command Log Filter",
+        "description": "Semicolon-separated list of commands to exclude from cmd.txt log. Use -vehicle.* to exclude all vehicle, +vehicle.installPart to include specific."
+      },
+      "ClientActionLogs": {
+        "label": "Client Action Logs",
+        "description": "Semicolon-separated list of actions written to ClientActionLogs.txt."
+      },
+      "PerkLogs": {
+        "label": "Perk Level Logging",
+        "description": "Track changes in player perk levels in PerkLog.txt."
+      }
+    }
+  },
+  "sandboxSettings": {
+    "time": {
+      "DayLength": {
+        "label": "Day Length",
+        "description": "How long a day lasts.",
+        "options": {
+          "1": {
+            "label": "15 Minutes"
+          },
+          "2": {
+            "label": "30 Minutes"
+          },
+          "3": {
+            "label": "1 Hour"
+          },
+          "4": {
+            "label": "1 Hour, 30 Minutes"
+          },
+          "5": {
+            "label": "2 Hours"
+          },
+          "6": {
+            "label": "3 Hours"
+          },
+          "7": {
+            "label": "4 Hours"
+          },
+          "8": {
+            "label": "5 Hours"
+          },
+          "9": {
+            "label": "6 Hours"
+          },
+          "10": {
+            "label": "7 Hours"
+          },
+          "11": {
+            "label": "8 Hours"
+          },
+          "12": {
+            "label": "9 Hours"
+          },
+          "13": {
+            "label": "10 Hours"
+          },
+          "14": {
+            "label": "11 Hours"
+          },
+          "15": {
+            "label": "12 Hours"
+          },
+          "16": {
+            "label": "13 Hours"
+          },
+          "17": {
+            "label": "14 Hours"
+          },
+          "18": {
+            "label": "15 Hours"
+          },
+          "19": {
+            "label": "16 Hours"
+          },
+          "20": {
+            "label": "17 Hours"
+          },
+          "21": {
+            "label": "18 Hours"
+          },
+          "22": {
+            "label": "19 Hours"
+          },
+          "23": {
+            "label": "20 Hours"
+          },
+          "24": {
+            "label": "21 Hours"
+          },
+          "25": {
+            "label": "22 Hours"
+          },
+          "26": {
+            "label": "23 Hours"
+          },
+          "27": {
+            "label": "Real-time"
+          }
+        }
+      },
+      "StartYear": {
+        "label": "Start Year",
+        "description": "Which year the game starts in."
+      },
+      "StartMonth": {
+        "label": "Start Month",
+        "description": "Which month the game starts in (1=Jan, 12=Dec).",
+        "options": {
+          "1": {
+            "label": "January"
+          },
+          "2": {
+            "label": "February"
+          },
+          "3": {
+            "label": "March"
+          },
+          "4": {
+            "label": "April"
+          },
+          "5": {
+            "label": "May"
+          },
+          "6": {
+            "label": "June"
+          },
+          "7": {
+            "label": "July"
+          },
+          "8": {
+            "label": "August"
+          },
+          "9": {
+            "label": "September"
+          },
+          "10": {
+            "label": "October"
+          },
+          "11": {
+            "label": "November"
+          },
+          "12": {
+            "label": "December"
+          }
+        }
+      },
+      "StartDay": {
+        "label": "Start Day",
+        "description": "Which day of the month the game starts on."
+      },
+      "StartTime": {
+        "label": "Start Time",
+        "description": "What time of day the game starts.",
+        "options": {
+          "1": {
+            "label": "7 AM"
+          },
+          "2": {
+            "label": "9 AM"
+          },
+          "3": {
+            "label": "12 PM"
+          },
+          "4": {
+            "label": "2 PM"
+          },
+          "5": {
+            "label": "5 PM"
+          },
+          "6": {
+            "label": "9 PM"
+          },
+          "7": {
+            "label": "12 AM"
+          },
+          "8": {
+            "label": "2 AM"
+          },
+          "9": {
+            "label": "5 AM"
+          }
+        }
+      }
+    },
+    "population": {
+      "Zombies": {
+        "label": "Zombie Count",
+        "description": "Initial zombie population level. Also sets Population Multiplier in Advanced Zombie Options.",
+        "options": {
+          "1": {
+            "label": "Insane"
+          },
+          "2": {
+            "label": "Very High"
+          },
+          "3": {
+            "label": "High"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Low"
+          },
+          "6": {
+            "label": "None"
+          }
+        }
+      },
+      "Distribution": {
+        "label": "Distribution",
+        "description": "How zombies are distributed across the map.",
+        "options": {
+          "1": {
+            "label": "Urban Focused"
+          },
+          "2": {
+            "label": "Uniform"
+          }
+        }
+      },
+      "ZombieVoronoiNoise": {
+        "label": "Randomize Distribution",
+        "description": "Apply randomization to zombie distribution."
+      },
+      "ZombieRespawn": {
+        "label": "Zombie Respawn",
+        "description": "How frequently new zombies are added to the world.",
+        "options": {
+          "1": {
+            "label": "High"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Low"
+          },
+          "4": {
+            "label": "None"
+          }
+        }
+      },
+      "ZombieMigrate": {
+        "label": "Zombie Migration",
+        "description": "Zombies can migrate to empty cells."
+      }
+    },
+    "loot": {
+      "LootItemRemovalList": {
+        "label": "Loot Item Removal List",
+        "description": "Comma-separated item types removed from the world by the loot cleanup system."
+      },
+      "FoodLootNew": {
+        "label": "Food Loot",
+        "description": "Any food that can rot or spoil."
+      },
+      "CannedFoodLootNew": {
+        "label": "Canned Food Loot",
+        "description": "Canned and dried food, beverages."
+      },
+      "LiteratureLootNew": {
+        "label": "Literature Loot",
+        "description": "All readable items including books, fliers, and newspapers."
+      },
+      "SkillBookLoot": {
+        "label": "Skill Book Loot",
+        "description": "Books that provide skill XP multipliers."
+      },
+      "RecipeResourceLoot": {
+        "label": "Recipe Loot",
+        "description": "Items that teach recipes."
+      },
+      "MedicalLootNew": {
+        "label": "Medical Loot",
+        "description": "Medicine, bandages, and first aid tools."
+      },
+      "SurvivalGearsLootNew": {
+        "label": "Survival Gear Loot",
+        "description": "Fishing rods, tents, camping gear."
+      },
+      "WeaponLootNew": {
+        "label": "Melee Weapon Loot",
+        "description": "Weapons that are not tools in other categories."
+      },
+      "RangedWeaponLootNew": {
+        "label": "Ranged Weapon Loot",
+        "description": "Ranged weapons and weapon attachments."
+      },
+      "AmmoLootNew": {
+        "label": "Ammo Loot",
+        "description": "Loose ammo, boxes, and magazines."
+      },
+      "MechanicsLootNew": {
+        "label": "Mechanics Loot",
+        "description": "Vehicle parts and installation tools."
+      },
+      "ClothingLootNew": {
+        "label": "Clothing Loot",
+        "description": "All wearable items that are not containers."
+      },
+      "ContainerLootNew": {
+        "label": "Container Loot",
+        "description": "Backpacks and wearable/equippable containers."
+      },
+      "KeyLootNew": {
+        "label": "Key Loot",
+        "description": "Keys for buildings/cars, key rings, and locks."
+      },
+      "MediaLootNew": {
+        "label": "Media Loot",
+        "description": "VHS tapes and CDs."
+      },
+      "MementoLootNew": {
+        "label": "Memento Loot",
+        "description": "Spiffo items, plushies, and collectible keepsakes."
+      },
+      "CookwareLootNew": {
+        "label": "Cookware Loot",
+        "description": "Cooking items including those that can be weapons. Does not include food."
+      },
+      "MaterialLootNew": {
+        "label": "Material Loot",
+        "description": "Crafting and building materials."
+      },
+      "FarmingLootNew": {
+        "label": "Farming Loot",
+        "description": "Seeds, trowels, shovels, and agriculture tools."
+      },
+      "ToolLootNew": {
+        "label": "Tool Loot",
+        "description": "Tools not in other categories like Mechanics or Farming."
+      },
+      "OtherLootNew": {
+        "label": "Other Loot",
+        "description": "Everything else. Also affects foraging in Town/Road zones."
+      },
+      "RollsMultiplier": {
+        "label": "Rolls Multiplier",
+        "description": "Multiplier for loot table rolls. Higher values may affect performance. NOT recommended to change."
+      },
+      "RemoveStoryLoot": {
+        "label": "Remove Story Loot",
+        "description": "Items on the removal list will not spawn in world stories."
+      },
+      "RemoveZombieLoot": {
+        "label": "Remove Zombie Loot",
+        "description": "Items on the removal list will not spawn on zombies."
+      },
+      "ZombiePopLootEffect": {
+        "label": "Zombie Pop Loot Effect",
+        "description": "If > 0, loot increases relative to nearby zombies, multiplied by this value."
+      },
+      "HoursForLootRespawn": {
+        "label": "Loot Respawn Hours",
+        "description": "Hours after which containers respawn loot. 0 = never."
+      },
+      "MaxItemsForLootRespawn": {
+        "label": "Max Items for Respawn",
+        "description": "Containers with this many items or more will not respawn loot."
+      },
+      "ConstructionPreventsLootRespawn": {
+        "label": "Construction Blocks Respawn",
+        "description": "Player constructions near containers prevent loot respawn."
+      },
+      "SeenHoursPreventLootRespawn": {
+        "label": "Seen Hours Prevent Respawn",
+        "description": "Hours a zone must be unvisited before loot respawns. 0 = disabled."
+      }
+    },
+    "lootRarity": {
+      "InsaneLootFactor": {
+        "label": "Insane Rarity Factor",
+        "description": "Spawn rate for Insane rarity items."
+      },
+      "ExtremeLootFactor": {
+        "label": "Extreme Rarity Factor",
+        "description": "Spawn rate for Extreme rarity items."
+      },
+      "RareLootFactor": {
+        "label": "Rare Rarity Factor",
+        "description": "Spawn rate for Rare rarity items."
+      },
+      "NormalLootFactor": {
+        "label": "Normal Rarity Factor",
+        "description": "Spawn rate for Normal rarity items."
+      },
+      "CommonLootFactor": {
+        "label": "Common Rarity Factor",
+        "description": "Spawn rate for Common rarity items."
+      },
+      "AbundantLootFactor": {
+        "label": "Abundant Rarity Factor",
+        "description": "Spawn rate for Abundant rarity items."
+      },
+      "MaximumLooted": {
+        "label": "Max Looted Building Chance",
+        "description": "Chance that any building is already looted when found."
+      },
+      "DaysUntilMaximumLooted": {
+        "label": "Days Until Max Looted",
+        "description": "Days before Maximum Looted Building Chance is reached."
+      },
+      "RuralLooted": {
+        "label": "Rural Looted Chance",
+        "description": "Chance that any rural building is already looted."
+      },
+      "MaximumDiminishedLoot": {
+        "label": "Max Diminished Loot %",
+        "description": "Maximum loot that won't spawn when diminished days reached."
+      },
+      "DaysUntilMaximumDiminishedLoot": {
+        "label": "Days Until Max Diminished",
+        "description": "Days before Maximum Diminished Loot is reached."
+      },
+      "MaximumLootedBuildingRooms": {
+        "label": "Max Looted Building Rooms",
+        "description": "Buildings with more than this many rooms will not be auto-looted."
+      }
+    },
+    "environment": {
+      "DayNightCycle": {
+        "label": "Day/Night Cycle",
+        "description": "Whether time of day changes naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Endless Day"
+          },
+          "3": {
+            "label": "Endless Night"
+          }
+        }
+      },
+      "ClimateCycle": {
+        "label": "Weather Cycle",
+        "description": "Whether weather changes or remains fixed.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "No Weather"
+          },
+          "3": {
+            "label": "Endless Rain"
+          },
+          "4": {
+            "label": "Endless Storm"
+          },
+          "5": {
+            "label": "Endless Snow"
+          },
+          "6": {
+            "label": "Endless Blizzard"
+          }
+        }
+      },
+      "FogCycle": {
+        "label": "Fog Cycle",
+        "description": "Whether fog occurs naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "No Fog"
+          },
+          "3": {
+            "label": "Endless Fog"
+          }
+        }
+      },
+      "WaterShut": {
+        "label": "Water Shutoff",
+        "description": "When plumbing fixtures stop being infinite water sources.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0 - 30 Days"
+          },
+          "3": {
+            "label": "0 - 2 Months"
+          },
+          "4": {
+            "label": "0 - 6 Months"
+          },
+          "5": {
+            "label": "0 - 1 Year"
+          },
+          "6": {
+            "label": "0 - 5 Years"
+          },
+          "7": {
+            "label": "2 - 6 Months"
+          },
+          "8": {
+            "label": "6 - 12 Months"
+          },
+          "9": {
+            "label": "Disabled"
+          }
+        }
+      },
+      "ElecShut": {
+        "label": "Electricity Shutoff",
+        "description": "When the world's electricity turns off.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "14 - 30 Days"
+          },
+          "3": {
+            "label": "14 Days - 2 Months"
+          },
+          "4": {
+            "label": "14 Days - 6 Months"
+          },
+          "5": {
+            "label": "14 Days - 1 Year"
+          },
+          "6": {
+            "label": "14 Days - 5 Years"
+          },
+          "7": {
+            "label": "2 - 6 Months"
+          },
+          "8": {
+            "label": "6 - 12 Months"
+          },
+          "9": {
+            "label": "Disabled"
+          }
+        }
+      },
+      "AlarmDecay": {
+        "label": "Alarm Battery Decay",
+        "description": "How long alarm batteries last after power shuts off.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0 - 30 Days"
+          },
+          "3": {
+            "label": "0 - 2 Months"
+          },
+          "4": {
+            "label": "0 - 6 Months"
+          },
+          "5": {
+            "label": "0 - 1 Year"
+          },
+          "6": {
+            "label": "0 - 5 Years"
+          },
+          "7": {
+            "label": "2 - 6 Months"
+          },
+          "8": {
+            "label": "6 - 12 Months"
+          },
+          "9": {
+            "label": "Disabled"
+          }
+        }
+      },
+      "WaterShutModifier": {
+        "label": "Water Shutoff Modifier",
+        "description": "Fine-tune water shutoff timing in days."
+      },
+      "ElecShutModifier": {
+        "label": "Electricity Shutoff Modifier",
+        "description": "Fine-tune electricity shutoff timing in days."
+      },
+      "AlarmDecayModifier": {
+        "label": "Alarm Decay Modifier",
+        "description": "Fine-tune alarm battery decay timing in days."
+      },
+      "Temperature": {
+        "label": "Temperature",
+        "description": "Global temperature setting.",
+        "options": {
+          "1": {
+            "label": "Very Cold"
+          },
+          "2": {
+            "label": "Cold"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hot"
+          },
+          "5": {
+            "label": "Very Hot"
+          }
+        }
+      },
+      "Rain": {
+        "label": "Rainfall",
+        "description": "How often it rains.",
+        "options": {
+          "1": {
+            "label": "Very Dry"
+          },
+          "2": {
+            "label": "Dry"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Rainy"
+          },
+          "5": {
+            "label": "Very Rainy"
+          }
+        }
+      },
+      "ErosionSpeed": {
+        "label": "Erosion Speed",
+        "description": "How fast nature reclaims the world.",
+        "options": {
+          "1": {
+            "label": "Very Fast (20 Days)"
+          },
+          "2": {
+            "label": "Fast (50 Days)"
+          },
+          "3": {
+            "label": "Normal (100 Days)"
+          },
+          "4": {
+            "label": "Slow (200 Days)"
+          },
+          "5": {
+            "label": "Very Slow (500 Days)"
+          }
+        }
+      },
+      "ErosionDays": {
+        "label": "Custom Erosion Days",
+        "description": "Custom erosion days. 0 = use Erosion Speed option."
+      },
+      "MaxFogIntensity": {
+        "label": "Max Fog Intensity",
+        "description": "Maximum intensity of fog.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Moderate"
+          },
+          "3": {
+            "label": "Low"
+          },
+          "4": {
+            "label": "None"
+          }
+        }
+      },
+      "MaxRainFxIntensity": {
+        "label": "Max Rain FX Intensity",
+        "description": "Maximum intensity of rain effects.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Moderate"
+          },
+          "3": {
+            "label": "Low"
+          }
+        }
+      },
+      "EnableSnowOnGround": {
+        "label": "Snow on Ground",
+        "description": "Whether snow accumulates on the ground."
+      },
+      "NightDarkness": {
+        "label": "Night Darkness",
+        "description": "Ambient lighting level at night.",
+        "options": {
+          "1": {
+            "label": "Pitch Black"
+          },
+          "2": {
+            "label": "Dark"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Bright"
+          }
+        }
+      },
+      "NightLength": {
+        "label": "Night Length",
+        "description": "Duration from dusk to dawn.",
+        "options": {
+          "1": {
+            "label": "Always Night"
+          },
+          "2": {
+            "label": "Long"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Short"
+          },
+          "5": {
+            "label": "Always Day"
+          }
+        }
+      },
+      "TimeSinceApo": {
+        "label": "Time Since Apocalypse",
+        "description": "How long after the apocalypse the game begins. Affects erosion and food spoilage.",
+        "options": {
+          "1": {
+            "label": "0"
+          },
+          "2": {
+            "label": "1"
+          },
+          "3": {
+            "label": "2"
+          },
+          "4": {
+            "label": "3"
+          },
+          "5": {
+            "label": "4"
+          },
+          "6": {
+            "label": "5"
+          },
+          "7": {
+            "label": "6"
+          },
+          "8": {
+            "label": "7"
+          },
+          "9": {
+            "label": "8"
+          },
+          "10": {
+            "label": "9"
+          },
+          "11": {
+            "label": "10"
+          },
+          "12": {
+            "label": "11"
+          },
+          "13": {
+            "label": "12"
+          }
+        }
+      },
+      "FireSpread": {
+        "label": "Fire Spread",
+        "description": "Whether fires spread when started."
+      }
+    },
+    "survival": {
+      "StatsDecrease": {
+        "label": "Stats Decrease",
+        "description": "How fast hunger, thirst, and fatigue decrease.",
+        "options": {
+          "1": {
+            "label": "Very Fast"
+          },
+          "2": {
+            "label": "Fast"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Slow"
+          },
+          "5": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "Nutrition": {
+        "label": "Nutrition",
+        "description": "Food nutrition affects player weight and condition."
+      },
+      "FoodRotSpeed": {
+        "label": "Food Rot Speed",
+        "description": "How fast food spoils.",
+        "options": {
+          "1": {
+            "label": "Very Fast"
+          },
+          "2": {
+            "label": "Fast"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Slow"
+          },
+          "5": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "FridgeFactor": {
+        "label": "Fridge Effectiveness",
+        "description": "How effective fridges are at preserving food.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          },
+          "6": {
+            "label": "No decay"
+          }
+        }
+      },
+      "StarterKit": {
+        "label": "Starter Kit",
+        "description": "Spawn with chips, water bottle, backpack, bat, and hammer."
+      },
+      "CharacterFreePoints": {
+        "label": "Free Character Points",
+        "description": "Extra free points during character creation."
+      },
+      "BoneFracture": {
+        "label": "Bone Fractures",
+        "description": "Survivors can get broken limbs from impacts, falls, etc."
+      },
+      "InjurySeverity": {
+        "label": "Injury Severity",
+        "description": "Impact of injuries and healing time.",
+        "options": {
+          "1": {
+            "label": "Low"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "High"
+          }
+        }
+      },
+      "EndRegen": {
+        "label": "Endurance Recovery",
+        "description": "Recovery from tiredness after actions.",
+        "options": {
+          "1": {
+            "label": "Very Fast"
+          },
+          "2": {
+            "label": "Fast"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Slow"
+          },
+          "5": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "HoursForCorpseRemoval": {
+        "label": "Corpse Removal Hours",
+        "description": "Hours before zombie corpses disappear. 0 = no maggots spawn."
+      },
+      "DecayingCorpseHealthImpact": {
+        "label": "Corpse Health Impact",
+        "description": "Impact of nearby decaying bodies on health/emotions.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Insane"
+          }
+        }
+      },
+      "ZombieHealthImpact": {
+        "label": "Zombie Health Impact",
+        "description": "Whether living zombies also affect player health/emotions."
+      },
+      "BloodLevel": {
+        "label": "Blood Level",
+        "description": "How much blood sprays on surfaces.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Ultra Gore"
+          }
+        }
+      },
+      "ClothingDegradation": {
+        "label": "Clothing Degradation",
+        "description": "How quickly clothing degrades and gets dirty.",
+        "options": {
+          "1": {
+            "label": "Disabled"
+          },
+          "2": {
+            "label": "Slow"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Fast"
+          }
+        }
+      },
+      "DaysForRottenFoodRemoval": {
+        "label": "Rotten Food Removal Days",
+        "description": "Days before rotten food is removed. -1 = never."
+      },
+      "AllClothesUnlocked": {
+        "label": "All Clothes Unlocked",
+        "description": "Select from every clothing item during character creation."
+      },
+      "EnableTaintedWaterText": {
+        "label": "Tainted Water Warning",
+        "description": "Show warning marking tainted water."
+      },
+      "EnablePoisoning": {
+        "label": "Enable Poisoning",
+        "description": "Whether poison can be added to food.",
+        "options": {
+          "1": {
+            "label": "True"
+          },
+          "2": {
+            "label": "False"
+          },
+          "3": {
+            "label": "Only bleach poisoning is disabled"
+          }
+        }
+      },
+      "MaggotSpawn": {
+        "label": "Maggot Spawn",
+        "description": "When maggots spawn in corpses.",
+        "options": {
+          "1": {
+            "label": "In and Around Bodies"
+          },
+          "2": {
+            "label": "In Bodies Only"
+          },
+          "3": {
+            "label": "Never"
+          }
+        }
+      },
+      "MuscleStrainFactor": {
+        "label": "Muscle Strain Factor",
+        "description": "Multiplier for muscle strain from swinging weapons or carrying heavy loads."
+      },
+      "DiscomfortFactor": {
+        "label": "Discomfort Factor",
+        "description": "Multiplier for discomfort from worn items."
+      },
+      "WoundInfectionFactor": {
+        "label": "Wound Infection Factor",
+        "description": "Damage from serious wound infections. 0 = disabled."
+      },
+      "NoBlackClothes": {
+        "label": "No Black Clothes",
+        "description": "Prevent randomized clothing from becoming near-black."
+      },
+      "EasyClimbing": {
+        "label": "Easy Climbing",
+        "description": "Disable failure chances when climbing sheet ropes or walls."
+      },
+      "NegativeTraitsPenalty": {
+        "label": "Negative Traits Penalty",
+        "description": "Diminishing returns on bonus points from negative traits.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "1 point penalty for every 3 negative traits selected"
+          },
+          "3": {
+            "label": "1 point penalty for every 2 negative traits selected"
+          },
+          "4": {
+            "label": "1 point penalty for every negative trait selected after the first"
+          }
+        }
+      },
+      "MinutesPerPage": {
+        "label": "Minutes Per Page",
+        "description": "In-game minutes to read one page of a skill book."
+      },
+      "LiteratureCooldown": {
+        "label": "Literature Cooldown",
+        "description": "Days before previously read literature can benefit again."
+      },
+      "LevelForMediaXPCutoff": {
+        "label": "Media XP Cutoff Level",
+        "description": "Skill level at which TV/VHS/media no longer provides XP."
+      },
+      "LevelForDismantleXPCutoff": {
+        "label": "Dismantle XP Cutoff Level",
+        "description": "Skill level at which scrapping furniture gives no XP."
+      },
+      "BloodSplatLifespanDays": {
+        "label": "Blood Splat Lifespan",
+        "description": "Days before blood splats disappear. 0 = never."
+      },
+      "MetaKnowledge": {
+        "label": "Meta Knowledge",
+        "description": "How unseen/unread media is displayed.",
+        "options": {
+          "1": {
+            "label": "Fully revealed"
+          },
+          "2": {
+            "label": "Shown as ???"
+          },
+          "3": {
+            "label": "Completely hidden"
+          }
+        }
+      },
+      "SeeNotLearntRecipe": {
+        "label": "See Unlearned Recipes",
+        "description": "See station recipes even if not yet learned."
+      },
+      "LightBulbLifespan": {
+        "label": "Light Bulb Lifespan",
+        "description": "Higher = bulbs last longer. 0 = never break."
+      },
+      "MaximumFireFuelHours": {
+        "label": "Max Fire Fuel Hours",
+        "description": "Max hours of fuel for campfires, wood stoves, etc."
+      },
+      "Alarm": {
+        "label": "House Alarms",
+        "description": "Frequency of residential alarms.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "LockedHouses": {
+        "label": "Locked Houses",
+        "description": "Frequency of locked houses.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "Helicopter": {
+        "label": "Helicopter Events",
+        "description": "Helicopter frequency.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Once"
+          },
+          "3": {
+            "label": "Sometimes"
+          },
+          "4": {
+            "label": "Often"
+          }
+        }
+      },
+      "MetaEvent": {
+        "label": "Meta Events",
+        "description": "Distant gunshots, screams, etc.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Sometimes"
+          },
+          "3": {
+            "label": "Often"
+          }
+        }
+      },
+      "SleepingEvent": {
+        "label": "Sleeping Events",
+        "description": "Events that happen while sleeping.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Sometimes"
+          },
+          "3": {
+            "label": "Often"
+          }
+        }
+      },
+      "NatureAbundance": {
+        "label": "Nature Abundance",
+        "description": "Governs abundance of wild foods, medicinal plants, etc.",
+        "options": {
+          "1": {
+            "label": "Very Poor"
+          },
+          "2": {
+            "label": "Poor"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundant"
+          },
+          "5": {
+            "label": "Very Abundant"
+          }
+        }
+      },
+      "FishAbundance": {
+        "label": "Fish Abundance",
+        "description": "Governs abundance of fish.",
+        "options": {
+          "1": {
+            "label": "Very Poor"
+          },
+          "2": {
+            "label": "Poor"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundant"
+          },
+          "5": {
+            "label": "Very Abundant"
+          }
+        }
+      },
+      "AnnotatedMapChance": {
+        "label": "Annotated Map Chance",
+        "description": "Chance of finding maps annotated with local features.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "ConstructionBonusPoints": {
+        "label": "Construction Bonus Points",
+        "description": "Extra points for carpentry/metalworking constructions."
+      },
+      "GeneratorSpawning": {
+        "label": "Generator Spawning",
+        "description": "How many generators spawn in the world.",
+        "options": {
+          "1": {
+            "label": "None (not recommended)"
+          },
+          "2": {
+            "label": "Insanely Rare"
+          },
+          "3": {
+            "label": "Extremely Rare"
+          },
+          "4": {
+            "label": "Rare"
+          },
+          "5": {
+            "label": "Normal"
+          },
+          "6": {
+            "label": "Common"
+          },
+          "7": {
+            "label": "Abundant"
+          }
+        }
+      },
+      "GeneratorFuelConsumption": {
+        "label": "Generator Fuel Consumption",
+        "description": "How fast generators consume fuel."
+      },
+      "AllowExteriorGenerator": {
+        "label": "Allow Exterior Generator",
+        "description": "Generators can be placed outdoors and inside tents."
+      },
+      "GeneratorTileRange": {
+        "label": "Generator Tile Range",
+        "description": "Horizontal range of generators in tiles."
+      },
+      "GeneratorVerticalPowerRange": {
+        "label": "Generator Vertical Range",
+        "description": "Vertical range of generators in floors."
+      },
+      "CompostTime": {
+        "label": "Compost Time",
+        "description": "How long composting takes.",
+        "options": {
+          "1": {
+            "label": "1 Week"
+          },
+          "2": {
+            "label": "2 Weeks"
+          },
+          "3": {
+            "label": "3 Weeks"
+          },
+          "4": {
+            "label": "4 Weeks"
+          },
+          "5": {
+            "label": "6 Weeks"
+          },
+          "6": {
+            "label": "8 Weeks"
+          },
+          "7": {
+            "label": "10 Weeks"
+          },
+          "8": {
+            "label": "12 Weeks"
+          }
+        }
+      },
+      "AttackBlockMovements": {
+        "label": "Attack Block Movements",
+        "description": "Player can't move while performing melee attacks."
+      },
+      "WorldItemRemovalList": {
+        "label": "World Item Removal List",
+        "description": "Types of items removed from world (comma separated, e.g. Base.Vest)."
+      },
+      "HoursForWorldItemRemoval": {
+        "label": "World Item Removal Hours",
+        "description": "Hours before listed items disappear from world. 0 = disabled."
+      },
+      "ItemRemovalListBlacklistToggle": {
+        "label": "Item Removal Blacklist Toggle",
+        "description": "If true, removal list acts as blacklist (remove everything except listed). Default is whitelist."
+      }
+    },
+    "combat": {
+      "MultiHitZombies": {
+        "label": "Multi-Hit Zombies",
+        "description": "A melee weapon can hit multiple zombies in one swing."
+      },
+      "RearVulnerability": {
+        "label": "Rear Vulnerability",
+        "description": "Zombies take more damage when attacked from behind.",
+        "options": {
+          "1": {
+            "label": "Low"
+          },
+          "2": {
+            "label": "Medium"
+          },
+          "3": {
+            "label": "High"
+          }
+        }
+      },
+      "FirearmUseDamageChance": {
+        "label": "Firearm Use Damage Chance",
+        "description": "Chance of weapon condition loss per use. 0 = never."
+      },
+      "FirearmNoiseMultiplier": {
+        "label": "Firearm Noise Multiplier",
+        "description": "Multiplier for gun noise attracting zombies."
+      },
+      "FirearmJamMultiplier": {
+        "label": "Firearm Jam Multiplier",
+        "description": "Multiplier for jamming chance."
+      },
+      "FirearmMoodleMultiplier": {
+        "label": "Firearm Moodle Multiplier",
+        "description": "Multiplier for panic/stress from gun use."
+      },
+      "FirearmWeatherMultiplier": {
+        "label": "Firearm Weather Multiplier",
+        "description": "Multiplier for rain affecting gun condition."
+      },
+      "FirearmHeadGearEffect": {
+        "label": "Firearm Head Gear Effect",
+        "description": "How much head-covering gear like helmets affects firearm aim/shoulder."
+      }
+    },
+    "vehicles": {
+      "EnableVehicles": {
+        "label": "Enable Vehicles",
+        "description": "Whether vehicles spawn and can be used."
+      },
+      "CarSpawnRate": {
+        "label": "Car Spawn Rate",
+        "description": "How many vehicles spawn.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Very Low"
+          },
+          "3": {
+            "label": "Low"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "High"
+          }
+        }
+      },
+      "VehicleEasyUse": {
+        "label": "Vehicle Easy Use",
+        "description": "All vehicles are automatic and easy to start."
+      },
+      "InitialGas": {
+        "label": "Initial Vehicle Gas",
+        "description": "How full the gas tank of discovered vehicles will be.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          },
+          "6": {
+            "label": "Full"
+          }
+        }
+      },
+      "FuelStationGasInfinite": {
+        "label": "Infinite Fuel Station Gas",
+        "description": "If enabled, gas pumps will never run out of fuel."
+      },
+      "FuelStationGasMin": {
+        "label": "Fuel Station Gas Min",
+        "description": "The minimum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasMax": {
+        "label": "Fuel Station Gas Max",
+        "description": "The maximum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasEmptyChance": {
+        "label": "Fuel Station Empty Chance",
+        "description": "The chance, as a percentage, that individual gas pumps will initially have no fuel."
+      },
+      "LockedCar": {
+        "label": "Locked Car Chance",
+        "description": "Chance of vehicle doors being locked.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "CarGasConsumption": {
+        "label": "Gas Consumption",
+        "description": "Rate of fuel consumption in vehicles."
+      },
+      "CarGeneralCondition": {
+        "label": "Car General Condition",
+        "description": "Initial condition of discovered vehicles.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "CarDamageOnImpact": {
+        "label": "Car Damage on Impact",
+        "description": "Damage vehicles take from collisions.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "DamageToPlayerFromHitByACar": {
+        "label": "Car Damage to Player",
+        "description": "How much damage players receive from vehicle impacts.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "TrafficJam": {
+        "label": "Traffic Jams",
+        "description": "Whether traffic jams spawn on roads."
+      },
+      "CarAlarm": {
+        "label": "Car Alarms",
+        "description": "Chance of vehicles having active alarms.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "PlayerDamageFromCrash": {
+        "label": "Crash Damage to Player",
+        "description": "If the player can get injured from being in a car accident."
+      },
+      "SirenShutoffHours": {
+        "label": "Siren Shutoff Hours",
+        "description": "Hours before vehicle siren batteries die. 0 = instant."
+      },
+      "ChanceHasGas": {
+        "label": "Chance Has Gas",
+        "description": "The chance of finding a vehicle with gas in its tank.",
+        "options": {
+          "1": {
+            "label": "Low"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "High"
+          }
+        }
+      },
+      "RecentlySurvivorVehicles": {
+        "label": "Recently Survivor Vehicles",
+        "description": "Whether a player can discover a car that has been cared for after the Knox infection struck.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          }
+        }
+      },
+      "ZombieAttractionMultiplier": {
+        "label": "Vehicle Zombie Attraction",
+        "description": "Multiplier for vehicle sounds attracting zombies."
+      },
+      "SirenEffectsZombies": {
+        "label": "Siren Effects Zombies",
+        "description": "If zombies will head towards the sound of vehicle sirens."
+      }
+    },
+    "animals": {
+      "AnimalStatsModifier": {
+        "label": "Animal Stats Speed",
+        "description": "Speed at which animal stats (hunger, thirst etc.) reduce.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalMetaStatsModifier": {
+        "label": "Animal Meta Stats Speed",
+        "description": "Speed at which animal stats reduce while in meta (overworld).",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalPregnancyTime": {
+        "label": "Animal Pregnancy Time",
+        "description": "How long animals will be pregnant for before giving birth.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalAgeModifier": {
+        "label": "Animal Aging Speed",
+        "description": "Speed at which animals age.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalMilkIncModifier": {
+        "label": "Milk Production Speed",
+        "description": "Speed of milk production.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalWoolIncModifier": {
+        "label": "Wool Production Speed",
+        "description": "Speed of wool production.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalRanchChance": {
+        "label": "Animal Ranch Chance",
+        "description": "The chance of finding animals in farms.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      },
+      "AnimalGrassRegrowTime": {
+        "label": "Grass Regrow Time",
+        "description": "The number of hours grass will regrow after being eaten by an animal or cut by the player."
+      },
+      "AnimalMetaPredator": {
+        "label": "Meta Predator",
+        "description": "If a meta fox may attack your chickens if the hutch door is left open at night."
+      },
+      "AnimalMatingSeason": {
+        "label": "Mating Season",
+        "description": "Restrict mating to spring/early summer or allow year-round."
+      },
+      "AnimalEggHatch": {
+        "label": "Egg Hatch Time",
+        "description": "How long before baby animals will hatch from eggs.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalSoundAttractZombies": {
+        "label": "Animal Sound Attracts Zombies",
+        "description": "If true, animal calls will attract nearby zombies."
+      },
+      "AnimalTrackChance": {
+        "label": "Animal Track Chance",
+        "description": "The chance of animals leaving tracks.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "AnimalPathChance": {
+        "label": "Animal Path Chance",
+        "description": "The chance of creating a path for animals to be hunted.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "MaximumRatIndex": {
+        "label": "Maximum Rat Index",
+        "description": "Maximum rat infestation level. 0 = no rats."
+      },
+      "DaysUntilMaximumRatIndex": {
+        "label": "Days Until Max Rat Index",
+        "description": "How many days until rat population peaks."
+      },
+      "Farming": {
+        "label": "Agriculture Multiplier",
+        "description": "Rate at which Agriculture skill levels up.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "PlantResilience": {
+        "label": "Plant Resilience",
+        "description": "How tough crops are.",
+        "options": {
+          "1": {
+            "label": "Very High"
+          },
+          "2": {
+            "label": "High"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Low"
+          },
+          "5": {
+            "label": "Very Low"
+          }
+        }
+      },
+      "PlantAbundance": {
+        "label": "Plant Abundance",
+        "description": "How much food crops produce.",
+        "options": {
+          "1": {
+            "label": "Very Poor"
+          },
+          "2": {
+            "label": "Poor"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundant"
+          },
+          "5": {
+            "label": "Very Abundant"
+          }
+        }
+      },
+      "KillInsideCrops": {
+        "label": "Kill Indoor Crops",
+        "description": "Whether stepping on indoor crops destroys them."
+      },
+      "PlantGrowingSeasons": {
+        "label": "Plant Growing Seasons",
+        "description": "Restrict crop growth to appropriate seasons."
+      },
+      "PlaceDirtAboveground": {
+        "label": "Place Dirt Aboveground",
+        "description": "Allow placing dirt on built floors above ground."
+      },
+      "FarmingSpeedNew": {
+        "label": "Farming Speed",
+        "description": "Growth speed multiplier. Lower = faster."
+      },
+      "FarmingAmountNew": {
+        "label": "Farming Amount",
+        "description": "Multiplier for number of crops harvested."
+      },
+      "ClayLakeChance": {
+        "label": "Clay Lake Chance",
+        "description": "Chance of finding clay when digging near lakes."
+      },
+      "ClayRiverChance": {
+        "label": "Clay River Chance",
+        "description": "Chance of finding clay when digging near rivers."
+      }
+    },
+    "world": {
+      "SurvivorHouseChance": {
+        "label": "Survivor House Chance",
+        "description": "Chance of finding survivor-modified houses.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always Tries"
+          }
+        }
+      },
+      "VehicleStoryChance": {
+        "label": "Vehicle Story Chance",
+        "description": "Chance of finding story-decorated vehicles.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "ZoneStoryChance": {
+        "label": "Zone Story Chance",
+        "description": "Chance of encountering zone-based story setups.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      }
+    },
+    "zombieLore": {
+      "Speed": {
+        "label": "Zombie Speed",
+        "description": "How fast zombies move.",
+        "options": {
+          "1": {
+            "label": "Sprinters"
+          },
+          "2": {
+            "label": "Fast Shamblers"
+          },
+          "3": {
+            "label": "Shamblers"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Strength": {
+        "label": "Strength",
+        "description": "How strong zombies are.",
+        "options": {
+          "1": {
+            "label": "Superhuman"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Weak"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Toughness": {
+        "label": "Toughness",
+        "description": "How tough zombies are to kill.",
+        "options": {
+          "1": {
+            "label": "Tough"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Fragile"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Transmission": {
+        "label": "Transmission",
+        "description": "How the zombie infection spreads.",
+        "options": {
+          "1": {
+            "label": "Blood and Saliva"
+          },
+          "2": {
+            "label": "Saliva Only"
+          },
+          "3": {
+            "label": "Everyone's Infected"
+          },
+          "4": {
+            "label": "None"
+          }
+        }
+      },
+      "Mortality": {
+        "label": "Infection Mortality",
+        "description": "How deadly the infection is.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0-30 Seconds"
+          },
+          "3": {
+            "label": "0-1 Minutes"
+          },
+          "4": {
+            "label": "0-12 Hours"
+          },
+          "5": {
+            "label": "2-3 Days"
+          },
+          "6": {
+            "label": "1-2 Weeks"
+          },
+          "7": {
+            "label": "Never"
+          }
+        }
+      },
+      "Cognition": {
+        "label": "Cognition",
+        "description": "What zombies can interact with.",
+        "options": {
+          "1": {
+            "label": "Navigate and Use Doors"
+          },
+          "2": {
+            "label": "Navigate"
+          },
+          "3": {
+            "label": "Basic Navigation"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Memory": {
+        "label": "Memory",
+        "description": "How long zombies remember where they last saw a target.",
+        "options": {
+          "1": {
+            "label": "Long"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Short"
+          },
+          "4": {
+            "label": "None"
+          },
+          "5": {
+            "label": "Random"
+          },
+          "6": {
+            "label": "Random between Normal and None"
+          }
+        }
+      },
+      "Sight": {
+        "label": "Sight",
+        "description": "How far zombies can see targets.",
+        "options": {
+          "1": {
+            "label": "Eagle"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Poor"
+          },
+          "4": {
+            "label": "Random"
+          },
+          "5": {
+            "label": "Random between Normal and Poor"
+          }
+        }
+      },
+      "Hearing": {
+        "label": "Hearing",
+        "description": "How well zombies can hear sounds.",
+        "options": {
+          "1": {
+            "label": "Pinpoint"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Poor"
+          },
+          "4": {
+            "label": "Random"
+          },
+          "5": {
+            "label": "Random between Normal and Poor"
+          }
+        }
+      },
+      "SpottedLogic": {
+        "label": "New Stealth System",
+        "description": "How zombies decide to chase their targets."
+      },
+      "ThumpNoChasing": {
+        "label": "Environmental Attacks",
+        "description": "Zombies that weren't chasing a player will not thump constructions."
+      },
+      "ThumpOnConstruction": {
+        "label": "Damage Construction",
+        "description": "Zombies thump player-built structures."
+      },
+      "ActiveOnly": {
+        "label": "Day/Night Zombie Speed Effect",
+        "description": "Zombies active during specific times.",
+        "options": {
+          "1": {
+            "label": "Both"
+          },
+          "2": {
+            "label": "Night"
+          },
+          "3": {
+            "label": "Day"
+          }
+        }
+      },
+      "TriggerHouseAlarm": {
+        "label": "Zombie House Alarm Triggering",
+        "description": "Whether zombies can randomly trigger house alarms."
+      },
+      "ZombiesDragDown": {
+        "label": "Zombies Drag Down",
+        "description": "Multiple zombies can pull player to ground."
+      },
+      "ZombiesCrawlersDragDown": {
+        "label": "Crawlers Drag Down",
+        "description": "Crawlers can drag players down."
+      },
+      "ZombiesFenceLunge": {
+        "label": "Fence Lunge",
+        "description": "Zombies can lunge at you over fences."
+      },
+      "ZombiesArmorFactor": {
+        "label": "Zombies Armor Factor",
+        "description": "Multiplier for zombie armor from clothing. Higher = harder to kill."
+      },
+      "ZombiesMaxDefense": {
+        "label": "Maximum Zombie Armor Defense",
+        "description": "Maximum defense value zombies can have."
+      },
+      "ChanceOfAttachedWeapon": {
+        "label": "Chance Of Attached Weapon",
+        "description": "Chance a zombie has a weapon stuck in them."
+      },
+      "ZombiesFallDamage": {
+        "label": "Zombie Fall Damage Multiplier",
+        "description": "Whether zombies can die from falling."
+      },
+      "DisableFakeDead": {
+        "label": "Fake Dead Zombie Reanimation",
+        "description": "No zombies will pretend to be dead.",
+        "options": {
+          "1": {
+            "label": "World Zombies"
+          },
+          "2": {
+            "label": "World and Combat Zombies"
+          },
+          "3": {
+            "label": "Never"
+          }
+        }
+      },
+      "PlayerSpawnZombieRemoval": {
+        "label": "Spawn Zone Clear",
+        "description": "Distance around spawn points cleared of zombies.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Small"
+          },
+          "3": {
+            "label": "Medium"
+          },
+          "4": {
+            "label": "Large"
+          },
+          "5": {
+            "label": "Very Large"
+          }
+        }
+      },
+      "FenceThumpersRequired": {
+        "label": "Zombies To Damage Fences",
+        "description": "Minimum zombies needed to damage a fence."
+      },
+      "FenceDamageMultiplier": {
+        "label": "Fence Damage Multiplier",
+        "description": "Multiplier for damage zombies do to fences."
+      },
+      "DoorOpeningPercentage": {
+        "label": "Random Door Opening Amount",
+        "description": "Percentage of zombies that can open doors when cognition allows it."
+      },
+      "CrawlUnderVehicle": {
+        "label": "Crawl Under Vehicle",
+        "description": "Crawler zombies can crawl under vehicles.",
+        "options": {
+          "1": {
+            "label": "Crawlers Only"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      },
+      "SprinterPercentage": {
+        "label": "Random Sprinter Amount",
+        "description": "Percentage of sprinter zombies when Speed is set to Random."
+      },
+      "Reanimate": {
+        "label": "Reanimate Time",
+        "description": "Dead zombies can get back up after being killed.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0-30 Seconds"
+          },
+          "3": {
+            "label": "0-1 Minutes"
+          },
+          "4": {
+            "label": "0-12 Hours"
+          },
+          "5": {
+            "label": "2-3 Days"
+          },
+          "6": {
+            "label": "1-2 Weeks"
+          }
+        }
+      }
+    },
+    "zombiePopulation": {
+      "PopulationMultiplier": {
+        "label": "Population Multiplier",
+        "description": "Overall zombie population multiplier."
+      },
+      "PopulationStartMultiplier": {
+        "label": "Start Multiplier",
+        "description": "Zombie population at game start."
+      },
+      "PopulationPeakMultiplier": {
+        "label": "Peak Multiplier",
+        "description": "Zombie population at peak day."
+      },
+      "PopulationPeakDay": {
+        "label": "Peak Day",
+        "description": "Day when zombie population peaks."
+      },
+      "RespawnHours": {
+        "label": "Respawn Hours",
+        "description": "Hours before zombies respawn. 0 = disabled."
+      },
+      "RespawnUnseenHours": {
+        "label": "Unseen Hours",
+        "description": "Hours a chunk must be unseen before respawn."
+      },
+      "RespawnMultiplier": {
+        "label": "Respawn Multiplier",
+        "description": "Fraction of population that respawns."
+      },
+      "RedistributeHours": {
+        "label": "Redistribute Hours",
+        "description": "Hours between zombie redistribution across the map."
+      },
+      "FollowSoundDistance": {
+        "label": "Follow Sound Distance",
+        "description": "How far zombies will follow sounds in cells."
+      },
+      "RallyGroupSize": {
+        "label": "Rally Group Size",
+        "description": "Base number of zombies in rally groups."
+      },
+      "RallyGroupSizeVariance": {
+        "label": "Rally Group Size Variance",
+        "description": "The amount, as a percentage, that zombie groups can vary in size from the default (both larger and smaller)."
+      },
+      "RallyTravelDistance": {
+        "label": "Rally Travel Distance",
+        "description": "How far rally groups travel in cells."
+      },
+      "RallyGroupSeparation": {
+        "label": "Rally Group Separation",
+        "description": "Minimum distance between rally groups."
+      },
+      "RallyGroupRadius": {
+        "label": "Rally Group Radius",
+        "description": "Radius of area a rally group spreads across."
+      },
+      "ZombiesCountBeforeDelete": {
+        "label": "Zombies Count Before Delete",
+        "description": "Minimum zombie count in a cell before deletion can occur."
+      }
+    },
+    "xpMultipliers": {
+      "Global": {
+        "label": "Global XP Multiplier",
+        "description": "The rate at which all skills level up."
+      },
+      "GlobalToggle": {
+        "label": "Use Global Multiplier For All Skills",
+        "description": "When enabled, all skills will use the Global Multiplier instead of individual values."
+      },
+      "Sprinting": {
+        "label": "Sprinting XP",
+        "description": "XP multiplier for Sprinting skill."
+      },
+      "Lightfoot": {
+        "label": "Lightfoot XP",
+        "description": "XP multiplier for Lightfoot skill."
+      },
+      "Nimble": {
+        "label": "Nimble XP",
+        "description": "XP multiplier for Nimble skill."
+      },
+      "Sneak": {
+        "label": "Sneaking XP",
+        "description": "XP multiplier for Sneaking skill."
+      },
+      "Axe": {
+        "label": "Axe XP",
+        "description": "XP multiplier for Axe skill."
+      },
+      "Blunt": {
+        "label": "Blunt XP",
+        "description": "XP multiplier for Blunt skill."
+      },
+      "SmallBlade": {
+        "label": "Small Blade XP",
+        "description": "XP multiplier for Small Blade skill."
+      },
+      "LongBlade": {
+        "label": "Long Blade XP",
+        "description": "XP multiplier for Long Blade skill."
+      },
+      "SmallBlunt": {
+        "label": "Small Blunt XP",
+        "description": "XP multiplier for Small Blunt skill."
+      },
+      "Aiming": {
+        "label": "Aiming XP",
+        "description": "XP multiplier for Aiming skill."
+      },
+      "Reloading": {
+        "label": "Reloading XP",
+        "description": "XP multiplier for Reloading skill."
+      },
+      "Fishing": {
+        "label": "Fishing XP",
+        "description": "XP multiplier for Fishing skill."
+      },
+      "Trapping": {
+        "label": "Trapping XP",
+        "description": "XP multiplier for Trapping skill."
+      },
+      "Woodwork": {
+        "label": "Carpentry XP",
+        "description": "XP multiplier for Carpentry skill."
+      },
+      "Cooking": {
+        "label": "Cooking XP",
+        "description": "XP multiplier for Cooking skill."
+      },
+      "Farming": {
+        "label": "Farming XP",
+        "description": "XP multiplier for Farming skill."
+      },
+      "Doctor": {
+        "label": "First Aid XP",
+        "description": "XP multiplier for First Aid skill."
+      },
+      "Electricity": {
+        "label": "Electricity XP",
+        "description": "XP multiplier for Electricity skill."
+      },
+      "MetalWelding": {
+        "label": "Metalworking XP",
+        "description": "XP multiplier for Metalworking skill."
+      },
+      "Mechanics": {
+        "label": "Mechanics XP",
+        "description": "XP multiplier for Mechanics skill."
+      },
+      "Tailoring": {
+        "label": "Tailoring XP",
+        "description": "XP multiplier for Tailoring skill."
+      },
+      "Maintenance": {
+        "label": "Maintenance XP",
+        "description": "XP multiplier for Maintenance skill."
+      },
+      "PlantScavenging": {
+        "label": "Foraging XP",
+        "description": "XP multiplier for Foraging skill."
+      },
+      "Fitness": {
+        "label": "Fitness XP",
+        "description": "XP multiplier for Fitness skill."
+      },
+      "Strength": {
+        "label": "Strength XP",
+        "description": "XP multiplier for Strength skill."
+      },
+      "FlintKnapping": {
+        "label": "Knapping XP",
+        "description": "XP multiplier for Knapping skill."
+      },
+      "Carving": {
+        "label": "Carving XP",
+        "description": "XP multiplier for Carving skill."
+      },
+      "Tracking": {
+        "label": "Tracking XP",
+        "description": "XP multiplier for Tracking skill."
+      },
+      "Butchering": {
+        "label": "Butchering XP",
+        "description": "XP multiplier for Butchering skill."
+      },
+      "Glassmaking": {
+        "label": "Glassmaking XP",
+        "description": "XP multiplier for Glassmaking skill."
+      },
+      "Husbandry": {
+        "label": "Animal Husbandry XP",
+        "description": "XP multiplier for Animal Husbandry skill."
+      },
+      "Spear": {
+        "label": "Spear XP",
+        "description": "XP multiplier for Spear skill."
+      },
+      "Masonry": {
+        "label": "Masonry XP",
+        "description": "XP multiplier for Masonry skill."
+      },
+      "Pottery": {
+        "label": "Pottery XP",
+        "description": "XP multiplier for Pottery skill."
+      },
+      "Blacksmith": {
+        "label": "Blacksmith XP",
+        "description": "XP multiplier for Blacksmith skill."
+      }
+    },
+    "map": {
+      "AllowMiniMap": {
+        "label": "Allow Mini Map",
+        "description": "Whether the in-game mini map is available."
+      },
+      "AllowWorldMap": {
+        "label": "Allow World Map",
+        "description": "Whether the in-game world map is available."
+      },
+      "MapAllKnown": {
+        "label": "Map All Known",
+        "description": "The entire map is revealed from the start."
+      },
+      "MapNeedsLight": {
+        "label": "Map Needs Light",
+        "description": "Map can only be used when there is enough light."
+      }
+    },
+    "basement": {
+      "SpawnFrequency": {
+        "label": "Basement Spawn Frequency",
+        "description": "How often basements appear in buildings.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Very Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      }
+    }
+  },
+  "iniCategories": {
+    "general": {
+      "label": "General"
+    },
+    "network": {
+      "label": "Network & Ports"
+    },
+    "steam": {
+      "label": "Steam Integration"
+    },
+    "discord": {
+      "label": "Discord"
+    },
+    "rcon": {
+      "label": "RCON"
+    },
+    "voice": {
+      "label": "Voice Chat"
+    },
+    "players": {
+      "label": "Players & Accounts"
+    },
+    "safehouse": {
+      "label": "Safehouses"
+    },
+    "chat": {
+      "label": "Chat & Communication"
+    },
+    "pvp": {
+      "label": "PvP & Safety"
+    },
+    "moderation": {
+      "label": "Moderation"
+    },
+    "anticheat": {
+      "label": "Anti-Cheat"
+    },
+    "loot": {
+      "label": "Loot & Items"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "mods": {
+      "label": "Mods & Workshop"
+    },
+    "radio": {
+      "label": "Radio"
+    },
+    "war": {
+      "label": "Faction War"
+    },
+    "backups": {
+      "label": "Backups"
+    },
+    "logging": {
+      "label": "Logging"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
+  },
+  "iniCategoryGroups": {
+    "identity": {
+      "label": "Identity"
+    },
+    "connectivity": {
+      "label": "Connectivity"
+    },
+    "players": {
+      "label": "Players"
+    },
+    "gameplay": {
+      "label": "Gameplay"
+    },
+    "ops": {
+      "label": "Ops"
+    }
+  },
+  "sandboxCategories": {
+    "time": {
+      "label": "Time & Season"
+    },
+    "environment": {
+      "label": "Environment & Weather"
+    },
+    "world": {
+      "label": "World & Stories"
+    },
+    "map": {
+      "label": "Map & Navigation"
+    },
+    "zombieLore": {
+      "label": "Zombie Behavior"
+    },
+    "zombiePopulation": {
+      "label": "Zombie Population"
+    },
+    "population": {
+      "label": "Population & Distribution"
+    },
+    "survival": {
+      "label": "Survival & Health"
+    },
+    "combat": {
+      "label": "Combat & Firearms"
+    },
+    "loot": {
+      "label": "Loot & Resources"
+    },
+    "lootRarity": {
+      "label": "Loot Rarity"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "animals": {
+      "label": "Animals & Farming"
+    },
+    "xpMultipliers": {
+      "label": "XP Multipliers"
+    },
+    "basement": {
+      "label": "Basements"
+    }
+  },
+  "sandboxCategoryGroups": {
+    "world": {
+      "label": "World"
+    },
+    "zombies": {
+      "label": "Zombies"
+    },
+    "survival": {
+      "label": "Survival"
+    },
+    "resources": {
+      "label": "Resources"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
   }
 }

--- a/client/src/locales/es/serverconfig.json
+++ b/client/src/locales/es/serverconfig.json
@@ -386,5 +386,3651 @@
     "title": "¿Restaurar esta copia de seguridad?",
     "description": "¿Reemplazar el archivo actual por «{{filename}}»? Se perderán los cambios sin guardar de la configuración activa.",
     "confirmLabel": "Restaurar"
+  },
+  "iniSettings": {
+    "general": {
+      "PublicName": {
+        "label": "Server Name",
+        "description": "Your server name as shown to the public."
+      },
+      "PublicDescription": {
+        "label": "Server Description",
+        "description": "The description that people can see while browsing your server."
+      },
+      "Public": {
+        "label": "Public Server",
+        "description": "Can your server be seen on Steam server browser."
+      },
+      "Open": {
+        "label": "Open (No Whitelist)",
+        "description": "Open to all players without requiring whitelist."
+      },
+      "Password": {
+        "label": "Server Password",
+        "description": "Password required to join the server. Leave empty for no password."
+      },
+      "MaxPlayers": {
+        "label": "Max Players",
+        "description": "Maximum allowed number of players."
+      },
+      "PauseEmpty": {
+        "label": "Pause When Empty",
+        "description": "The server will pause when no players are logged in."
+      },
+      "ServerWelcomeMessage": {
+        "label": "Welcome Message",
+        "description": "The welcome message displayed to players after connecting. Use <LINE> for new lines."
+      },
+      "Map": {
+        "label": "Map",
+        "description": "The map you're playing on. Default is Muldraugh, KY."
+      },
+      "SaveWorldEveryMinutes": {
+        "label": "Auto-Save Interval",
+        "description": "Auto-save world every X minutes. 0 = never."
+      },
+      "AnnounceDeath": {
+        "label": "Announce Deaths",
+        "description": "Server-wide announcement when a character dies."
+      },
+      "AnnounceAnimalDeath": {
+        "label": "Announce Animal Deaths",
+        "description": "Display a global chat message when an animal dies."
+      },
+      "Seed": {
+        "label": "World Seed",
+        "description": "The worldgen seed used to generate the world. Changing this requires deleting map_worldgen.bin."
+      }
+    },
+    "network": {
+      "DefaultPort": {
+        "label": "Game Port",
+        "description": "The port players will use to connect to your server. Must be open on your router."
+      },
+      "UPnP": {
+        "label": "Enable UPnP",
+        "description": "Enable UPnP for automatic port forwarding."
+      },
+      "PingFrequency": {
+        "label": "Ping Frequency",
+        "description": "How often the server checks connection to players (seconds)."
+      },
+      "PingLimit": {
+        "label": "Ping Limit",
+        "description": "Ping limit before being kicked (milliseconds). 100 to disable."
+      },
+      "DenyLoginOnOverloadedServer": {
+        "label": "Deny Login When Overloaded",
+        "description": "Prevent new connections when server is overloaded."
+      },
+      "SpeedLimit": {
+        "label": "Speed Limit",
+        "description": "Maximum movement speed allowed."
+      },
+      "UseTCPForMapDownloads": {
+        "label": "Use TCP for Map Downloads",
+        "description": "Use TCP instead of UDP for map downloads."
+      },
+      "MaxPacketsPerSecond": {
+        "label": "Max Packets Per Second",
+        "description": "Cap on packets per second sent to a connected client. Higher values increase bandwidth use; lower values may cause stutter under load."
+      },
+      "UDPPort": {
+        "label": "UDP Port",
+        "description": "Second port used for UDP connections."
+      },
+      "LoginQueueEnabled": {
+        "label": "Login Queue",
+        "description": "Enable a login queue when the server is full."
+      },
+      "LoginQueueConnectTimeout": {
+        "label": "Login Queue Timeout",
+        "description": "Seconds before a queued connection times out."
+      },
+      "server_browser_announced_ip": {
+        "label": "Announced IP",
+        "description": "IP address broadcast to the server browser. For multi-IP setups like server farms."
+      },
+      "MultiplayerStatisticsPeriod": {
+        "label": "Statistics Period",
+        "description": "Multiplayer statistics update period in seconds. 0 = disabled."
+      }
+    },
+    "pvp": {
+      "PVP": {
+        "label": "Enable PvP",
+        "description": "Allow player vs player combat (each player can still toggle their own PvP)."
+      },
+      "SafetySystem": {
+        "label": "Safety System",
+        "description": "If PvP is enabled, allows players to toggle their own PvP on/off."
+      },
+      "ShowSafety": {
+        "label": "Show Safety Status",
+        "description": "Show skull icon for players with safety off."
+      },
+      "SafetyToggleTimer": {
+        "label": "Safety Toggle Timer",
+        "description": "Time in seconds to switch between PvP on and off."
+      },
+      "SafetyCooldownTimer": {
+        "label": "Safety Cooldown Timer",
+        "description": "Time in seconds before you can toggle safety again."
+      },
+      "PVPMeleeWhileHitReaction": {
+        "label": "Melee While Hit Reaction",
+        "description": "Allow melee attacks during hit reaction in PvP."
+      },
+      "PVPMeleeDamageModifier": {
+        "label": "PvP Melee Damage %",
+        "description": "Melee damage modifier for PvP (percentage)."
+      },
+      "PVPFirearmDamageModifier": {
+        "label": "PvP Firearm Damage %",
+        "description": "Firearm damage modifier for PvP (percentage)."
+      },
+      "PlayerBumpPlayer": {
+        "label": "Player Collision",
+        "description": "Players can bump into each other."
+      },
+      "PVPLogToolChat": {
+        "label": "Log PvP to Chat",
+        "description": "PvP events are logged to admin chat."
+      },
+      "PVPLogToolFile": {
+        "label": "Log PvP to File",
+        "description": "PvP events are logged to a file."
+      },
+      "SafetyDisconnectDelay": {
+        "label": "Safety Disconnect Delay",
+        "description": "Seconds before PvP safety mode resets on disconnect."
+      }
+    },
+    "chat": {
+      "GlobalChat": {
+        "label": "Enable Global Chat",
+        "description": "Enable /all command for server-wide chat."
+      },
+      "ChatStreams": {
+        "label": "Chat Streams",
+        "description": "Enabled chat streams: s=say, r=radio, a=admin, w=whisper, y=yell, sh=safehouse, f=faction, all=global."
+      },
+      "DisplayUserName": {
+        "label": "Display Usernames",
+        "description": "Show player usernames above their heads and in chat."
+      },
+      "ShowFirstAndLastName": {
+        "label": "Show Character Names",
+        "description": "Display character first and last name instead of username."
+      },
+      "MouseOverToSeeDisplayName": {
+        "label": "Mouse Over for Name",
+        "description": "Require mouse hover to see player names."
+      },
+      "HidePlayersBehindYou": {
+        "label": "Hide Players Behind You",
+        "description": "Hide player names for players behind your character."
+      },
+      "AllowNonAsciiUsername": {
+        "label": "Allow Non-ASCII Usernames",
+        "description": "Allow usernames with non-ASCII characters."
+      },
+      "BanKickGlobalSound": {
+        "label": "Ban/Kick Sound",
+        "description": "Play global sound when a player is banned or kicked."
+      },
+      "UsernameDisguises": {
+        "label": "Username Disguises",
+        "description": "Allow players to disguise their username."
+      },
+      "HideDisguisedUserName": {
+        "label": "Hide Disguised Names",
+        "description": "Hide the real username of disguised players."
+      },
+      "ChatMessageCharacterLimit": {
+        "label": "Chat Character Limit",
+        "description": "Maximum characters per chat message."
+      },
+      "ChatMessageSlowModeTime": {
+        "label": "Chat Slow Mode",
+        "description": "Seconds between allowed chat messages per player."
+      }
+    },
+    "players": {
+      "MaxAccountsPerUser": {
+        "label": "Max Accounts Per User",
+        "description": "Limit accounts per Steam user. 0 = unlimited."
+      },
+      "DropOffWhiteListAfterDeath": {
+        "label": "Remove From Whitelist On Death",
+        "description": "Remove player from whitelist if their character dies."
+      },
+      "KickFastPlayers": {
+        "label": "Kick Speed Hackers",
+        "description": "Kick players moving faster than possible. May be buggy."
+      },
+      "SpawnPoint": {
+        "label": "Spawn Point",
+        "description": "Custom spawn point coordinates (X,Y,Z). 0,0,0 for default."
+      },
+      "SpawnItems": {
+        "label": "Spawn Items",
+        "description": "Items new characters spawn with (comma-separated, e.g., Base.BaseballBat,Base.WaterBottleFull)."
+      },
+      "SleepAllowed": {
+        "label": "Allow Sleep",
+        "description": "Whether sleeping is allowed."
+      },
+      "SleepNeeded": {
+        "label": "Sleep Required",
+        "description": "Whether players need to sleep when exhausted."
+      },
+      "PlayerRespawnWithSelf": {
+        "label": "Respawn at Death Location",
+        "description": "Allow respawning at death location."
+      },
+      "PlayerRespawnWithOther": {
+        "label": "Respawn with Partner",
+        "description": "Enable spawning at splitscreen partner location."
+      },
+      "PlayerSaveOnDamage": {
+        "label": "Save on Damage",
+        "description": "Save player state when they take damage."
+      },
+      "Faction": {
+        "label": "Enable Factions",
+        "description": "Allow creation and use of factions."
+      },
+      "FactionDaySurvivedToCreate": {
+        "label": "Days to Create Faction",
+        "description": "Days a player must survive to create a faction."
+      },
+      "FactionPlayersRequiredForTag": {
+        "label": "Players for Faction Tag",
+        "description": "Players required in faction to show tag."
+      },
+      "AllowTradeUI": {
+        "label": "Allow Trading",
+        "description": "Allow players to directly trade with one another."
+      },
+      "AllowCoop": {
+        "label": "Allow Co-op",
+        "description": "Allow co-op/splitscreen players to join."
+      },
+      "KnockedDownAllowed": {
+        "label": "Knocked Down",
+        "description": "Allow players to be knocked down. WIP: may cause visual desync."
+      },
+      "SneakModeHideFromOtherPlayers": {
+        "label": "Sneak Hides From Players",
+        "description": "Players in sneak mode are hidden from other players."
+      },
+      "MapRemotePlayerVisibility": {
+        "label": "Map Player Visibility",
+        "description": "Who can see other players on the in-game map.",
+        "options": {
+          "1": {
+            "label": "Hidden"
+          },
+          "2": {
+            "label": "Friends Only"
+          },
+          "3": {
+            "label": "Friends and Nearby Players"
+          },
+          "4": {
+            "label": "Everyone"
+          }
+        }
+      },
+      "DisableScoreboard": {
+        "label": "Disable Scoreboard",
+        "description": "Disable the in-game scoreboard."
+      },
+      "HideAdminsInPlayerList": {
+        "label": "Hide Admins in Player List",
+        "description": "Hide admin accounts from the player list."
+      }
+    },
+    "safehouse": {
+      "PlayerSafehouse": {
+        "label": "Enable Safehouses",
+        "description": "Allow players to claim safehouses."
+      },
+      "AdminSafehouse": {
+        "label": "Admin Safehouses",
+        "description": "Allow admins to have safehouses."
+      },
+      "SafehouseAllowTrepass": {
+        "label": "Allow Trespass",
+        "description": "Allow non-members to enter safehouses without invite."
+      },
+      "SafehouseAllowFire": {
+        "label": "Allow Fire Damage",
+        "description": "Allow fire to damage safehouses."
+      },
+      "SafehouseAllowLoot": {
+        "label": "Allow Looting",
+        "description": "Allow non-members to take items from safehouses."
+      },
+      "SafehouseAllowRespawn": {
+        "label": "Allow Safehouse Respawn",
+        "description": "Players can respawn in their safehouse."
+      },
+      "SafehouseDaySurvivedToClaim": {
+        "label": "Days to Claim Safehouse",
+        "description": "Days a player must survive before claiming a safehouse."
+      },
+      "SafeHouseRemovalTime": {
+        "label": "Safehouse Removal Time",
+        "description": "Real-time hours of inactivity before removal from safehouse."
+      },
+      "DisableSafehouseWhenOwnerConnected": {
+        "label": "Disable When Owner Online",
+        "description": "Disable safehouse protection when the owner is connected. (Renamed from DisableSafehouseWhenPlayerConnected in the Dec 2025 MP patch.)"
+      },
+      "SafehouseAllowNonResidential": {
+        "label": "Allow Non-Residential",
+        "description": "Allow players to claim non-residential buildings as safehouses."
+      },
+      "SafehouseDisableDisguises": {
+        "label": "Disable Disguises in Safehouse",
+        "description": "Disable username disguises inside safehouses."
+      },
+      "MaxSafezoneSize": {
+        "label": "Max Safezone Size",
+        "description": "Maximum tile size for safezones."
+      }
+    },
+    "loot": {
+      "ItemNumbersLimitPerContainer": {
+        "label": "Container Item Limit",
+        "description": "Max items per container. 0 = unlimited."
+      },
+      "TrashDeleteAll": {
+        "label": "Delete All Trash",
+        "description": "Delete all items when placed in trash."
+      },
+      "RemovePlayerCorpsesOnCorpseRemoval": {
+        "label": "Remove Player Corpses",
+        "description": "Remove player corpses when corpse removal runs."
+      },
+      "AllowDestructionBySledgehammer": {
+        "label": "Sledgehammer Destruction",
+        "description": "Allow players to destroy world objects with sledgehammer."
+      },
+      "NoFire": {
+        "label": "Disable Fire",
+        "description": "Disable all fires except campfires."
+      },
+      "SafehousePreventsLootRespawn": {
+        "label": "Safehouse Blocks Loot Respawn",
+        "description": "Items will not respawn in buildings claimed as safehouses."
+      },
+      "SledgehammerOnlyInSafehouse": {
+        "label": "Sledgehammer Only in Safehouse",
+        "description": "Restrict sledgehammer destruction to safehouses only. Requires Sledgehammer Destruction enabled."
+      }
+    },
+    "mods": {
+      "Mods": {
+        "label": "Mods",
+        "description": "List of installed mod IDs (semicolon-separated)."
+      },
+      "WorkshopItems": {
+        "label": "Workshop Items",
+        "description": "Steam Workshop item IDs to download (semicolon-separated)."
+      },
+      "DoLuaChecksum": {
+        "label": "Lua Checksum",
+        "description": "Verify client Lua matches server. Must be disabled when using PanelBridge — the mod modifies server-side Lua files, which causes checksum mismatches and prevents players from connecting."
+      }
+    },
+    "steam": {
+      "SteamPort1": {
+        "label": "Steam Port 1",
+        "description": "First Steam port."
+      },
+      "SteamPort2": {
+        "label": "Steam Port 2",
+        "description": "Second Steam port."
+      },
+      "SteamScoreboard": {
+        "label": "Steam Scoreboard",
+        "description": "Show Steam usernames and avatars. true/false/admin.",
+        "options": {
+          "true": {
+            "label": "Everyone"
+          },
+          "false": {
+            "label": "No One"
+          },
+          "admin": {
+            "label": "Admins Only"
+          }
+        }
+      },
+      "SteamVAC": {
+        "label": "VAC Ban Check",
+        "description": "Check if connecting players have VAC bans."
+      }
+    },
+    "voice": {
+      "VoiceEnable": {
+        "label": "Enable Voice Chat",
+        "description": "Enable in-game voice chat."
+      },
+      "Voice3D": {
+        "label": "3D Voice",
+        "description": "Enable 3D positional voice chat."
+      },
+      "VoiceMinDistance": {
+        "label": "Voice Min Distance",
+        "description": "Minimum voice distance."
+      },
+      "VoiceMaxDistance": {
+        "label": "Voice Max Distance",
+        "description": "Maximum voice distance."
+      }
+    },
+    "discord": {
+      "DiscordEnable": {
+        "label": "Enable Discord",
+        "description": "Enable built-in Discord integration."
+      },
+      "DiscordToken": {
+        "label": "Discord Token",
+        "description": "Discord bot token."
+      },
+      "DiscordChannel": {
+        "label": "Discord Channel",
+        "description": "Discord channel name."
+      },
+      "DiscordChannelID": {
+        "label": "Discord Channel ID",
+        "description": "Discord channel ID."
+      },
+      "DiscordChatChannel": {
+        "label": "Discord Chat Channel",
+        "description": "The Discord channel name for game chat."
+      },
+      "DiscordLogChannel": {
+        "label": "Discord Log Channel",
+        "description": "The Discord channel name for server logs."
+      },
+      "DiscordCommandChannel": {
+        "label": "Discord Command Channel",
+        "description": "The Discord channel name for commands."
+      },
+      "WebhookAddress": {
+        "label": "Webhook URL",
+        "description": "Slack/Discord incoming webhook URL for notifications."
+      }
+    },
+    "rcon": {
+      "RCONPort": {
+        "label": "RCON Port",
+        "description": "Port for RCON connections."
+      },
+      "RCONPassword": {
+        "label": "RCON Password",
+        "description": "Password for RCON connections."
+      }
+    },
+    "advanced": {
+      "ResetID": {
+        "label": "Reset ID",
+        "description": "Removing this resets zombies and loot (not time)."
+      },
+      "ServerPlayerID": {
+        "label": "Server Player ID",
+        "description": "Identifies if character is from another server."
+      },
+      "PhysicsDelay": {
+        "label": "Physics Delay",
+        "description": "Physics update delay in milliseconds."
+      },
+      "FastForwardMultiplier": {
+        "label": "Fast Forward Multiplier",
+        "description": "Speed multiplier when fast-forwarding."
+      },
+      "CarEngineAttractionModifier": {
+        "label": "Car Engine Attraction",
+        "description": "Modifier for zombie attraction to car engines."
+      },
+      "ZombieUpdateMaxHighPriority": {
+        "label": "Zombie High Priority Updates",
+        "description": "Max high priority zombie updates per tick."
+      },
+      "ZombieUpdateDelta": {
+        "label": "Zombie Update Delta",
+        "description": "Zombie update time delta."
+      },
+      "SwitchZombiesOwnershipEachUpdate": {
+        "label": "Switch Zombie Ownership",
+        "description": "Switch zombie ownership between players each update tick."
+      },
+      "UltraSpeedDoesnotAffectToAnimals": {
+        "label": "Ultra Speed Ignores Animals",
+        "description": "Ultra speed mode does not affect animal simulation."
+      },
+      "UsePhysicsHitReaction": {
+        "label": "Physics Hit Reaction",
+        "description": "Use physics-based hit reactions."
+      }
+    },
+    "war": {
+      "War": {
+        "label": "Enable Faction War",
+        "description": "Enable faction war system. (Disabled by default since the Dec 2025 MP patch.)"
+      },
+      "WarStartDelay": {
+        "label": "War Start Delay",
+        "description": "Seconds before war starts after being declared."
+      },
+      "WarDuration": {
+        "label": "War Duration",
+        "description": "War duration in seconds."
+      },
+      "WarSafehouseHitPoints": {
+        "label": "War Safehouse Hit Points",
+        "description": "Safehouse hit points during faction war."
+      }
+    },
+    "radio": {
+      "DisableRadioStaff": {
+        "label": "Disable Radio for Staff",
+        "description": "Disable radio transmissions from staff access level."
+      },
+      "DisableRadioAdmin": {
+        "label": "Disable Radio for Admins",
+        "description": "Disable radio transmissions from admin access level."
+      },
+      "DisableRadioGM": {
+        "label": "Disable Radio for GMs",
+        "description": "Disable radio transmissions from GM access level."
+      },
+      "DisableRadioOverseer": {
+        "label": "Disable Radio for Overseers",
+        "description": "Disable radio transmissions from overseer access level."
+      },
+      "DisableRadioModerator": {
+        "label": "Disable Radio for Moderators",
+        "description": "Disable radio transmissions from moderator access level."
+      },
+      "DisableRadioInvisible": {
+        "label": "Disable Radio for Invisible",
+        "description": "Disable radio transmissions from invisible players."
+      }
+    },
+    "backups": {
+      "BackupsCount": {
+        "label": "Backup Count",
+        "description": "Number of backup copies to keep."
+      },
+      "BackupsOnStart": {
+        "label": "Backup on Start",
+        "description": "Create a backup when the server starts."
+      },
+      "BackupsOnVersionChange": {
+        "label": "Backup on Version Change",
+        "description": "Create a backup when the game version changes."
+      },
+      "BackupsPeriod": {
+        "label": "Backup Period",
+        "description": "Minutes between automatic backups. 0 = disabled."
+      }
+    },
+    "vehicles": {
+      "DisableVehicleTowing": {
+        "label": "Disable Vehicle Towing",
+        "description": "Disable vehicle towing."
+      },
+      "DisableTrailerTowing": {
+        "label": "Disable Trailer Towing",
+        "description": "Disable trailer towing."
+      },
+      "DisableBurntTowing": {
+        "label": "Disable Burnt Vehicle Towing",
+        "description": "Disable towing of burnt vehicles."
+      }
+    },
+    "moderation": {
+      "BadWordListFile": {
+        "label": "Bad Word List File",
+        "description": "Path to file with prohibited words, one per line."
+      },
+      "GoodWordListFile": {
+        "label": "Good Word List File",
+        "description": "Path to file with allowed words that may contain bad words, one per line."
+      },
+      "BadWordPolicy": {
+        "label": "Bad Word Policy",
+        "description": "Action taken when a bad word is detected in chat.",
+        "options": {
+          "1": {
+            "label": "Ban"
+          },
+          "2": {
+            "label": "Kick"
+          },
+          "3": {
+            "label": "Record Violation"
+          },
+          "4": {
+            "label": "Mute"
+          }
+        }
+      },
+      "BadWordReplacement": {
+        "label": "Bad Word Replacement",
+        "description": "Text that replaces bad words in chat."
+      }
+    },
+    "anticheat": {
+      "AntiCheatSafety": {
+        "label": "Safety",
+        "description": "Anti-cheat protection for the safety system.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSpeed": {
+        "label": "Speed",
+        "description": "Anti-cheat protection for player speed.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatNoClip": {
+        "label": "No Clip",
+        "description": "Anti-cheat protection against moving through solid objects.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatHit": {
+        "label": "Hit Detection",
+        "description": "Anti-cheat protection for character hits.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPacketException": {
+        "label": "Packet Exceptions",
+        "description": "Anti-cheat protection for invalid network packets.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPermission": {
+        "label": "Permissions",
+        "description": "Anti-cheat protection for player permissions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatXP": {
+        "label": "XP Validation",
+        "description": "Anti-cheat protection for player XP.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSafeHouse": {
+        "label": "Safehouse Protection",
+        "description": "Anti-cheat protection for safehouses.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPlayer": {
+        "label": "Player Validation",
+        "description": "Anti-cheat protection for player actions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatChecksum": {
+        "label": "Checksum Validation",
+        "description": "Anti-cheat protection for file checksums.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      }
+    },
+    "logging": {
+      "ClientCommandFilter": {
+        "label": "Command Log Filter",
+        "description": "Semicolon-separated list of commands to exclude from cmd.txt log. Use -vehicle.* to exclude all vehicle, +vehicle.installPart to include specific."
+      },
+      "ClientActionLogs": {
+        "label": "Client Action Logs",
+        "description": "Semicolon-separated list of actions written to ClientActionLogs.txt."
+      },
+      "PerkLogs": {
+        "label": "Perk Level Logging",
+        "description": "Track changes in player perk levels in PerkLog.txt."
+      }
+    }
+  },
+  "sandboxSettings": {
+    "time": {
+      "DayLength": {
+        "label": "Duración del día",
+        "description": "How long a day lasts.",
+        "options": {
+          "1": {
+            "label": "15 Minutos"
+          },
+          "2": {
+            "label": "30 Minutos"
+          },
+          "3": {
+            "label": "1 Hora"
+          },
+          "4": {
+            "label": "1 Hora, 30 Minutos"
+          },
+          "5": {
+            "label": "2 Horas"
+          },
+          "6": {
+            "label": "3 Horas"
+          },
+          "7": {
+            "label": "4 Horas"
+          },
+          "8": {
+            "label": "5 Horas"
+          },
+          "9": {
+            "label": "6 Horas"
+          },
+          "10": {
+            "label": "7 Horas"
+          },
+          "11": {
+            "label": "8 Horas"
+          },
+          "12": {
+            "label": "9 Horas"
+          },
+          "13": {
+            "label": "10 Horas"
+          },
+          "14": {
+            "label": "11 Horas"
+          },
+          "15": {
+            "label": "12 Horas"
+          },
+          "16": {
+            "label": "13 Horas"
+          },
+          "17": {
+            "label": "14 Horas"
+          },
+          "18": {
+            "label": "15 Horas"
+          },
+          "19": {
+            "label": "16 Horas"
+          },
+          "20": {
+            "label": "17 Horas"
+          },
+          "21": {
+            "label": "18 Horas"
+          },
+          "22": {
+            "label": "19 Horas"
+          },
+          "23": {
+            "label": "20 Horas"
+          },
+          "24": {
+            "label": "21 Horas"
+          },
+          "25": {
+            "label": "22 Horas"
+          },
+          "26": {
+            "label": "23 Horas"
+          },
+          "27": {
+            "label": "Tiempo real"
+          }
+        }
+      },
+      "StartYear": {
+        "label": "Año de inicio",
+        "description": "Which year the game starts in."
+      },
+      "StartMonth": {
+        "label": "Mes de inicio",
+        "description": "Which month the game starts in (1=Jan, 12=Dec).",
+        "options": {
+          "1": {
+            "label": "Enero"
+          },
+          "2": {
+            "label": "Febrero"
+          },
+          "3": {
+            "label": "Marzo"
+          },
+          "4": {
+            "label": "Abril"
+          },
+          "5": {
+            "label": "Mayo"
+          },
+          "6": {
+            "label": "Junio"
+          },
+          "7": {
+            "label": "Julio"
+          },
+          "8": {
+            "label": "Agosto"
+          },
+          "9": {
+            "label": "Septiembre"
+          },
+          "10": {
+            "label": "Octubre"
+          },
+          "11": {
+            "label": "Noviembre"
+          },
+          "12": {
+            "label": "Diciembre"
+          }
+        }
+      },
+      "StartDay": {
+        "label": "Día de inicio",
+        "description": "Which day of the month the game starts on."
+      },
+      "StartTime": {
+        "label": "Hora de inicio",
+        "description": "What time of day the game starts.",
+        "options": {
+          "1": {
+            "label": "7 AM"
+          },
+          "2": {
+            "label": "9 AM"
+          },
+          "3": {
+            "label": "12 PM"
+          },
+          "4": {
+            "label": "2 PM"
+          },
+          "5": {
+            "label": "5 PM"
+          },
+          "6": {
+            "label": "9 PM"
+          },
+          "7": {
+            "label": "12 AM"
+          },
+          "8": {
+            "label": "2 AM"
+          },
+          "9": {
+            "label": "5 AM"
+          }
+        }
+      }
+    },
+    "population": {
+      "Zombies": {
+        "label": "Número de zombis",
+        "description": "Initial zombie population level. Also sets Population Multiplier in Advanced Zombie Options.",
+        "options": {
+          "1": {
+            "label": "Zombicidio"
+          },
+          "2": {
+            "label": "Muy alto"
+          },
+          "3": {
+            "label": "Alto"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Bajo"
+          },
+          "6": {
+            "label": "Nada"
+          }
+        }
+      },
+      "Distribution": {
+        "label": "Distribución de zombis",
+        "description": "How zombies are distributed across the map.",
+        "options": {
+          "1": {
+            "label": "Enfoque urbano"
+          },
+          "2": {
+            "label": "Uniforme"
+          }
+        }
+      },
+      "ZombieVoronoiNoise": {
+        "label": "Ruido Voronoi",
+        "description": "Apply randomization to zombie distribution."
+      },
+      "ZombieRespawn": {
+        "label": "Intervalo de reaparición de zombis",
+        "description": "How frequently new zombies are added to the world.",
+        "options": {
+          "1": {
+            "label": "Alto"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Bajo"
+          },
+          "4": {
+            "label": "Ninguno"
+          }
+        }
+      },
+      "ZombieMigrate": {
+        "label": "Migración De Zombis",
+        "description": "Zombies can migrate to empty cells."
+      }
+    },
+    "loot": {
+      "LootItemRemovalList": {
+        "label": "Lista De Eliminación De Botín",
+        "description": "Comma-separated item types removed from the world by the loot cleanup system."
+      },
+      "FoodLootNew": {
+        "label": "Comida Perecedera",
+        "description": "Any food that can rot or spoil."
+      },
+      "CannedFoodLootNew": {
+        "label": "Comida No Perecedera",
+        "description": "Canned and dried food, beverages."
+      },
+      "LiteratureLootNew": {
+        "label": "Literatura",
+        "description": "All readable items including books, fliers, and newspapers."
+      },
+      "SkillBookLoot": {
+        "label": "Libros de habilidades",
+        "description": "Books that provide skill XP multipliers."
+      },
+      "RecipeResourceLoot": {
+        "label": "Recursos de recetas",
+        "description": "Items that teach recipes."
+      },
+      "MedicalLootNew": {
+        "label": "Médicos",
+        "description": "Medicine, bandages, and first aid tools."
+      },
+      "SurvivalGearsLootNew": {
+        "label": "Elementos De Supervivencia",
+        "description": "Fishing rods, tents, camping gear."
+      },
+      "WeaponLootNew": {
+        "label": "Armas Cuerpo A Cuerpo",
+        "description": "Weapons that are not tools in other categories."
+      },
+      "RangedWeaponLootNew": {
+        "label": "Armas De Larga Distancia",
+        "description": "Ranged weapons and weapon attachments."
+      },
+      "AmmoLootNew": {
+        "label": "Munición",
+        "description": "Loose ammo, boxes, and magazines."
+      },
+      "MechanicsLootNew": {
+        "label": "Mecánica",
+        "description": "Vehicle parts and installation tools."
+      },
+      "ClothingLootNew": {
+        "label": "Ropa",
+        "description": "All wearable items that are not containers."
+      },
+      "ContainerLootNew": {
+        "label": "Bolsas",
+        "description": "Backpacks and wearable/equippable containers."
+      },
+      "KeyLootNew": {
+        "label": "Llaves",
+        "description": "Keys for buildings/cars, key rings, and locks."
+      },
+      "MediaLootNew": {
+        "label": "Medios",
+        "description": "VHS tapes and CDs."
+      },
+      "MementoLootNew": {
+        "label": "Recuerdos",
+        "description": "Spiffo items, plushies, and collectible keepsakes."
+      },
+      "CookwareLootNew": {
+        "label": "Utensilios De Cocina",
+        "description": "Cooking items including those that can be weapons. Does not include food."
+      },
+      "MaterialLootNew": {
+        "label": "Materiales",
+        "description": "Crafting and building materials."
+      },
+      "FarmingLootNew": {
+        "label": "Agricultura",
+        "description": "Seeds, trowels, shovels, and agriculture tools."
+      },
+      "ToolLootNew": {
+        "label": "Herramientas",
+        "description": "Tools not in other categories like Mechanics or Farming."
+      },
+      "OtherLootNew": {
+        "label": "Otros",
+        "description": "Everything else. Also affects foraging in Town/Road zones."
+      },
+      "RollsMultiplier": {
+        "label": "Multiplicador De Tiradas [!]",
+        "description": "Multiplier for loot table rolls. Higher values may affect performance. NOT recommended to change."
+      },
+      "RemoveStoryLoot": {
+        "label": "Eliminar Botín De Historia No Deseado",
+        "description": "Items on the removal list will not spawn in world stories."
+      },
+      "RemoveZombieLoot": {
+        "label": "Eliminar Botín De Zombis No Deseado",
+        "description": "Items on the removal list will not spawn on zombies."
+      },
+      "ZombiePopLootEffect": {
+        "label": "Efecto De Botín Por Población Zombi",
+        "description": "If > 0, loot increases relative to nearby zombies, multiplied by this value."
+      },
+      "HoursForLootRespawn": {
+        "label": "Horas Para Reaparición De Botín",
+        "description": "Hours after which containers respawn loot. 0 = never."
+      },
+      "MaxItemsForLootRespawn": {
+        "label": "Máximo De Objetos Para Reaparición",
+        "description": "Containers with this many items or more will not respawn loot."
+      },
+      "ConstructionPreventsLootRespawn": {
+        "label": "La Construcción Evita La Reaparición De Botín",
+        "description": "Player constructions near containers prevent loot respawn."
+      },
+      "SeenHoursPreventLootRespawn": {
+        "label": "Horas para reaparición de loot",
+        "description": "Hours a zone must be unvisited before loot respawns. 0 = disabled."
+      }
+    },
+    "lootRarity": {
+      "InsaneLootFactor": {
+        "label": "Factor De Botín Extremadamente Raro",
+        "description": "Spawn rate for Insane rarity items."
+      },
+      "ExtremeLootFactor": {
+        "label": "Factor De Botín Muy Raro",
+        "description": "Spawn rate for Extreme rarity items."
+      },
+      "RareLootFactor": {
+        "label": "Factor De Botín Raro",
+        "description": "Spawn rate for Rare rarity items."
+      },
+      "NormalLootFactor": {
+        "label": "Factor De Botín Normal",
+        "description": "Spawn rate for Normal rarity items."
+      },
+      "CommonLootFactor": {
+        "label": "Factor De Botín Común",
+        "description": "Spawn rate for Common rarity items."
+      },
+      "AbundantLootFactor": {
+        "label": "Factor De Botín Abundante",
+        "description": "Spawn rate for Abundant rarity items."
+      },
+      "MaximumLooted": {
+        "label": "Probabilidad Máxima De Edificio Saqueado",
+        "description": "Chance that any building is already looted when found."
+      },
+      "DaysUntilMaximumLooted": {
+        "label": "Días Hasta La Probabilidad Máxima De Saqueo",
+        "description": "Days before Maximum Looted Building Chance is reached."
+      },
+      "RuralLooted": {
+        "label": "Multiplicador De Probabilidad De Saqueo En Áreas Rurales",
+        "description": "Chance that any rural building is already looted."
+      },
+      "MaximumDiminishedLoot": {
+        "label": "Porcentaje Máximo De Botín Reducido",
+        "description": "Maximum loot that won't spawn when diminished days reached."
+      },
+      "DaysUntilMaximumDiminishedLoot": {
+        "label": "Días Hasta Botín Reducido Máximo",
+        "description": "Days before Maximum Diminished Loot is reached."
+      },
+      "MaximumLootedBuildingRooms": {
+        "label": "Máximo de Habitaciones Saqueadas en un Edificio",
+        "description": "Buildings with more than this many rooms will not be auto-looted."
+      }
+    },
+    "environment": {
+      "DayNightCycle": {
+        "label": "Ciclo Día / Noche",
+        "description": "Whether time of day changes naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Día Infinito"
+          },
+          "3": {
+            "label": "Noche Infinita"
+          }
+        }
+      },
+      "ClimateCycle": {
+        "label": "Ciclo Climático",
+        "description": "Whether weather changes or remains fixed.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Sin Clima"
+          },
+          "3": {
+            "label": "Lluvia Infinita"
+          },
+          "4": {
+            "label": "Tormenta Infinita"
+          },
+          "5": {
+            "label": "Nieve Infinita"
+          },
+          "6": {
+            "label": "Ventisca Infinita"
+          }
+        }
+      },
+      "FogCycle": {
+        "label": "Ciclo de Niebla",
+        "description": "Whether fog occurs naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Sin Niebla"
+          },
+          "3": {
+            "label": "Niebla Infinita"
+          }
+        }
+      },
+      "WaterShut": {
+        "label": "Corte de agua",
+        "description": "When plumbing fixtures stop being infinite water sources.",
+        "options": {
+          "1": {
+            "label": "Instantáneo"
+          },
+          "2": {
+            "label": "0 - 30 días"
+          },
+          "3": {
+            "label": "0 - 2 meses"
+          },
+          "4": {
+            "label": "0 - 6 meses"
+          },
+          "5": {
+            "label": "0 - 1 año"
+          },
+          "6": {
+            "label": "0 - 5 años"
+          },
+          "7": {
+            "label": "2 - 6 meses"
+          },
+          "8": {
+            "label": "6 - 12 meses"
+          },
+          "9": {
+            "label": "Desactivado"
+          }
+        }
+      },
+      "ElecShut": {
+        "label": "Corte de electricidad",
+        "description": "When the world's electricity turns off.",
+        "options": {
+          "1": {
+            "label": "Instantáneo"
+          },
+          "2": {
+            "label": "14 - 30 días"
+          },
+          "3": {
+            "label": "14 días - 2 meses"
+          },
+          "4": {
+            "label": "14 días - 6 meses"
+          },
+          "5": {
+            "label": "14 días - 1 año"
+          },
+          "6": {
+            "label": "14 días - 5 años"
+          },
+          "7": {
+            "label": "2 - 6 meses"
+          },
+          "8": {
+            "label": "6 - 12 meses"
+          },
+          "9": {
+            "label": "Desactivado"
+          }
+        }
+      },
+      "AlarmDecay": {
+        "label": "Decadencia De La Alarma",
+        "description": "How long alarm batteries last after power shuts off.",
+        "options": {
+          "1": {
+            "label": "Instantáneo"
+          },
+          "2": {
+            "label": "0 - 30 días"
+          },
+          "3": {
+            "label": "0 - 2 meses"
+          },
+          "4": {
+            "label": "0 - 6 meses"
+          },
+          "5": {
+            "label": "0 - 1 año"
+          },
+          "6": {
+            "label": "0 - 5 años"
+          },
+          "7": {
+            "label": "2 - 6 meses"
+          },
+          "8": {
+            "label": "6 - 12 meses"
+          },
+          "9": {
+            "label": "Desactivado"
+          }
+        }
+      },
+      "WaterShutModifier": {
+        "label": "Modificador del corte de agua",
+        "description": "Fine-tune water shutoff timing in days."
+      },
+      "ElecShutModifier": {
+        "label": "Modificador del corte de electricidad",
+        "description": "Fine-tune electricity shutoff timing in days."
+      },
+      "AlarmDecayModifier": {
+        "label": "Alarm Decay Modifier",
+        "description": "Fine-tune alarm battery decay timing in days."
+      },
+      "Temperature": {
+        "label": "Temperatura",
+        "description": "Global temperature setting.",
+        "options": {
+          "1": {
+            "label": "Mucho frío"
+          },
+          "2": {
+            "label": "Frío"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Calor"
+          },
+          "5": {
+            "label": "Mucho calor"
+          }
+        }
+      },
+      "Rain": {
+        "label": "Lluvia",
+        "description": "How often it rains.",
+        "options": {
+          "1": {
+            "label": "Muy seco"
+          },
+          "2": {
+            "label": "Seco"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Lluvioso"
+          },
+          "5": {
+            "label": "Muy lluvioso"
+          }
+        }
+      },
+      "ErosionSpeed": {
+        "label": "Velocidad de la erosión",
+        "description": "How fast nature reclaims the world.",
+        "options": {
+          "1": {
+            "label": "Muy rápido (20 días)"
+          },
+          "2": {
+            "label": "Rápido (50 días)"
+          },
+          "3": {
+            "label": "Normal (100 días)"
+          },
+          "4": {
+            "label": "Lento (200 días)"
+          },
+          "5": {
+            "label": "Muy lento (500 días)"
+          }
+        }
+      },
+      "ErosionDays": {
+        "label": "Días de erosión",
+        "description": "Custom erosion days. 0 = use Erosion Speed option."
+      },
+      "MaxFogIntensity": {
+        "label": "Máxima intensidad de niebla",
+        "description": "Maximum intensity of fog.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Moderada"
+          },
+          "3": {
+            "label": "Baja"
+          },
+          "4": {
+            "label": "Ninguna"
+          }
+        }
+      },
+      "MaxRainFxIntensity": {
+        "label": "Intensidad máxima del efecto de lluvia",
+        "description": "Maximum intensity of rain effects.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Moderado"
+          },
+          "3": {
+            "label": "Bajo"
+          }
+        }
+      },
+      "EnableSnowOnGround": {
+        "label": "Habilitar la nieve en el suelo",
+        "description": "Whether snow accumulates on the ground."
+      },
+      "NightDarkness": {
+        "label": "Oscuridad durante la noche",
+        "description": "Ambient lighting level at night.",
+        "options": {
+          "1": {
+            "label": "Noche cerrada"
+          },
+          "2": {
+            "label": "Oscuro"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Claro"
+          }
+        }
+      },
+      "NightLength": {
+        "label": "Duración de las noches",
+        "description": "Duration from dusk to dawn.",
+        "options": {
+          "1": {
+            "label": "Siempre de noche"
+          },
+          "2": {
+            "label": "Largo"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Corto"
+          },
+          "5": {
+            "label": "Siempre de día"
+          }
+        }
+      },
+      "TimeSinceApo": {
+        "label": "Meses desde el apocalipsis",
+        "description": "How long after the apocalypse the game begins. Affects erosion and food spoilage.",
+        "options": {
+          "1": {
+            "label": "0"
+          },
+          "2": {
+            "label": "1"
+          },
+          "3": {
+            "label": "2"
+          },
+          "4": {
+            "label": "3"
+          },
+          "5": {
+            "label": "4"
+          },
+          "6": {
+            "label": "5"
+          },
+          "7": {
+            "label": "6"
+          },
+          "8": {
+            "label": "7"
+          },
+          "9": {
+            "label": "8"
+          },
+          "10": {
+            "label": "9"
+          },
+          "11": {
+            "label": "10"
+          },
+          "12": {
+            "label": "11"
+          },
+          "13": {
+            "label": "12"
+          }
+        }
+      },
+      "FireSpread": {
+        "label": "Propagación del fuego",
+        "description": "Whether fires spread when started."
+      }
+    },
+    "survival": {
+      "StatsDecrease": {
+        "label": "Deterioro de la comida",
+        "description": "How fast hunger, thirst, and fatigue decrease.",
+        "options": {
+          "1": {
+            "label": "Muy rápido"
+          },
+          "2": {
+            "label": "Rápido"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Lento"
+          },
+          "5": {
+            "label": "Muy lento"
+          }
+        }
+      },
+      "Nutrition": {
+        "label": "Nutrición",
+        "description": "Food nutrition affects player weight and condition."
+      },
+      "FoodRotSpeed": {
+        "label": "Deterioro de la comida",
+        "description": "How fast food spoils.",
+        "options": {
+          "1": {
+            "label": "Muy rápido"
+          },
+          "2": {
+            "label": "Rápido"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Lento"
+          },
+          "5": {
+            "label": "Muy lento"
+          }
+        }
+      },
+      "FridgeFactor": {
+        "label": "Eficacia de la refrigeración",
+        "description": "How effective fridges are at preserving food.",
+        "options": {
+          "1": {
+            "label": "Muy baja"
+          },
+          "2": {
+            "label": "Baja"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Alta"
+          },
+          "5": {
+            "label": "Muy alta"
+          },
+          "6": {
+            "label": "Sin deterioro"
+          }
+        }
+      },
+      "StarterKit": {
+        "label": "Paquete de bienvenida",
+        "description": "Spawn with chips, water bottle, backpack, bat, and hammer."
+      },
+      "CharacterFreePoints": {
+        "label": "Puntos adicionales para rasgos",
+        "description": "Extra free points during character creation."
+      },
+      "BoneFracture": {
+        "label": "Fracturas de huesos",
+        "description": "Survivors can get broken limbs from impacts, falls, etc."
+      },
+      "InjurySeverity": {
+        "label": "Gravedad de las lesiones",
+        "description": "Impact of injuries and healing time.",
+        "options": {
+          "1": {
+            "label": "Bajo"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Alto"
+          }
+        }
+      },
+      "EndRegen": {
+        "label": "Deterioro de la comida",
+        "description": "Recovery from tiredness after actions.",
+        "options": {
+          "1": {
+            "label": "Muy rápido"
+          },
+          "2": {
+            "label": "Rápido"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Lento"
+          },
+          "5": {
+            "label": "Muy lento"
+          }
+        }
+      },
+      "HoursForCorpseRemoval": {
+        "label": "Eliminación de cadáveres",
+        "description": "Hours before zombie corpses disappear. 0 = no maggots spawn."
+      },
+      "DecayingCorpseHealthImpact": {
+        "label": "Malestar producido por cadáveres en descomposición",
+        "description": "Impact of nearby decaying bodies on health/emotions.",
+        "options": {
+          "1": {
+            "label": "Ninguno"
+          },
+          "2": {
+            "label": "Bajo"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Alto"
+          },
+          "5": {
+            "label": "Insano"
+          }
+        }
+      },
+      "ZombieHealthImpact": {
+        "label": "Impacto De Salud Por Zombis",
+        "description": "Whether living zombies also affect player health/emotions."
+      },
+      "BloodLevel": {
+        "label": "Nivel de sangre",
+        "description": "How much blood sprays on surfaces.",
+        "options": {
+          "1": {
+            "label": "Ninguno"
+          },
+          "2": {
+            "label": "Bajo"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Alto"
+          },
+          "5": {
+            "label": "Sangriento"
+          }
+        }
+      },
+      "ClothingDegradation": {
+        "label": "Deterioro de la ropa",
+        "description": "How quickly clothing degrades and gets dirty.",
+        "options": {
+          "1": {
+            "label": "Deshabilitado"
+          },
+          "2": {
+            "label": "Lento"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Rápido"
+          }
+        }
+      },
+      "DaysForRottenFoodRemoval": {
+        "label": "Eliminación de comida podrida",
+        "description": "Days before rotten food is removed. -1 = never."
+      },
+      "AllClothesUnlocked": {
+        "label": "Toda la ropa desbloqueada",
+        "description": "Select from every clothing item during character creation."
+      },
+      "EnableTaintedWaterText": {
+        "label": "Activar la información de \"Agua contaminada\"",
+        "description": "Show warning marking tainted water."
+      },
+      "EnablePoisoning": {
+        "label": "Habilitar el envenenamiento",
+        "description": "Whether poison can be added to food.",
+        "options": {
+          "1": {
+            "label": "Verdadero"
+          },
+          "2": {
+            "label": "Falso"
+          },
+          "3": {
+            "label": "Sólo está deshabilitado el envenenamiento por lejía"
+          }
+        }
+      },
+      "MaggotSpawn": {
+        "label": "Gusanos en cadáveres",
+        "description": "When maggots spawn in corpses.",
+        "options": {
+          "1": {
+            "label": "Dentro y alrededor de los cuerpos"
+          },
+          "2": {
+            "label": "Sólo dentro de los cuerpos"
+          },
+          "3": {
+            "label": "Nunca"
+          }
+        }
+      },
+      "MuscleStrainFactor": {
+        "label": "Factor De Tensión Muscular",
+        "description": "Multiplier for muscle strain from swinging weapons or carrying heavy loads."
+      },
+      "DiscomfortFactor": {
+        "label": "Factor de incomodidad",
+        "description": "Multiplier for discomfort from worn items."
+      },
+      "WoundInfectionFactor": {
+        "label": "Factor De Daño Por Infección De Heridas",
+        "description": "Damage from serious wound infections. 0 = disabled."
+      },
+      "NoBlackClothes": {
+        "label": "Sin Ropa Negra",
+        "description": "Prevent randomized clothing from becoming near-black."
+      },
+      "EasyClimbing": {
+        "label": "Escalada Fácil",
+        "description": "Disable failure chances when climbing sheet ropes or walls."
+      },
+      "NegativeTraitsPenalty": {
+        "label": "Penalización Por Rasgos Negativos",
+        "description": "Diminishing returns on bonus points from negative traits.",
+        "options": {
+          "1": {
+            "label": "Ninguna"
+          },
+          "2": {
+            "label": "1 punto de penalización por cada 3 rasgos negativos seleccionados"
+          },
+          "3": {
+            "label": "1 punto de penalización por cada 2 rasgos negativos seleccionados"
+          },
+          "4": {
+            "label": "1 punto de penalización por cada rasgo negativo seleccionado después del primero"
+          }
+        }
+      },
+      "MinutesPerPage": {
+        "label": "Minutos Por Página De Libro De Habilidades",
+        "description": "In-game minutes to read one page of a skill book."
+      },
+      "LiteratureCooldown": {
+        "label": "Días De Enfriamiento Para Literatura",
+        "description": "Days before previously read literature can benefit again."
+      },
+      "LevelForMediaXPCutoff": {
+        "label": "Nivel Máximo De XP Por Medios",
+        "description": "Skill level at which TV/VHS/media no longer provides XP."
+      },
+      "LevelForDismantleXPCutoff": {
+        "label": "Nivel Máximo De XP Por Desmantelar",
+        "description": "Skill level at which scrapping furniture gives no XP."
+      },
+      "BloodSplatLifespanDays": {
+        "label": "Duración De Salpicaduras De Sangre (Días)",
+        "description": "Days before blood splats disappear. 0 = never."
+      },
+      "MetaKnowledge": {
+        "label": "Conocimiento Meta De Medios",
+        "description": "How unseen/unread media is displayed.",
+        "options": {
+          "1": {
+            "label": "Totalmente revelado"
+          },
+          "2": {
+            "label": "Mostrado como ???"
+          },
+          "3": {
+            "label": "Completamente oculto"
+          }
+        }
+      },
+      "SeeNotLearntRecipe": {
+        "label": "Ver Recetas No Conocidas",
+        "description": "See station recipes even if not yet learned."
+      },
+      "LightBulbLifespan": {
+        "label": "Duración de las bombillas",
+        "description": "Higher = bulbs last longer. 0 = never break."
+      },
+      "MaximumFireFuelHours": {
+        "label": "Horas máximas de combustible para fuego",
+        "description": "Max hours of fuel for campfires, wood stoves, etc."
+      },
+      "Alarm": {
+        "label": "Alarmas en las casas",
+        "description": "Frequency of residential alarms.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Muy raro"
+          },
+          "3": {
+            "label": "Raro"
+          },
+          "4": {
+            "label": "A veces"
+          },
+          "5": {
+            "label": "A menudo"
+          },
+          "6": {
+            "label": "Muy frecuentemente"
+          }
+        }
+      },
+      "LockedHouses": {
+        "label": "Alarmas en las casas",
+        "description": "Frequency of locked houses.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Muy raro"
+          },
+          "3": {
+            "label": "Raro"
+          },
+          "4": {
+            "label": "A veces"
+          },
+          "5": {
+            "label": "A menudo"
+          },
+          "6": {
+            "label": "Muy frecuentemente"
+          }
+        }
+      },
+      "Helicopter": {
+        "label": "Helicóptero",
+        "description": "Helicopter frequency.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Una vez"
+          },
+          "3": {
+            "label": "A veces"
+          },
+          "4": {
+            "label": "A menudo"
+          }
+        }
+      },
+      "MetaEvent": {
+        "label": "Meta eventos",
+        "description": "Distant gunshots, screams, etc.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "A veces"
+          },
+          "3": {
+            "label": "A menudo"
+          }
+        }
+      },
+      "SleepingEvent": {
+        "label": "Eventos al dormir",
+        "description": "Events that happen while sleeping.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "A veces"
+          },
+          "3": {
+            "label": "A menudo"
+          }
+        }
+      },
+      "NatureAbundance": {
+        "label": "Abundancia De Agricultura",
+        "description": "Governs abundance of wild foods, medicinal plants, etc.",
+        "options": {
+          "1": {
+            "label": "Muy Pobre"
+          },
+          "2": {
+            "label": "Pobre"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundante"
+          },
+          "5": {
+            "label": "Muy Abundante"
+          }
+        }
+      },
+      "FishAbundance": {
+        "label": "Abundancia De Agricultura",
+        "description": "Governs abundance of fish.",
+        "options": {
+          "1": {
+            "label": "Muy Pobre"
+          },
+          "2": {
+            "label": "Pobre"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundante"
+          },
+          "5": {
+            "label": "Muy Abundante"
+          }
+        }
+      },
+      "AnnotatedMapChance": {
+        "label": "Probabilidad de mapas anotados",
+        "description": "Chance of finding maps annotated with local features.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Muy raro"
+          },
+          "3": {
+            "label": "Raro"
+          },
+          "4": {
+            "label": "A veces"
+          },
+          "5": {
+            "label": "A menudo"
+          },
+          "6": {
+            "label": "Muy frecuentemente"
+          }
+        }
+      },
+      "ConstructionBonusPoints": {
+        "label": "Resistencia de las construcciones del jugador",
+        "description": "Extra points for carpentry/metalworking constructions."
+      },
+      "GeneratorSpawning": {
+        "label": "Aparición de generadores",
+        "description": "How many generators spawn in the world.",
+        "options": {
+          "1": {
+            "label": "Ninguno (no recomendado)"
+          },
+          "2": {
+            "label": "Extremadamente Raro"
+          },
+          "3": {
+            "label": "Muy Raro"
+          },
+          "4": {
+            "label": "Raro"
+          },
+          "5": {
+            "label": "Normal"
+          },
+          "6": {
+            "label": "Común"
+          },
+          "7": {
+            "label": "Abundante"
+          }
+        }
+      },
+      "GeneratorFuelConsumption": {
+        "label": "Consumo de combustible del generador",
+        "description": "How fast generators consume fuel."
+      },
+      "AllowExteriorGenerator": {
+        "label": "Generador operativo en exteriores",
+        "description": "Generators can be placed outdoors and inside tents."
+      },
+      "GeneratorTileRange": {
+        "label": "Rango de Baldosas del Generador",
+        "description": "Horizontal range of generators in tiles."
+      },
+      "GeneratorVerticalPowerRange": {
+        "label": "Rango Vertical del Generador",
+        "description": "Vertical range of generators in floors."
+      },
+      "CompostTime": {
+        "label": "Tiempo de compostaje",
+        "description": "How long composting takes.",
+        "options": {
+          "1": {
+            "label": "1 Semana"
+          },
+          "2": {
+            "label": "2 Semanas"
+          },
+          "3": {
+            "label": "3 Semanas"
+          },
+          "4": {
+            "label": "4 Semanas"
+          },
+          "5": {
+            "label": "6 Semanas"
+          },
+          "6": {
+            "label": "8 Semanas"
+          },
+          "7": {
+            "label": "10 Semanas"
+          },
+          "8": {
+            "label": "12 Semanas"
+          }
+        }
+      },
+      "AttackBlockMovements": {
+        "label": "Interrupción del movimiento cuerpo a cuerpo",
+        "description": "Player can't move while performing melee attacks."
+      },
+      "WorldItemRemovalList": {
+        "label": "Eliminación de objetos del mundo",
+        "description": "Types of items removed from world (comma separated, e.g. Base.Vest)."
+      },
+      "HoursForWorldItemRemoval": {
+        "label": "Horas para eliminación de objetos",
+        "description": "Hours before listed items disappear from world. 0 = disabled."
+      },
+      "ItemRemovalListBlacklistToggle": {
+        "label": "Lista blanca de eliminación",
+        "description": "If true, removal list acts as blacklist (remove everything except listed). Default is whitelist."
+      }
+    },
+    "combat": {
+      "MultiHitZombies": {
+        "label": "Golpe múltiple del arma",
+        "description": "A melee weapon can hit multiple zombies in one swing."
+      },
+      "RearVulnerability": {
+        "label": "Retaguardia vulnerable",
+        "description": "Zombies take more damage when attacked from behind.",
+        "options": {
+          "1": {
+            "label": "Bajo"
+          },
+          "2": {
+            "label": "Medio"
+          },
+          "3": {
+            "label": "Alto"
+          }
+        }
+      },
+      "FirearmUseDamageChance": {
+        "label": "Probabilidad de daño al usar armas de fuego",
+        "description": "Chance of weapon condition loss per use. 0 = never."
+      },
+      "FirearmNoiseMultiplier": {
+        "label": "Multiplicador De Ruido De Armas De Fuego",
+        "description": "Multiplier for gun noise attracting zombies."
+      },
+      "FirearmJamMultiplier": {
+        "label": "Multiplicador De Atascos De Armas De Fuego",
+        "description": "Multiplier for jamming chance."
+      },
+      "FirearmMoodleMultiplier": {
+        "label": "Multiplicador De Estado De Ánimo Para Armas De Fuego",
+        "description": "Multiplier for panic/stress from gun use."
+      },
+      "FirearmWeatherMultiplier": {
+        "label": "Multiplicador De Clima Para Armas De Fuego",
+        "description": "Multiplier for rain affecting gun condition."
+      },
+      "FirearmHeadGearEffect": {
+        "label": "Efecto De Protección En La Precisión",
+        "description": "How much head-covering gear like helmets affects firearm aim/shoulder."
+      }
+    },
+    "vehicles": {
+      "EnableVehicles": {
+        "label": "Habilitar vehículo",
+        "description": "Whether vehicles spawn and can be used."
+      },
+      "CarSpawnRate": {
+        "label": "Aparición de vehículos",
+        "description": "How many vehicles spawn.",
+        "options": {
+          "1": {
+            "label": "Ninguno"
+          },
+          "2": {
+            "label": "Muy bajo"
+          },
+          "3": {
+            "label": "Bajo"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Alto"
+          }
+        }
+      },
+      "VehicleEasyUse": {
+        "label": "Uso sencillo",
+        "description": "All vehicles are automatic and easy to start."
+      },
+      "InitialGas": {
+        "label": "Combustible inicial",
+        "description": "How full the gas tank of discovered vehicles will be.",
+        "options": {
+          "1": {
+            "label": "Muy bajo"
+          },
+          "2": {
+            "label": "Bajo"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Alto"
+          },
+          "5": {
+            "label": "Muy alto"
+          },
+          "6": {
+            "label": "Lleno"
+          }
+        }
+      },
+      "FuelStationGasInfinite": {
+        "label": "Bombas De Gasolina Infinitas",
+        "description": "If enabled, gas pumps will never run out of fuel."
+      },
+      "FuelStationGasMin": {
+        "label": "Cantidad Mínima Inicial De Gasolina",
+        "description": "The minimum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasMax": {
+        "label": "Cantidad Máxima Inicial De Gasolina",
+        "description": "The maximum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasEmptyChance": {
+        "label": "Probabilidad Inicial De Bombas Vacías",
+        "description": "The chance, as a percentage, that individual gas pumps will initially have no fuel."
+      },
+      "LockedCar": {
+        "label": "Frecuencia de vehículos cerrados",
+        "description": "Chance of vehicle doors being locked.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Muy raro"
+          },
+          "3": {
+            "label": "Raro"
+          },
+          "4": {
+            "label": "A veces"
+          },
+          "5": {
+            "label": "A menudo"
+          },
+          "6": {
+            "label": "Muy frecuentemente"
+          }
+        }
+      },
+      "CarGasConsumption": {
+        "label": "Consumo de combustible",
+        "description": "Rate of fuel consumption in vehicles."
+      },
+      "CarGeneralCondition": {
+        "label": "Estado general",
+        "description": "Initial condition of discovered vehicles.",
+        "options": {
+          "1": {
+            "label": "Muy bajo"
+          },
+          "2": {
+            "label": "Bajo"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Alto"
+          },
+          "5": {
+            "label": "Muy alto"
+          }
+        }
+      },
+      "CarDamageOnImpact": {
+        "label": "Daños al coche por impactos",
+        "description": "Damage vehicles take from collisions.",
+        "options": {
+          "1": {
+            "label": "Muy bajo"
+          },
+          "2": {
+            "label": "Bajo"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Alto"
+          },
+          "5": {
+            "label": "Muy alto"
+          }
+        }
+      },
+      "DamageToPlayerFromHitByACar": {
+        "label": "Daños al jugador por atropello de un vehículo",
+        "description": "How much damage players receive from vehicle impacts.",
+        "options": {
+          "1": {
+            "label": "Ninguno"
+          },
+          "2": {
+            "label": "Bajo"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Alto"
+          },
+          "5": {
+            "label": "Muy alto"
+          }
+        }
+      },
+      "TrafficJam": {
+        "label": "Bloqueos de carreteras",
+        "description": "Whether traffic jams spawn on roads."
+      },
+      "CarAlarm": {
+        "label": "Frecuencia de alarmas en coches",
+        "description": "Chance of vehicles having active alarms.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Muy raro"
+          },
+          "3": {
+            "label": "Raro"
+          },
+          "4": {
+            "label": "A veces"
+          },
+          "5": {
+            "label": "A menudo"
+          },
+          "6": {
+            "label": "Muy frecuentemente"
+          }
+        }
+      },
+      "PlayerDamageFromCrash": {
+        "label": "Daños causados por un accidente",
+        "description": "If the player can get injured from being in a car accident."
+      },
+      "SirenShutoffHours": {
+        "label": "Duración de alarmas",
+        "description": "Hours before vehicle siren batteries die. 0 = instant."
+      },
+      "ChanceHasGas": {
+        "label": "Probabilidad de combustible",
+        "description": "The chance of finding a vehicle with gas in its tank.",
+        "options": {
+          "1": {
+            "label": "Bajo"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Alto"
+          }
+        }
+      },
+      "RecentlySurvivorVehicles": {
+        "label": "Vehículos de supervivientes recientes",
+        "description": "Whether a player can discover a car that has been cared for after the Knox infection struck.",
+        "options": {
+          "1": {
+            "label": "Ninguno"
+          },
+          "2": {
+            "label": "Bajo"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Alto"
+          }
+        }
+      },
+      "ZombieAttractionMultiplier": {
+        "label": "Multiplicador de atracción de zombis",
+        "description": "Multiplier for vehicle sounds attracting zombies."
+      },
+      "SirenEffectsZombies": {
+        "label": "Las Sirenas Atraen Zombis",
+        "description": "If zombies will head towards the sound of vehicle sirens."
+      }
+    },
+    "animals": {
+      "AnimalStatsModifier": {
+        "label": "Velocidad De Reducción De Estadísticas",
+        "description": "Speed at which animal stats (hunger, thirst etc.) reduce.",
+        "options": {
+          "1": {
+            "label": "Ultrarrápido"
+          },
+          "2": {
+            "label": "Muy Rápido"
+          },
+          "3": {
+            "label": "Rápido"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Lento"
+          },
+          "6": {
+            "label": "Muy Lento"
+          }
+        }
+      },
+      "AnimalMetaStatsModifier": {
+        "label": "Velocidad De Reducción De Metadatos",
+        "description": "Speed at which animal stats reduce while in meta (overworld).",
+        "options": {
+          "1": {
+            "label": "Ultrarrápido"
+          },
+          "2": {
+            "label": "Muy Rápido"
+          },
+          "3": {
+            "label": "Rápido"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Lento"
+          },
+          "6": {
+            "label": "Muy Lento"
+          }
+        }
+      },
+      "AnimalPregnancyTime": {
+        "label": "Duración Del Embarazo",
+        "description": "How long animals will be pregnant for before giving birth.",
+        "options": {
+          "1": {
+            "label": "Ultrarrápido"
+          },
+          "2": {
+            "label": "Muy Rápido"
+          },
+          "3": {
+            "label": "Rápido"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Lento"
+          },
+          "6": {
+            "label": "Muy Lento"
+          }
+        }
+      },
+      "AnimalAgeModifier": {
+        "label": "Velocidad De Envejecimiento",
+        "description": "Speed at which animals age.",
+        "options": {
+          "1": {
+            "label": "Muy Rápido"
+          },
+          "2": {
+            "label": "Rápido"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalMilkIncModifier": {
+        "label": "Velocidad De Producción De Leche",
+        "description": "Speed of milk production.",
+        "options": {
+          "1": {
+            "label": "Ultrarrápido"
+          },
+          "2": {
+            "label": "Muy Rápido"
+          },
+          "3": {
+            "label": "Rápido"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Lento"
+          },
+          "6": {
+            "label": "Muy Lento"
+          }
+        }
+      },
+      "AnimalWoolIncModifier": {
+        "label": "Velocidad De Producción De Lana",
+        "description": "Speed of wool production.",
+        "options": {
+          "1": {
+            "label": "Ultrarrápido"
+          },
+          "2": {
+            "label": "Muy Rápido"
+          },
+          "3": {
+            "label": "Rápido"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Lento"
+          },
+          "6": {
+            "label": "Muy Lento"
+          }
+        }
+      },
+      "AnimalRanchChance": {
+        "label": "Probabilidad De Aparición De Animales",
+        "description": "The chance of finding animals in farms.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Extremadamente Rara"
+          },
+          "3": {
+            "label": "Rara"
+          },
+          "4": {
+            "label": "A Veces"
+          },
+          "5": {
+            "label": "Frecuente"
+          },
+          "6": {
+            "label": "Muy Frecuente"
+          },
+          "7": {
+            "label": "Siempre"
+          }
+        }
+      },
+      "AnimalGrassRegrowTime": {
+        "label": "Tiempo De Regeneración De Pasto",
+        "description": "The number of hours grass will regrow after being eaten by an animal or cut by the player."
+      },
+      "AnimalMetaPredator": {
+        "label": "Depredador Meta",
+        "description": "If a meta fox may attack your chickens if the hutch door is left open at night."
+      },
+      "AnimalMatingSeason": {
+        "label": "Temporada De Reproducción",
+        "description": "Restrict mating to spring/early summer or allow year-round."
+      },
+      "AnimalEggHatch": {
+        "label": "Tiempo De Incubación",
+        "description": "How long before baby animals will hatch from eggs.",
+        "options": {
+          "1": {
+            "label": "Ultrarrápido"
+          },
+          "2": {
+            "label": "Muy Rápido"
+          },
+          "3": {
+            "label": "Rápido"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Lento"
+          },
+          "6": {
+            "label": "Muy Lento"
+          }
+        }
+      },
+      "AnimalSoundAttractZombies": {
+        "label": "Sonidos De Animales Atraen Zombis",
+        "description": "If true, animal calls will attract nearby zombies."
+      },
+      "AnimalTrackChance": {
+        "label": "Probabilidad de huellas de animales",
+        "description": "The chance of animals leaving tracks.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Muy raro"
+          },
+          "3": {
+            "label": "Raro"
+          },
+          "4": {
+            "label": "A veces"
+          },
+          "5": {
+            "label": "A menudo"
+          },
+          "6": {
+            "label": "Muy frecuentemente"
+          }
+        }
+      },
+      "AnimalPathChance": {
+        "label": "Probabilidad de sendas de animales",
+        "description": "The chance of creating a path for animals to be hunted.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Muy raro"
+          },
+          "3": {
+            "label": "Raro"
+          },
+          "4": {
+            "label": "A veces"
+          },
+          "5": {
+            "label": "A menudo"
+          },
+          "6": {
+            "label": "Muy frecuentemente"
+          }
+        }
+      },
+      "MaximumRatIndex": {
+        "label": "Índice Máximo De Plagas",
+        "description": "Maximum rat infestation level. 0 = no rats."
+      },
+      "DaysUntilMaximumRatIndex": {
+        "label": "Días Hasta El Índice Máximo De Plagas",
+        "description": "How many days until rat population peaks."
+      },
+      "Farming": {
+        "label": "Multiplicador De Agricultura",
+        "description": "Rate at which Agriculture skill levels up.",
+        "options": {
+          "1": {
+            "label": "Muy bajo"
+          },
+          "2": {
+            "label": "Bajo"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Alto"
+          },
+          "5": {
+            "label": "Muy alto"
+          }
+        }
+      },
+      "PlantResilience": {
+        "label": "Resistencia de los cultivos",
+        "description": "How tough crops are.",
+        "options": {
+          "1": {
+            "label": "Muy alto"
+          },
+          "2": {
+            "label": "Alto"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Bajo"
+          },
+          "5": {
+            "label": "Muy bajo"
+          }
+        }
+      },
+      "PlantAbundance": {
+        "label": "Abundancia de la agricultura",
+        "description": "How much food crops produce.",
+        "options": {
+          "1": {
+            "label": "Muy Pobre"
+          },
+          "2": {
+            "label": "Pobre"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundante"
+          },
+          "5": {
+            "label": "Muy Abundante"
+          }
+        }
+      },
+      "KillInsideCrops": {
+        "label": "Matar Cultivos Cultivados En Interiores",
+        "description": "Whether stepping on indoor crops destroys them."
+      },
+      "PlantGrowingSeasons": {
+        "label": "Temporadas De Crecimiento De Plantas",
+        "description": "Restrict crop growth to appropriate seasons."
+      },
+      "PlaceDirtAboveground": {
+        "label": "Granjas Fuera Del Nivel Del Suelo [!]",
+        "description": "Allow placing dirt on built floors above ground."
+      },
+      "FarmingSpeedNew": {
+        "label": "Velocidad De Agricultura",
+        "description": "Growth speed multiplier. Lower = faster."
+      },
+      "FarmingAmountNew": {
+        "label": "Abundancia De Agricultura",
+        "description": "Multiplier for number of crops harvested."
+      },
+      "ClayLakeChance": {
+        "label": "Probabilidad de Arcilla - Lago",
+        "description": "Chance of finding clay when digging near lakes."
+      },
+      "ClayRiverChance": {
+        "label": "Probabilidad de Arcilla - Río",
+        "description": "Chance of finding clay when digging near rivers."
+      }
+    },
+    "world": {
+      "SurvivorHouseChance": {
+        "label": "Casas aleatorias",
+        "description": "Chance of finding survivor-modified houses.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Muy raro"
+          },
+          "3": {
+            "label": "Raro"
+          },
+          "4": {
+            "label": "A veces"
+          },
+          "5": {
+            "label": "A menudo"
+          },
+          "6": {
+            "label": "Muy frecuentemente"
+          },
+          "7": {
+            "label": "Siempre Intenta"
+          }
+        }
+      },
+      "VehicleStoryChance": {
+        "label": "Posibilidad de historias de vehículos al azar",
+        "description": "Chance of finding story-decorated vehicles.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Muy raro"
+          },
+          "3": {
+            "label": "Raro"
+          },
+          "4": {
+            "label": "A veces"
+          },
+          "5": {
+            "label": "A menudo"
+          },
+          "6": {
+            "label": "Muy frecuentemente"
+          }
+        }
+      },
+      "ZoneStoryChance": {
+        "label": "Historias aleatorias por zonas",
+        "description": "Chance of encountering zone-based story setups.",
+        "options": {
+          "1": {
+            "label": "Nunca"
+          },
+          "2": {
+            "label": "Muy raro"
+          },
+          "3": {
+            "label": "Raro"
+          },
+          "4": {
+            "label": "A veces"
+          },
+          "5": {
+            "label": "A menudo"
+          },
+          "6": {
+            "label": "Muy frecuentemente"
+          }
+        }
+      }
+    },
+    "zombieLore": {
+      "Speed": {
+        "label": "Velocidad",
+        "description": "How fast zombies move.",
+        "options": {
+          "1": {
+            "label": "Velocistas"
+          },
+          "2": {
+            "label": "Tambaleantes veloces"
+          },
+          "3": {
+            "label": "Tambaleantes"
+          },
+          "4": {
+            "label": "Aleatorio"
+          }
+        }
+      },
+      "Strength": {
+        "label": "Multiplicador De Fuerza",
+        "description": "How strong zombies are.",
+        "options": {
+          "1": {
+            "label": "Superhumano"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Débil"
+          },
+          "4": {
+            "label": "Aleatorio"
+          }
+        }
+      },
+      "Toughness": {
+        "label": "Resistencia",
+        "description": "How tough zombies are to kill.",
+        "options": {
+          "1": {
+            "label": "Duro"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Frágil"
+          },
+          "4": {
+            "label": "Aleatorio"
+          }
+        }
+      },
+      "Transmission": {
+        "label": "Contagio",
+        "description": "How the zombie infection spreads.",
+        "options": {
+          "1": {
+            "label": "Sangre + saliva"
+          },
+          "2": {
+            "label": "Sólo saliva"
+          },
+          "3": {
+            "label": "Todos están infectados"
+          },
+          "4": {
+            "label": "Ninguno"
+          }
+        }
+      },
+      "Mortality": {
+        "label": "Mortalidad por infección",
+        "description": "How deadly the infection is.",
+        "options": {
+          "1": {
+            "label": "Instantáneo"
+          },
+          "2": {
+            "label": "0-30 segundos"
+          },
+          "3": {
+            "label": "0-1 minuto"
+          },
+          "4": {
+            "label": "0-12 horas"
+          },
+          "5": {
+            "label": "2-3 días"
+          },
+          "6": {
+            "label": "1-2 semanas"
+          },
+          "7": {
+            "label": "Nunca"
+          }
+        }
+      },
+      "Cognition": {
+        "label": "Cognición",
+        "description": "What zombies can interact with.",
+        "options": {
+          "1": {
+            "label": "Exploración + usar las puertas"
+          },
+          "2": {
+            "label": "Exploración"
+          },
+          "3": {
+            "label": "Exploración básica"
+          },
+          "4": {
+            "label": "Aleatorio"
+          }
+        }
+      },
+      "Memory": {
+        "label": "Memoria",
+        "description": "How long zombies remember where they last saw a target.",
+        "options": {
+          "1": {
+            "label": "Larga"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Corta"
+          },
+          "4": {
+            "label": "Ninguna"
+          },
+          "5": {
+            "label": "Aleatoria"
+          },
+          "6": {
+            "label": "Aleatorio entre Normal y Ninguno"
+          }
+        }
+      },
+      "Sight": {
+        "label": "Visión",
+        "description": "How far zombies can see targets.",
+        "options": {
+          "1": {
+            "label": "Águila"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Mala"
+          },
+          "4": {
+            "label": "Aleatoria"
+          },
+          "5": {
+            "label": "Aleatorio entre Normal y Pobre"
+          }
+        }
+      },
+      "Hearing": {
+        "label": "Audición",
+        "description": "How well zombies can hear sounds.",
+        "options": {
+          "1": {
+            "label": "Precisa"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Mala"
+          },
+          "4": {
+            "label": "Aleatoria"
+          },
+          "5": {
+            "label": "Aleatorio entre Normal y Pobre"
+          }
+        }
+      },
+      "SpottedLogic": {
+        "label": "Nuevo Sistema De Sigilo",
+        "description": "How zombies decide to chase their targets."
+      },
+      "ThumpNoChasing": {
+        "label": "Ataques ambientales",
+        "description": "Zombies that weren't chasing a player will not thump constructions."
+      },
+      "ThumpOnConstruction": {
+        "label": "Daños en las construcciones",
+        "description": "Zombies thump player-built structures."
+      },
+      "ActiveOnly": {
+        "label": "Actividad diurna/nocturna",
+        "description": "Zombies active during specific times.",
+        "options": {
+          "1": {
+            "label": "Ambos"
+          },
+          "2": {
+            "label": "Noche"
+          },
+          "3": {
+            "label": "Día"
+          }
+        }
+      },
+      "TriggerHouseAlarm": {
+        "label": "Activación de alarmas por zombis",
+        "description": "Whether zombies can randomly trigger house alarms."
+      },
+      "ZombiesDragDown": {
+        "label": "Derribo",
+        "description": "Multiple zombies can pull player to ground."
+      },
+      "ZombiesCrawlersDragDown": {
+        "label": "Arrastre De Zombis Reptantes",
+        "description": "Crawlers can drag players down."
+      },
+      "ZombiesFenceLunge": {
+        "label": "Embestida en la valla",
+        "description": "Zombies can lunge at you over fences."
+      },
+      "ZombiesArmorFactor": {
+        "label": "Factor De Armadura De Zombis",
+        "description": "Multiplier for zombie armor from clothing. Higher = harder to kill."
+      },
+      "ZombiesMaxDefense": {
+        "label": "Defensa Máxima De Armadura De Zombis",
+        "description": "Maximum defense value zombies can have."
+      },
+      "ChanceOfAttachedWeapon": {
+        "label": "Probabilidad De Armas Adjuntas",
+        "description": "Chance a zombie has a weapon stuck in them."
+      },
+      "ZombiesFallDamage": {
+        "label": "Multiplicador De Daño Por Caída De Zombis",
+        "description": "Whether zombies can die from falling."
+      },
+      "DisableFakeDead": {
+        "label": "Reanimación de falsos zombis muertos",
+        "description": "No zombies will pretend to be dead.",
+        "options": {
+          "1": {
+            "label": "Algunos zombis del mundo se harán pasar por muertos"
+          },
+          "2": {
+            "label": "Algunos zombis del mundo, así como algunos que \"matas\", pueden fingir estar muertos"
+          },
+          "3": {
+            "label": "Los zombis nunca fingirán estar muertos"
+          }
+        }
+      },
+      "PlayerSpawnZombieRemoval": {
+        "label": "Spawn Zone Clear",
+        "description": "Distance around spawn points cleared of zombies.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Small"
+          },
+          "3": {
+            "label": "Medium"
+          },
+          "4": {
+            "label": "Large"
+          },
+          "5": {
+            "label": "Very Large"
+          }
+        }
+      },
+      "FenceThumpersRequired": {
+        "label": "Zombis Para Dañar Vallas",
+        "description": "Minimum zombies needed to damage a fence."
+      },
+      "FenceDamageMultiplier": {
+        "label": "Multiplicador de Daño a Vallas",
+        "description": "Multiplier for damage zombies do to fences."
+      },
+      "DoorOpeningPercentage": {
+        "label": "Random Door Opening Amount",
+        "description": "Percentage of zombies that can open doors when cognition allows it."
+      },
+      "CrawlUnderVehicle": {
+        "label": "Arrastrarse debajo del vehículo",
+        "description": "Crawler zombies can crawl under vehicles.",
+        "options": {
+          "1": {
+            "label": "Sólo reptantes"
+          },
+          "2": {
+            "label": "Extremadamente raro"
+          },
+          "3": {
+            "label": "Raro"
+          },
+          "4": {
+            "label": "A veces"
+          },
+          "5": {
+            "label": "A menudo"
+          },
+          "6": {
+            "label": "Muy a menudo"
+          },
+          "7": {
+            "label": "Siempre"
+          }
+        }
+      },
+      "SprinterPercentage": {
+        "label": "Random Sprinter Amount",
+        "description": "Percentage of sprinter zombies when Speed is set to Random."
+      },
+      "Reanimate": {
+        "label": "Tiempo de reanimación",
+        "description": "Dead zombies can get back up after being killed.",
+        "options": {
+          "1": {
+            "label": "Instantáneo"
+          },
+          "2": {
+            "label": "0-30 segundos"
+          },
+          "3": {
+            "label": "0-1 minuto"
+          },
+          "4": {
+            "label": "0-12 horas"
+          },
+          "5": {
+            "label": "2-3 días"
+          },
+          "6": {
+            "label": "1-2 semanas"
+          }
+        }
+      }
+    },
+    "zombiePopulation": {
+      "PopulationMultiplier": {
+        "label": "Multiplicador de población",
+        "description": "Overall zombie population multiplier."
+      },
+      "PopulationStartMultiplier": {
+        "label": "Multiplicador de inicio de población",
+        "description": "Zombie population at game start."
+      },
+      "PopulationPeakMultiplier": {
+        "label": "Multiplicador del pico de población",
+        "description": "Zombie population at peak day."
+      },
+      "PopulationPeakDay": {
+        "label": "Día del pico de población",
+        "description": "Day when zombie population peaks."
+      },
+      "RespawnHours": {
+        "label": "Horas para reaparición",
+        "description": "Hours before zombies respawn. 0 = disabled."
+      },
+      "RespawnUnseenHours": {
+        "label": "Horas sin visitar una zona",
+        "description": "Hours a chunk must be unseen before respawn."
+      },
+      "RespawnMultiplier": {
+        "label": "Multiplicador de reaparición",
+        "description": "Fraction of population that respawns."
+      },
+      "RedistributeHours": {
+        "label": "Horas para migración",
+        "description": "Hours between zombie redistribution across the map."
+      },
+      "FollowSoundDistance": {
+        "label": "Distancia de seguimiento de sonido",
+        "description": "How far zombies will follow sounds in cells."
+      },
+      "RallyGroupSize": {
+        "label": "Tamaño de la horda",
+        "description": "Base number of zombies in rally groups."
+      },
+      "RallyGroupSizeVariance": {
+        "label": "Varianza Del Tamaño De Grupos De Reunión",
+        "description": "The amount, as a percentage, that zombie groups can vary in size from the default (both larger and smaller)."
+      },
+      "RallyTravelDistance": {
+        "label": "Distancia de recorrido para formar una horda",
+        "description": "How far rally groups travel in cells."
+      },
+      "RallyGroupSeparation": {
+        "label": "Separación entre hordas",
+        "description": "Minimum distance between rally groups."
+      },
+      "RallyGroupRadius": {
+        "label": "Radio de unión de la horda",
+        "description": "Radius of area a rally group spreads across."
+      },
+      "ZombiesCountBeforeDelete": {
+        "label": "Cantidad De Zombis Antes De Borrar",
+        "description": "Minimum zombie count in a cell before deletion can occur."
+      }
+    },
+    "xpMultipliers": {
+      "Global": {
+        "label": "Multiplicador Global",
+        "description": "The rate at which all skills level up."
+      },
+      "GlobalToggle": {
+        "label": "Usar Multiplicador Global",
+        "description": "When enabled, all skills will use the Global Multiplier instead of individual values."
+      },
+      "Sprinting": {
+        "label": "Multiplicador De Carrera",
+        "description": "XP multiplier for Sprinting skill."
+      },
+      "Lightfoot": {
+        "label": "Multiplicador De Pies Ligeros",
+        "description": "XP multiplier for Lightfoot skill."
+      },
+      "Nimble": {
+        "label": "Multiplicador De Destreza",
+        "description": "XP multiplier for Nimble skill."
+      },
+      "Sneak": {
+        "label": "Multiplicador De Sigilo",
+        "description": "XP multiplier for Sneaking skill."
+      },
+      "Axe": {
+        "label": "Multiplicador De Hacha",
+        "description": "XP multiplier for Axe skill."
+      },
+      "Blunt": {
+        "label": "Multiplicador De Armas Largas Contundentes ",
+        "description": "XP multiplier for Blunt skill."
+      },
+      "SmallBlade": {
+        "label": "Multiplicador De Armas de Hoja Corta",
+        "description": "XP multiplier for Small Blade skill."
+      },
+      "LongBlade": {
+        "label": "Multiplicador De Armas de Hoja Larga",
+        "description": "XP multiplier for Long Blade skill."
+      },
+      "SmallBlunt": {
+        "label": "Multiplicador De Armas Cortas Contundentes ",
+        "description": "XP multiplier for Small Blunt skill."
+      },
+      "Aiming": {
+        "label": "Multiplicador De Puntería",
+        "description": "XP multiplier for Aiming skill."
+      },
+      "Reloading": {
+        "label": "Multiplicador De Recarga",
+        "description": "XP multiplier for Reloading skill."
+      },
+      "Fishing": {
+        "label": "Multiplicador De Pesca",
+        "description": "XP multiplier for Fishing skill."
+      },
+      "Trapping": {
+        "label": "Multiplicador De Trampas",
+        "description": "XP multiplier for Trapping skill."
+      },
+      "Woodwork": {
+        "label": "Multiplicador De Carpintería",
+        "description": "XP multiplier for Carpentry skill."
+      },
+      "Cooking": {
+        "label": "Multiplicador De Cocina",
+        "description": "XP multiplier for Cooking skill."
+      },
+      "Farming": {
+        "label": "Multiplicador De Agricultura",
+        "description": "XP multiplier for Farming skill."
+      },
+      "Doctor": {
+        "label": "Multiplicador De Primeros Auxilios",
+        "description": "XP multiplier for First Aid skill."
+      },
+      "Electricity": {
+        "label": "Multiplicador De Electricidad",
+        "description": "XP multiplier for Electricity skill."
+      },
+      "MetalWelding": {
+        "label": "Multiplicador De Metalistería",
+        "description": "XP multiplier for Metalworking skill."
+      },
+      "Mechanics": {
+        "label": "Multiplicador De Mecánica",
+        "description": "XP multiplier for Mechanics skill."
+      },
+      "Tailoring": {
+        "label": "Multiplicador De Sastrería",
+        "description": "XP multiplier for Tailoring skill."
+      },
+      "Maintenance": {
+        "label": "Multiplicador De Mantenimiento",
+        "description": "XP multiplier for Maintenance skill."
+      },
+      "PlantScavenging": {
+        "label": "Multiplicador De Recolección",
+        "description": "XP multiplier for Foraging skill."
+      },
+      "Fitness": {
+        "label": "Multiplicador De Estado Físico",
+        "description": "XP multiplier for Fitness skill."
+      },
+      "Strength": {
+        "label": "Multiplicador De Fuerza",
+        "description": "XP multiplier for Strength skill."
+      },
+      "FlintKnapping": {
+        "label": "Multiplicador De Labrar Piedra",
+        "description": "XP multiplier for Knapping skill."
+      },
+      "Carving": {
+        "label": "Multiplicador De Tallar",
+        "description": "XP multiplier for Carving skill."
+      },
+      "Tracking": {
+        "label": "Multiplicador De Rastrear",
+        "description": "XP multiplier for Tracking skill."
+      },
+      "Butchering": {
+        "label": "Multiplicador De Carnicería",
+        "description": "XP multiplier for Butchering skill."
+      },
+      "Glassmaking": {
+        "label": "Multiplicador de Cristalería",
+        "description": "XP multiplier for Glassmaking skill."
+      },
+      "Husbandry": {
+        "label": "Multiplicador De Cuidado Animal",
+        "description": "XP multiplier for Animal Husbandry skill."
+      },
+      "Spear": {
+        "label": "Multiplicador De Lanza",
+        "description": "XP multiplier for Spear skill."
+      },
+      "Masonry": {
+        "label": "Multiplicador De Albañilería",
+        "description": "XP multiplier for Masonry skill."
+      },
+      "Pottery": {
+        "label": "Multiplicador De Alfarería",
+        "description": "XP multiplier for Pottery skill."
+      },
+      "Blacksmith": {
+        "label": "Multiplicador De Herrería",
+        "description": "XP multiplier for Blacksmith skill."
+      }
+    },
+    "map": {
+      "AllowMiniMap": {
+        "label": "Permitir mini mapa",
+        "description": "Whether the in-game mini map is available."
+      },
+      "AllowWorldMap": {
+        "label": "Permitir mapa del mundo",
+        "description": "Whether the in-game world map is available."
+      },
+      "MapAllKnown": {
+        "label": "Todo conocido al inicio",
+        "description": "The entire map is revealed from the start."
+      },
+      "MapNeedsLight": {
+        "label": "Luz Necesaria Para Leer El Mapa",
+        "description": "Map can only be used when there is enough light."
+      }
+    },
+    "basement": {
+      "SpawnFrequency": {
+        "label": "Basement Spawn Frequency",
+        "description": "How often basements appear in buildings.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Very Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      }
+    }
+  },
+  "iniCategories": {
+    "general": {
+      "label": "General"
+    },
+    "network": {
+      "label": "Network & Ports"
+    },
+    "steam": {
+      "label": "Steam Integration"
+    },
+    "discord": {
+      "label": "Discord"
+    },
+    "rcon": {
+      "label": "RCON"
+    },
+    "voice": {
+      "label": "Voice Chat"
+    },
+    "players": {
+      "label": "Players & Accounts"
+    },
+    "safehouse": {
+      "label": "Safehouses"
+    },
+    "chat": {
+      "label": "Chat & Communication"
+    },
+    "pvp": {
+      "label": "PvP & Safety"
+    },
+    "moderation": {
+      "label": "Moderation"
+    },
+    "anticheat": {
+      "label": "Anti-Cheat"
+    },
+    "loot": {
+      "label": "Loot & Items"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "mods": {
+      "label": "Mods & Workshop"
+    },
+    "radio": {
+      "label": "Radio"
+    },
+    "war": {
+      "label": "Faction War"
+    },
+    "backups": {
+      "label": "Backups"
+    },
+    "logging": {
+      "label": "Logging"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
+  },
+  "iniCategoryGroups": {
+    "identity": {
+      "label": "Identity"
+    },
+    "connectivity": {
+      "label": "Connectivity"
+    },
+    "players": {
+      "label": "Players"
+    },
+    "gameplay": {
+      "label": "Gameplay"
+    },
+    "ops": {
+      "label": "Ops"
+    }
+  },
+  "sandboxCategories": {
+    "time": {
+      "label": "Time & Season"
+    },
+    "environment": {
+      "label": "Environment & Weather"
+    },
+    "world": {
+      "label": "World & Stories"
+    },
+    "map": {
+      "label": "Map & Navigation"
+    },
+    "zombieLore": {
+      "label": "Zombie Behavior"
+    },
+    "zombiePopulation": {
+      "label": "Zombie Population"
+    },
+    "population": {
+      "label": "Population & Distribution"
+    },
+    "survival": {
+      "label": "Survival & Health"
+    },
+    "combat": {
+      "label": "Combat & Firearms"
+    },
+    "loot": {
+      "label": "Loot & Resources"
+    },
+    "lootRarity": {
+      "label": "Loot Rarity"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "animals": {
+      "label": "Animals & Farming"
+    },
+    "xpMultipliers": {
+      "label": "XP Multipliers"
+    },
+    "basement": {
+      "label": "Basements"
+    }
+  },
+  "sandboxCategoryGroups": {
+    "world": {
+      "label": "World"
+    },
+    "zombies": {
+      "label": "Zombies"
+    },
+    "survival": {
+      "label": "Survival"
+    },
+    "resources": {
+      "label": "Resources"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
   }
 }

--- a/client/src/locales/fr/serverconfig.json
+++ b/client/src/locales/fr/serverconfig.json
@@ -386,5 +386,3651 @@
     "title": "Restaurer cette sauvegarde ?",
     "description": "Remplacer le fichier actuel par « {{filename}} » ? Les modifications non enregistrées de la config active seront perdues.",
     "confirmLabel": "Restaurer"
+  },
+  "iniSettings": {
+    "general": {
+      "PublicName": {
+        "label": "Server Name",
+        "description": "Your server name as shown to the public."
+      },
+      "PublicDescription": {
+        "label": "Server Description",
+        "description": "The description that people can see while browsing your server."
+      },
+      "Public": {
+        "label": "Public Server",
+        "description": "Can your server be seen on Steam server browser."
+      },
+      "Open": {
+        "label": "Open (No Whitelist)",
+        "description": "Open to all players without requiring whitelist."
+      },
+      "Password": {
+        "label": "Server Password",
+        "description": "Password required to join the server. Leave empty for no password."
+      },
+      "MaxPlayers": {
+        "label": "Max Players",
+        "description": "Maximum allowed number of players."
+      },
+      "PauseEmpty": {
+        "label": "Pause When Empty",
+        "description": "The server will pause when no players are logged in."
+      },
+      "ServerWelcomeMessage": {
+        "label": "Welcome Message",
+        "description": "The welcome message displayed to players after connecting. Use <LINE> for new lines."
+      },
+      "Map": {
+        "label": "Map",
+        "description": "The map you're playing on. Default is Muldraugh, KY."
+      },
+      "SaveWorldEveryMinutes": {
+        "label": "Auto-Save Interval",
+        "description": "Auto-save world every X minutes. 0 = never."
+      },
+      "AnnounceDeath": {
+        "label": "Announce Deaths",
+        "description": "Server-wide announcement when a character dies."
+      },
+      "AnnounceAnimalDeath": {
+        "label": "Announce Animal Deaths",
+        "description": "Display a global chat message when an animal dies."
+      },
+      "Seed": {
+        "label": "World Seed",
+        "description": "The worldgen seed used to generate the world. Changing this requires deleting map_worldgen.bin."
+      }
+    },
+    "network": {
+      "DefaultPort": {
+        "label": "Game Port",
+        "description": "The port players will use to connect to your server. Must be open on your router."
+      },
+      "UPnP": {
+        "label": "Enable UPnP",
+        "description": "Enable UPnP for automatic port forwarding."
+      },
+      "PingFrequency": {
+        "label": "Ping Frequency",
+        "description": "How often the server checks connection to players (seconds)."
+      },
+      "PingLimit": {
+        "label": "Ping Limit",
+        "description": "Ping limit before being kicked (milliseconds). 100 to disable."
+      },
+      "DenyLoginOnOverloadedServer": {
+        "label": "Deny Login When Overloaded",
+        "description": "Prevent new connections when server is overloaded."
+      },
+      "SpeedLimit": {
+        "label": "Speed Limit",
+        "description": "Maximum movement speed allowed."
+      },
+      "UseTCPForMapDownloads": {
+        "label": "Use TCP for Map Downloads",
+        "description": "Use TCP instead of UDP for map downloads."
+      },
+      "MaxPacketsPerSecond": {
+        "label": "Max Packets Per Second",
+        "description": "Cap on packets per second sent to a connected client. Higher values increase bandwidth use; lower values may cause stutter under load."
+      },
+      "UDPPort": {
+        "label": "UDP Port",
+        "description": "Second port used for UDP connections."
+      },
+      "LoginQueueEnabled": {
+        "label": "Login Queue",
+        "description": "Enable a login queue when the server is full."
+      },
+      "LoginQueueConnectTimeout": {
+        "label": "Login Queue Timeout",
+        "description": "Seconds before a queued connection times out."
+      },
+      "server_browser_announced_ip": {
+        "label": "Announced IP",
+        "description": "IP address broadcast to the server browser. For multi-IP setups like server farms."
+      },
+      "MultiplayerStatisticsPeriod": {
+        "label": "Statistics Period",
+        "description": "Multiplayer statistics update period in seconds. 0 = disabled."
+      }
+    },
+    "pvp": {
+      "PVP": {
+        "label": "Enable PvP",
+        "description": "Allow player vs player combat (each player can still toggle their own PvP)."
+      },
+      "SafetySystem": {
+        "label": "Safety System",
+        "description": "If PvP is enabled, allows players to toggle their own PvP on/off."
+      },
+      "ShowSafety": {
+        "label": "Show Safety Status",
+        "description": "Show skull icon for players with safety off."
+      },
+      "SafetyToggleTimer": {
+        "label": "Safety Toggle Timer",
+        "description": "Time in seconds to switch between PvP on and off."
+      },
+      "SafetyCooldownTimer": {
+        "label": "Safety Cooldown Timer",
+        "description": "Time in seconds before you can toggle safety again."
+      },
+      "PVPMeleeWhileHitReaction": {
+        "label": "Melee While Hit Reaction",
+        "description": "Allow melee attacks during hit reaction in PvP."
+      },
+      "PVPMeleeDamageModifier": {
+        "label": "PvP Melee Damage %",
+        "description": "Melee damage modifier for PvP (percentage)."
+      },
+      "PVPFirearmDamageModifier": {
+        "label": "PvP Firearm Damage %",
+        "description": "Firearm damage modifier for PvP (percentage)."
+      },
+      "PlayerBumpPlayer": {
+        "label": "Player Collision",
+        "description": "Players can bump into each other."
+      },
+      "PVPLogToolChat": {
+        "label": "Log PvP to Chat",
+        "description": "PvP events are logged to admin chat."
+      },
+      "PVPLogToolFile": {
+        "label": "Log PvP to File",
+        "description": "PvP events are logged to a file."
+      },
+      "SafetyDisconnectDelay": {
+        "label": "Safety Disconnect Delay",
+        "description": "Seconds before PvP safety mode resets on disconnect."
+      }
+    },
+    "chat": {
+      "GlobalChat": {
+        "label": "Enable Global Chat",
+        "description": "Enable /all command for server-wide chat."
+      },
+      "ChatStreams": {
+        "label": "Chat Streams",
+        "description": "Enabled chat streams: s=say, r=radio, a=admin, w=whisper, y=yell, sh=safehouse, f=faction, all=global."
+      },
+      "DisplayUserName": {
+        "label": "Display Usernames",
+        "description": "Show player usernames above their heads and in chat."
+      },
+      "ShowFirstAndLastName": {
+        "label": "Show Character Names",
+        "description": "Display character first and last name instead of username."
+      },
+      "MouseOverToSeeDisplayName": {
+        "label": "Mouse Over for Name",
+        "description": "Require mouse hover to see player names."
+      },
+      "HidePlayersBehindYou": {
+        "label": "Hide Players Behind You",
+        "description": "Hide player names for players behind your character."
+      },
+      "AllowNonAsciiUsername": {
+        "label": "Allow Non-ASCII Usernames",
+        "description": "Allow usernames with non-ASCII characters."
+      },
+      "BanKickGlobalSound": {
+        "label": "Ban/Kick Sound",
+        "description": "Play global sound when a player is banned or kicked."
+      },
+      "UsernameDisguises": {
+        "label": "Username Disguises",
+        "description": "Allow players to disguise their username."
+      },
+      "HideDisguisedUserName": {
+        "label": "Hide Disguised Names",
+        "description": "Hide the real username of disguised players."
+      },
+      "ChatMessageCharacterLimit": {
+        "label": "Chat Character Limit",
+        "description": "Maximum characters per chat message."
+      },
+      "ChatMessageSlowModeTime": {
+        "label": "Chat Slow Mode",
+        "description": "Seconds between allowed chat messages per player."
+      }
+    },
+    "players": {
+      "MaxAccountsPerUser": {
+        "label": "Max Accounts Per User",
+        "description": "Limit accounts per Steam user. 0 = unlimited."
+      },
+      "DropOffWhiteListAfterDeath": {
+        "label": "Remove From Whitelist On Death",
+        "description": "Remove player from whitelist if their character dies."
+      },
+      "KickFastPlayers": {
+        "label": "Kick Speed Hackers",
+        "description": "Kick players moving faster than possible. May be buggy."
+      },
+      "SpawnPoint": {
+        "label": "Spawn Point",
+        "description": "Custom spawn point coordinates (X,Y,Z). 0,0,0 for default."
+      },
+      "SpawnItems": {
+        "label": "Spawn Items",
+        "description": "Items new characters spawn with (comma-separated, e.g., Base.BaseballBat,Base.WaterBottleFull)."
+      },
+      "SleepAllowed": {
+        "label": "Allow Sleep",
+        "description": "Whether sleeping is allowed."
+      },
+      "SleepNeeded": {
+        "label": "Sleep Required",
+        "description": "Whether players need to sleep when exhausted."
+      },
+      "PlayerRespawnWithSelf": {
+        "label": "Respawn at Death Location",
+        "description": "Allow respawning at death location."
+      },
+      "PlayerRespawnWithOther": {
+        "label": "Respawn with Partner",
+        "description": "Enable spawning at splitscreen partner location."
+      },
+      "PlayerSaveOnDamage": {
+        "label": "Save on Damage",
+        "description": "Save player state when they take damage."
+      },
+      "Faction": {
+        "label": "Enable Factions",
+        "description": "Allow creation and use of factions."
+      },
+      "FactionDaySurvivedToCreate": {
+        "label": "Days to Create Faction",
+        "description": "Days a player must survive to create a faction."
+      },
+      "FactionPlayersRequiredForTag": {
+        "label": "Players for Faction Tag",
+        "description": "Players required in faction to show tag."
+      },
+      "AllowTradeUI": {
+        "label": "Allow Trading",
+        "description": "Allow players to directly trade with one another."
+      },
+      "AllowCoop": {
+        "label": "Allow Co-op",
+        "description": "Allow co-op/splitscreen players to join."
+      },
+      "KnockedDownAllowed": {
+        "label": "Knocked Down",
+        "description": "Allow players to be knocked down. WIP: may cause visual desync."
+      },
+      "SneakModeHideFromOtherPlayers": {
+        "label": "Sneak Hides From Players",
+        "description": "Players in sneak mode are hidden from other players."
+      },
+      "MapRemotePlayerVisibility": {
+        "label": "Map Player Visibility",
+        "description": "Who can see other players on the in-game map.",
+        "options": {
+          "1": {
+            "label": "Hidden"
+          },
+          "2": {
+            "label": "Friends Only"
+          },
+          "3": {
+            "label": "Friends and Nearby Players"
+          },
+          "4": {
+            "label": "Everyone"
+          }
+        }
+      },
+      "DisableScoreboard": {
+        "label": "Disable Scoreboard",
+        "description": "Disable the in-game scoreboard."
+      },
+      "HideAdminsInPlayerList": {
+        "label": "Hide Admins in Player List",
+        "description": "Hide admin accounts from the player list."
+      }
+    },
+    "safehouse": {
+      "PlayerSafehouse": {
+        "label": "Enable Safehouses",
+        "description": "Allow players to claim safehouses."
+      },
+      "AdminSafehouse": {
+        "label": "Admin Safehouses",
+        "description": "Allow admins to have safehouses."
+      },
+      "SafehouseAllowTrepass": {
+        "label": "Allow Trespass",
+        "description": "Allow non-members to enter safehouses without invite."
+      },
+      "SafehouseAllowFire": {
+        "label": "Allow Fire Damage",
+        "description": "Allow fire to damage safehouses."
+      },
+      "SafehouseAllowLoot": {
+        "label": "Allow Looting",
+        "description": "Allow non-members to take items from safehouses."
+      },
+      "SafehouseAllowRespawn": {
+        "label": "Allow Safehouse Respawn",
+        "description": "Players can respawn in their safehouse."
+      },
+      "SafehouseDaySurvivedToClaim": {
+        "label": "Days to Claim Safehouse",
+        "description": "Days a player must survive before claiming a safehouse."
+      },
+      "SafeHouseRemovalTime": {
+        "label": "Safehouse Removal Time",
+        "description": "Real-time hours of inactivity before removal from safehouse."
+      },
+      "DisableSafehouseWhenOwnerConnected": {
+        "label": "Disable When Owner Online",
+        "description": "Disable safehouse protection when the owner is connected. (Renamed from DisableSafehouseWhenPlayerConnected in the Dec 2025 MP patch.)"
+      },
+      "SafehouseAllowNonResidential": {
+        "label": "Allow Non-Residential",
+        "description": "Allow players to claim non-residential buildings as safehouses."
+      },
+      "SafehouseDisableDisguises": {
+        "label": "Disable Disguises in Safehouse",
+        "description": "Disable username disguises inside safehouses."
+      },
+      "MaxSafezoneSize": {
+        "label": "Max Safezone Size",
+        "description": "Maximum tile size for safezones."
+      }
+    },
+    "loot": {
+      "ItemNumbersLimitPerContainer": {
+        "label": "Container Item Limit",
+        "description": "Max items per container. 0 = unlimited."
+      },
+      "TrashDeleteAll": {
+        "label": "Delete All Trash",
+        "description": "Delete all items when placed in trash."
+      },
+      "RemovePlayerCorpsesOnCorpseRemoval": {
+        "label": "Remove Player Corpses",
+        "description": "Remove player corpses when corpse removal runs."
+      },
+      "AllowDestructionBySledgehammer": {
+        "label": "Sledgehammer Destruction",
+        "description": "Allow players to destroy world objects with sledgehammer."
+      },
+      "NoFire": {
+        "label": "Disable Fire",
+        "description": "Disable all fires except campfires."
+      },
+      "SafehousePreventsLootRespawn": {
+        "label": "Safehouse Blocks Loot Respawn",
+        "description": "Items will not respawn in buildings claimed as safehouses."
+      },
+      "SledgehammerOnlyInSafehouse": {
+        "label": "Sledgehammer Only in Safehouse",
+        "description": "Restrict sledgehammer destruction to safehouses only. Requires Sledgehammer Destruction enabled."
+      }
+    },
+    "mods": {
+      "Mods": {
+        "label": "Mods",
+        "description": "List of installed mod IDs (semicolon-separated)."
+      },
+      "WorkshopItems": {
+        "label": "Workshop Items",
+        "description": "Steam Workshop item IDs to download (semicolon-separated)."
+      },
+      "DoLuaChecksum": {
+        "label": "Lua Checksum",
+        "description": "Verify client Lua matches server. Must be disabled when using PanelBridge — the mod modifies server-side Lua files, which causes checksum mismatches and prevents players from connecting."
+      }
+    },
+    "steam": {
+      "SteamPort1": {
+        "label": "Steam Port 1",
+        "description": "First Steam port."
+      },
+      "SteamPort2": {
+        "label": "Steam Port 2",
+        "description": "Second Steam port."
+      },
+      "SteamScoreboard": {
+        "label": "Steam Scoreboard",
+        "description": "Show Steam usernames and avatars. true/false/admin.",
+        "options": {
+          "true": {
+            "label": "Everyone"
+          },
+          "false": {
+            "label": "No One"
+          },
+          "admin": {
+            "label": "Admins Only"
+          }
+        }
+      },
+      "SteamVAC": {
+        "label": "VAC Ban Check",
+        "description": "Check if connecting players have VAC bans."
+      }
+    },
+    "voice": {
+      "VoiceEnable": {
+        "label": "Enable Voice Chat",
+        "description": "Enable in-game voice chat."
+      },
+      "Voice3D": {
+        "label": "3D Voice",
+        "description": "Enable 3D positional voice chat."
+      },
+      "VoiceMinDistance": {
+        "label": "Voice Min Distance",
+        "description": "Minimum voice distance."
+      },
+      "VoiceMaxDistance": {
+        "label": "Voice Max Distance",
+        "description": "Maximum voice distance."
+      }
+    },
+    "discord": {
+      "DiscordEnable": {
+        "label": "Enable Discord",
+        "description": "Enable built-in Discord integration."
+      },
+      "DiscordToken": {
+        "label": "Discord Token",
+        "description": "Discord bot token."
+      },
+      "DiscordChannel": {
+        "label": "Discord Channel",
+        "description": "Discord channel name."
+      },
+      "DiscordChannelID": {
+        "label": "Discord Channel ID",
+        "description": "Discord channel ID."
+      },
+      "DiscordChatChannel": {
+        "label": "Discord Chat Channel",
+        "description": "The Discord channel name for game chat."
+      },
+      "DiscordLogChannel": {
+        "label": "Discord Log Channel",
+        "description": "The Discord channel name for server logs."
+      },
+      "DiscordCommandChannel": {
+        "label": "Discord Command Channel",
+        "description": "The Discord channel name for commands."
+      },
+      "WebhookAddress": {
+        "label": "Webhook URL",
+        "description": "Slack/Discord incoming webhook URL for notifications."
+      }
+    },
+    "rcon": {
+      "RCONPort": {
+        "label": "RCON Port",
+        "description": "Port for RCON connections."
+      },
+      "RCONPassword": {
+        "label": "RCON Password",
+        "description": "Password for RCON connections."
+      }
+    },
+    "advanced": {
+      "ResetID": {
+        "label": "Reset ID",
+        "description": "Removing this resets zombies and loot (not time)."
+      },
+      "ServerPlayerID": {
+        "label": "Server Player ID",
+        "description": "Identifies if character is from another server."
+      },
+      "PhysicsDelay": {
+        "label": "Physics Delay",
+        "description": "Physics update delay in milliseconds."
+      },
+      "FastForwardMultiplier": {
+        "label": "Fast Forward Multiplier",
+        "description": "Speed multiplier when fast-forwarding."
+      },
+      "CarEngineAttractionModifier": {
+        "label": "Car Engine Attraction",
+        "description": "Modifier for zombie attraction to car engines."
+      },
+      "ZombieUpdateMaxHighPriority": {
+        "label": "Zombie High Priority Updates",
+        "description": "Max high priority zombie updates per tick."
+      },
+      "ZombieUpdateDelta": {
+        "label": "Zombie Update Delta",
+        "description": "Zombie update time delta."
+      },
+      "SwitchZombiesOwnershipEachUpdate": {
+        "label": "Switch Zombie Ownership",
+        "description": "Switch zombie ownership between players each update tick."
+      },
+      "UltraSpeedDoesnotAffectToAnimals": {
+        "label": "Ultra Speed Ignores Animals",
+        "description": "Ultra speed mode does not affect animal simulation."
+      },
+      "UsePhysicsHitReaction": {
+        "label": "Physics Hit Reaction",
+        "description": "Use physics-based hit reactions."
+      }
+    },
+    "war": {
+      "War": {
+        "label": "Enable Faction War",
+        "description": "Enable faction war system. (Disabled by default since the Dec 2025 MP patch.)"
+      },
+      "WarStartDelay": {
+        "label": "War Start Delay",
+        "description": "Seconds before war starts after being declared."
+      },
+      "WarDuration": {
+        "label": "War Duration",
+        "description": "War duration in seconds."
+      },
+      "WarSafehouseHitPoints": {
+        "label": "War Safehouse Hit Points",
+        "description": "Safehouse hit points during faction war."
+      }
+    },
+    "radio": {
+      "DisableRadioStaff": {
+        "label": "Disable Radio for Staff",
+        "description": "Disable radio transmissions from staff access level."
+      },
+      "DisableRadioAdmin": {
+        "label": "Disable Radio for Admins",
+        "description": "Disable radio transmissions from admin access level."
+      },
+      "DisableRadioGM": {
+        "label": "Disable Radio for GMs",
+        "description": "Disable radio transmissions from GM access level."
+      },
+      "DisableRadioOverseer": {
+        "label": "Disable Radio for Overseers",
+        "description": "Disable radio transmissions from overseer access level."
+      },
+      "DisableRadioModerator": {
+        "label": "Disable Radio for Moderators",
+        "description": "Disable radio transmissions from moderator access level."
+      },
+      "DisableRadioInvisible": {
+        "label": "Disable Radio for Invisible",
+        "description": "Disable radio transmissions from invisible players."
+      }
+    },
+    "backups": {
+      "BackupsCount": {
+        "label": "Backup Count",
+        "description": "Number of backup copies to keep."
+      },
+      "BackupsOnStart": {
+        "label": "Backup on Start",
+        "description": "Create a backup when the server starts."
+      },
+      "BackupsOnVersionChange": {
+        "label": "Backup on Version Change",
+        "description": "Create a backup when the game version changes."
+      },
+      "BackupsPeriod": {
+        "label": "Backup Period",
+        "description": "Minutes between automatic backups. 0 = disabled."
+      }
+    },
+    "vehicles": {
+      "DisableVehicleTowing": {
+        "label": "Disable Vehicle Towing",
+        "description": "Disable vehicle towing."
+      },
+      "DisableTrailerTowing": {
+        "label": "Disable Trailer Towing",
+        "description": "Disable trailer towing."
+      },
+      "DisableBurntTowing": {
+        "label": "Disable Burnt Vehicle Towing",
+        "description": "Disable towing of burnt vehicles."
+      }
+    },
+    "moderation": {
+      "BadWordListFile": {
+        "label": "Bad Word List File",
+        "description": "Path to file with prohibited words, one per line."
+      },
+      "GoodWordListFile": {
+        "label": "Good Word List File",
+        "description": "Path to file with allowed words that may contain bad words, one per line."
+      },
+      "BadWordPolicy": {
+        "label": "Bad Word Policy",
+        "description": "Action taken when a bad word is detected in chat.",
+        "options": {
+          "1": {
+            "label": "Ban"
+          },
+          "2": {
+            "label": "Kick"
+          },
+          "3": {
+            "label": "Record Violation"
+          },
+          "4": {
+            "label": "Mute"
+          }
+        }
+      },
+      "BadWordReplacement": {
+        "label": "Bad Word Replacement",
+        "description": "Text that replaces bad words in chat."
+      }
+    },
+    "anticheat": {
+      "AntiCheatSafety": {
+        "label": "Safety",
+        "description": "Anti-cheat protection for the safety system.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSpeed": {
+        "label": "Speed",
+        "description": "Anti-cheat protection for player speed.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatNoClip": {
+        "label": "No Clip",
+        "description": "Anti-cheat protection against moving through solid objects.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatHit": {
+        "label": "Hit Detection",
+        "description": "Anti-cheat protection for character hits.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPacketException": {
+        "label": "Packet Exceptions",
+        "description": "Anti-cheat protection for invalid network packets.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPermission": {
+        "label": "Permissions",
+        "description": "Anti-cheat protection for player permissions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatXP": {
+        "label": "XP Validation",
+        "description": "Anti-cheat protection for player XP.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSafeHouse": {
+        "label": "Safehouse Protection",
+        "description": "Anti-cheat protection for safehouses.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPlayer": {
+        "label": "Player Validation",
+        "description": "Anti-cheat protection for player actions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatChecksum": {
+        "label": "Checksum Validation",
+        "description": "Anti-cheat protection for file checksums.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      }
+    },
+    "logging": {
+      "ClientCommandFilter": {
+        "label": "Command Log Filter",
+        "description": "Semicolon-separated list of commands to exclude from cmd.txt log. Use -vehicle.* to exclude all vehicle, +vehicle.installPart to include specific."
+      },
+      "ClientActionLogs": {
+        "label": "Client Action Logs",
+        "description": "Semicolon-separated list of actions written to ClientActionLogs.txt."
+      },
+      "PerkLogs": {
+        "label": "Perk Level Logging",
+        "description": "Track changes in player perk levels in PerkLog.txt."
+      }
+    }
+  },
+  "sandboxSettings": {
+    "time": {
+      "DayLength": {
+        "label": "Durée d'une journée (en temps réel)",
+        "description": "How long a day lasts.",
+        "options": {
+          "1": {
+            "label": "15 minutes"
+          },
+          "2": {
+            "label": "30 minutes"
+          },
+          "3": {
+            "label": "1 heure"
+          },
+          "4": {
+            "label": "1 heure 30 minutes"
+          },
+          "5": {
+            "label": "2 heures"
+          },
+          "6": {
+            "label": "3 heures"
+          },
+          "7": {
+            "label": "4 heures"
+          },
+          "8": {
+            "label": "5 heures"
+          },
+          "9": {
+            "label": "6 heures"
+          },
+          "10": {
+            "label": "7 h"
+          },
+          "11": {
+            "label": "8 heures"
+          },
+          "12": {
+            "label": "9 h"
+          },
+          "13": {
+            "label": "10 heures"
+          },
+          "14": {
+            "label": "11 heures"
+          },
+          "15": {
+            "label": "12 heures"
+          },
+          "16": {
+            "label": "13 heures"
+          },
+          "17": {
+            "label": "14 h"
+          },
+          "18": {
+            "label": "15 heures"
+          },
+          "19": {
+            "label": "16 heures"
+          },
+          "20": {
+            "label": "17 h"
+          },
+          "21": {
+            "label": "18 heures"
+          },
+          "22": {
+            "label": "19 heures"
+          },
+          "23": {
+            "label": "20 heures"
+          },
+          "24": {
+            "label": "21 h"
+          },
+          "25": {
+            "label": "22 heures"
+          },
+          "26": {
+            "label": "23 heures"
+          },
+          "27": {
+            "label": "Temps réel"
+          }
+        }
+      },
+      "StartYear": {
+        "label": "Année de départ",
+        "description": "Which year the game starts in."
+      },
+      "StartMonth": {
+        "label": "Mois de départ",
+        "description": "Which month the game starts in (1=Jan, 12=Dec).",
+        "options": {
+          "1": {
+            "label": "Janvier"
+          },
+          "2": {
+            "label": "Février"
+          },
+          "3": {
+            "label": "Mars"
+          },
+          "4": {
+            "label": "Avril"
+          },
+          "5": {
+            "label": "Mai"
+          },
+          "6": {
+            "label": "Juin"
+          },
+          "7": {
+            "label": "Juillet"
+          },
+          "8": {
+            "label": "Août"
+          },
+          "9": {
+            "label": "Septembre"
+          },
+          "10": {
+            "label": "Octobre"
+          },
+          "11": {
+            "label": "Novembre"
+          },
+          "12": {
+            "label": "Décembre"
+          }
+        }
+      },
+      "StartDay": {
+        "label": "Jour de départ",
+        "description": "Which day of the month the game starts on."
+      },
+      "StartTime": {
+        "label": "Heure de départ",
+        "description": "What time of day the game starts.",
+        "options": {
+          "1": {
+            "label": "7 heures"
+          },
+          "2": {
+            "label": "9 heures"
+          },
+          "3": {
+            "label": "Midi"
+          },
+          "4": {
+            "label": "14 heures"
+          },
+          "5": {
+            "label": "17 heures"
+          },
+          "6": {
+            "label": "21 heures"
+          },
+          "7": {
+            "label": "Minuit"
+          },
+          "8": {
+            "label": "2 h"
+          },
+          "9": {
+            "label": "5 h"
+          }
+        }
+      }
+    },
+    "population": {
+      "Zombies": {
+        "label": "Nombre de zombie",
+        "description": "Initial zombie population level. Also sets Population Multiplier in Advanced Zombie Options.",
+        "options": {
+          "1": {
+            "label": "Hardcore"
+          },
+          "2": {
+            "label": "Très Élevé"
+          },
+          "3": {
+            "label": "Élevé"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Faible"
+          },
+          "6": {
+            "label": "Aucun"
+          }
+        }
+      },
+      "Distribution": {
+        "label": "Répartition des zombies",
+        "description": "How zombies are distributed across the map.",
+        "options": {
+          "1": {
+            "label": "Focalisés en ville"
+          },
+          "2": {
+            "label": "Uniforme"
+          }
+        }
+      },
+      "ZombieVoronoiNoise": {
+        "label": "Voronoi noise",
+        "description": "Apply randomization to zombie distribution."
+      },
+      "ZombieRespawn": {
+        "label": "Réapparition des zombies",
+        "description": "How frequently new zombies are added to the world.",
+        "options": {
+          "1": {
+            "label": "Élevée"
+          },
+          "2": {
+            "label": "Normale"
+          },
+          "3": {
+            "label": "Faible"
+          },
+          "4": {
+            "label": "Aucune"
+          }
+        }
+      },
+      "ZombieMigrate": {
+        "label": "Migration des zombies",
+        "description": "Zombies can migrate to empty cells."
+      }
+    },
+    "loot": {
+      "LootItemRemovalList": {
+        "label": "Lise des objets à retirer du butin",
+        "description": "Comma-separated item types removed from the world by the loot cleanup system."
+      },
+      "FoodLootNew": {
+        "label": "Nourriture périssable",
+        "description": "Any food that can rot or spoil."
+      },
+      "CannedFoodLootNew": {
+        "label": "Nourriture non-périssable",
+        "description": "Canned and dried food, beverages."
+      },
+      "LiteratureLootNew": {
+        "label": "Littérature diverse",
+        "description": "All readable items including books, fliers, and newspapers."
+      },
+      "SkillBookLoot": {
+        "label": "Livres de compétences",
+        "description": "Books that provide skill XP multipliers."
+      },
+      "RecipeResourceLoot": {
+        "label": "Ressources de recette",
+        "description": "Items that teach recipes."
+      },
+      "MedicalLootNew": {
+        "label": "Matériel médical",
+        "description": "Medicine, bandages, and first aid tools."
+      },
+      "SurvivalGearsLootNew": {
+        "label": "Essentiel de survie",
+        "description": "Fishing rods, tents, camping gear."
+      },
+      "WeaponLootNew": {
+        "label": "Armes de mêlée",
+        "description": "Weapons that are not tools in other categories."
+      },
+      "RangedWeaponLootNew": {
+        "label": "Armes à distance",
+        "description": "Ranged weapons and weapon attachments."
+      },
+      "AmmoLootNew": {
+        "label": "Munitions",
+        "description": "Loose ammo, boxes, and magazines."
+      },
+      "MechanicsLootNew": {
+        "label": "Matériel de mécanique",
+        "description": "Vehicle parts and installation tools."
+      },
+      "ClothingLootNew": {
+        "label": "Vêtements",
+        "description": "All wearable items that are not containers."
+      },
+      "ContainerLootNew": {
+        "label": "Sacs",
+        "description": "Backpacks and wearable/equippable containers."
+      },
+      "KeyLootNew": {
+        "label": "Clés",
+        "description": "Keys for buildings/cars, key rings, and locks."
+      },
+      "MediaLootNew": {
+        "label": "Média",
+        "description": "VHS tapes and CDs."
+      },
+      "MementoLootNew": {
+        "label": "Mémentos",
+        "description": "Spiffo items, plushies, and collectible keepsakes."
+      },
+      "CookwareLootNew": {
+        "label": "Cuisine",
+        "description": "Cooking items including those that can be weapons. Does not include food."
+      },
+      "MaterialLootNew": {
+        "label": "Matériaux",
+        "description": "Crafting and building materials."
+      },
+      "FarmingLootNew": {
+        "label": "Agriculture",
+        "description": "Seeds, trowels, shovels, and agriculture tools."
+      },
+      "ToolLootNew": {
+        "label": "Outils",
+        "description": "Tools not in other categories like Mechanics or Farming."
+      },
+      "OtherLootNew": {
+        "label": "Autres",
+        "description": "Everything else. Also affects foraging in Town/Road zones."
+      },
+      "RollsMultiplier": {
+        "label": "Multiplicateur de lancers (rolls) [!]",
+        "description": "Multiplier for loot table rolls. Higher values may affect performance. NOT recommended to change."
+      },
+      "RemoveStoryLoot": {
+        "label": "Retirer le butin des zones d'histoire",
+        "description": "Items on the removal list will not spawn in world stories."
+      },
+      "RemoveZombieLoot": {
+        "label": "Retirer le butin indésirable des zombies",
+        "description": "Items on the removal list will not spawn on zombies."
+      },
+      "ZombiePopLootEffect": {
+        "label": "Effet de la population de Z sur le butin",
+        "description": "If > 0, loot increases relative to nearby zombies, multiplied by this value."
+      },
+      "HoursForLootRespawn": {
+        "label": "Heures avant réapparition du butin",
+        "description": "Hours after which containers respawn loot. 0 = never."
+      },
+      "MaxItemsForLootRespawn": {
+        "label": "Objets max pour réapparition du butin",
+        "description": "Containers with this many items or more will not respawn loot."
+      },
+      "ConstructionPreventsLootRespawn": {
+        "label": "Constructions empêchent la réapparition de butin",
+        "description": "Player constructions near containers prevent loot respawn."
+      },
+      "SeenHoursPreventLootRespawn": {
+        "label": "Réapparition du butin si zone visitée",
+        "description": "Hours a zone must be unvisited before loot respawns. 0 = disabled."
+      }
+    },
+    "lootRarity": {
+      "InsaneLootFactor": {
+        "label": "Facteur de butin ridiculement rare",
+        "description": "Spawn rate for Insane rarity items."
+      },
+      "ExtremeLootFactor": {
+        "label": "Facteur de butin extrêmement rare",
+        "description": "Spawn rate for Extreme rarity items."
+      },
+      "RareLootFactor": {
+        "label": "Facteur de butin rare",
+        "description": "Spawn rate for Rare rarity items."
+      },
+      "NormalLootFactor": {
+        "label": "Facteur de butin normal",
+        "description": "Spawn rate for Normal rarity items."
+      },
+      "CommonLootFactor": {
+        "label": "Facteur de butin commun",
+        "description": "Spawn rate for Common rarity items."
+      },
+      "AbundantLootFactor": {
+        "label": "Facteur de butin abondant",
+        "description": "Spawn rate for Abundant rarity items."
+      },
+      "MaximumLooted": {
+        "label": "Multiplicateur de bâtiments déjà pillés",
+        "description": "Chance that any building is already looted when found."
+      },
+      "DaysUntilMaximumLooted": {
+        "label": "Jours max bâtiments déjà pillés",
+        "description": "Days before Maximum Looted Building Chance is reached."
+      },
+      "RuralLooted": {
+        "label": "Multiplicateur de bâtiments ruraux déjà pillés",
+        "description": "Chance that any rural building is already looted."
+      },
+      "MaximumDiminishedLoot": {
+        "label": "Pourcentage max de butin diminué",
+        "description": "Maximum loot that won't spawn when diminished days reached."
+      },
+      "DaysUntilMaximumDiminishedLoot": {
+        "label": "Jours jusqu'à la diminution maximum du butin",
+        "description": "Days before Maximum Diminished Loot is reached."
+      },
+      "MaximumLootedBuildingRooms": {
+        "label": "Nombre max de pièces pillées",
+        "description": "Buildings with more than this many rooms will not be auto-looted."
+      }
+    },
+    "environment": {
+      "DayNightCycle": {
+        "label": "Cycle jour/nuit",
+        "description": "Whether time of day changes naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Jour permanent"
+          },
+          "3": {
+            "label": "Nuit permanente"
+          }
+        }
+      },
+      "ClimateCycle": {
+        "label": "Cycle climatique",
+        "description": "Whether weather changes or remains fixed.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Pas de changements"
+          },
+          "3": {
+            "label": "Pluie permanente"
+          },
+          "4": {
+            "label": "Tempête permanente"
+          },
+          "5": {
+            "label": "Neige permanente"
+          },
+          "6": {
+            "label": "Blizzard permanent"
+          }
+        }
+      },
+      "FogCycle": {
+        "label": "Cycle du brouillard",
+        "description": "Whether fog occurs naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Pas de brouillard"
+          },
+          "3": {
+            "label": "Brouillard permanent"
+          }
+        }
+      },
+      "WaterShut": {
+        "label": "Coupure d'eau",
+        "description": "When plumbing fixtures stop being infinite water sources.",
+        "options": {
+          "1": {
+            "label": "Immédiate"
+          },
+          "2": {
+            "label": "0 - 30 jours"
+          },
+          "3": {
+            "label": "0 - 2 mois"
+          },
+          "4": {
+            "label": "0 - 6 mois"
+          },
+          "5": {
+            "label": "0 - 1 année"
+          },
+          "6": {
+            "label": "0 - 5 années"
+          },
+          "7": {
+            "label": "2 - 6 mois"
+          },
+          "8": {
+            "label": "6 - 12 mois"
+          },
+          "9": {
+            "label": "Désactivée"
+          }
+        }
+      },
+      "ElecShut": {
+        "label": "Coupure d'électricité",
+        "description": "When the world's electricity turns off.",
+        "options": {
+          "1": {
+            "label": "Instantané"
+          },
+          "2": {
+            "label": "14 - 30 jours"
+          },
+          "3": {
+            "label": "14 jours - 2 mois"
+          },
+          "4": {
+            "label": "14 jours - 6 mois"
+          },
+          "5": {
+            "label": "14 jours - 1 an"
+          },
+          "6": {
+            "label": "14 jours - 5 ans"
+          },
+          "7": {
+            "label": "2 - 6 mois"
+          },
+          "8": {
+            "label": "6 - 12 mois"
+          },
+          "9": {
+            "label": "Désactivée"
+          }
+        }
+      },
+      "AlarmDecay": {
+        "label": "Dégradation batterie des alarmes",
+        "description": "How long alarm batteries last after power shuts off.",
+        "options": {
+          "1": {
+            "label": "Immédiate"
+          },
+          "2": {
+            "label": "0 - 30 jours"
+          },
+          "3": {
+            "label": "0 - 2 mois"
+          },
+          "4": {
+            "label": "0 - 6 mois"
+          },
+          "5": {
+            "label": "0 - 1 année"
+          },
+          "6": {
+            "label": "0 - 5 années"
+          },
+          "7": {
+            "label": "2 - 6 mois"
+          },
+          "8": {
+            "label": "6 - 12 mois"
+          },
+          "9": {
+            "label": "Désactivée"
+          }
+        }
+      },
+      "WaterShutModifier": {
+        "label": "Modificateur de la coupure d'eau",
+        "description": "Fine-tune water shutoff timing in days."
+      },
+      "ElecShutModifier": {
+        "label": "Modificateur de la coupure d'électricité",
+        "description": "Fine-tune electricity shutoff timing in days."
+      },
+      "AlarmDecayModifier": {
+        "label": "Alarm Decay Modifier",
+        "description": "Fine-tune alarm battery decay timing in days."
+      },
+      "Temperature": {
+        "label": "Température",
+        "description": "Global temperature setting.",
+        "options": {
+          "1": {
+            "label": "Très froide"
+          },
+          "2": {
+            "label": "Froide"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Chaude"
+          },
+          "5": {
+            "label": "Très chaude"
+          }
+        }
+      },
+      "Rain": {
+        "label": "Pluie",
+        "description": "How often it rains.",
+        "options": {
+          "1": {
+            "label": "Très sèche"
+          },
+          "2": {
+            "label": "Sèche"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Fréquente"
+          },
+          "5": {
+            "label": "Très fréquente"
+          }
+        }
+      },
+      "ErosionSpeed": {
+        "label": "Vitesse de détérioration",
+        "description": "How fast nature reclaims the world.",
+        "options": {
+          "1": {
+            "label": "Très rapide (20 jours)"
+          },
+          "2": {
+            "label": "Rapide (50 jours)"
+          },
+          "3": {
+            "label": "Normale (100 jours)"
+          },
+          "4": {
+            "label": "Lente (200 jours)"
+          },
+          "5": {
+            "label": "Très lente (500 jours)"
+          }
+        }
+      },
+      "ErosionDays": {
+        "label": "Jours de détérioration",
+        "description": "Custom erosion days. 0 = use Erosion Speed option."
+      },
+      "MaxFogIntensity": {
+        "label": "Densité maximale du brouillard",
+        "description": "Maximum intensity of fog.",
+        "options": {
+          "1": {
+            "label": "Normale"
+          },
+          "2": {
+            "label": "Modérée"
+          },
+          "3": {
+            "label": "Basse"
+          },
+          "4": {
+            "label": "Aucun"
+          }
+        }
+      },
+      "MaxRainFxIntensity": {
+        "label": "Intensité maximale des effets de pluie",
+        "description": "Maximum intensity of rain effects.",
+        "options": {
+          "1": {
+            "label": "Normale"
+          },
+          "2": {
+            "label": "Modérée"
+          },
+          "3": {
+            "label": "Basse"
+          }
+        }
+      },
+      "EnableSnowOnGround": {
+        "label": "Neige au sol",
+        "description": "Whether snow accumulates on the ground."
+      },
+      "NightDarkness": {
+        "label": "Obscurité durant la nuit",
+        "description": "Ambient lighting level at night.",
+        "options": {
+          "1": {
+            "label": "Nuit noire"
+          },
+          "2": {
+            "label": "Sombre"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Claire"
+          }
+        }
+      },
+      "NightLength": {
+        "label": "Durée des nuits",
+        "description": "Duration from dusk to dawn.",
+        "options": {
+          "1": {
+            "label": "Toujours la nuit"
+          },
+          "2": {
+            "label": "Longue"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Courte"
+          },
+          "5": {
+            "label": "Toujours le jour"
+          }
+        }
+      },
+      "TimeSinceApo": {
+        "label": "Mois depuis l'apocalypse",
+        "description": "How long after the apocalypse the game begins. Affects erosion and food spoilage.",
+        "options": {
+          "1": {
+            "label": "0"
+          },
+          "2": {
+            "label": "1"
+          },
+          "3": {
+            "label": "2"
+          },
+          "4": {
+            "label": "3"
+          },
+          "5": {
+            "label": "4"
+          },
+          "6": {
+            "label": "5"
+          },
+          "7": {
+            "label": "6"
+          },
+          "8": {
+            "label": "7"
+          },
+          "9": {
+            "label": "8"
+          },
+          "10": {
+            "label": "9"
+          },
+          "11": {
+            "label": "10"
+          },
+          "12": {
+            "label": "11"
+          },
+          "13": {
+            "label": "12"
+          }
+        }
+      },
+      "FireSpread": {
+        "label": "Propagation du feu",
+        "description": "Whether fires spread when started."
+      }
+    },
+    "survival": {
+      "StatsDecrease": {
+        "label": "Diminution des stats",
+        "description": "How fast hunger, thirst, and fatigue decrease.",
+        "options": {
+          "1": {
+            "label": "Très rapide"
+          },
+          "2": {
+            "label": "Rapide"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Lente"
+          },
+          "5": {
+            "label": "Très lente"
+          }
+        }
+      },
+      "Nutrition": {
+        "label": "Système de nutrition",
+        "description": "Food nutrition affects player weight and condition."
+      },
+      "FoodRotSpeed": {
+        "label": "Péremption de la nourriture",
+        "description": "How fast food spoils.",
+        "options": {
+          "1": {
+            "label": "Très rapide"
+          },
+          "2": {
+            "label": "Rapide"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Lente"
+          },
+          "5": {
+            "label": "Très lente"
+          }
+        }
+      },
+      "FridgeFactor": {
+        "label": "Efficacité du réfrigérateur",
+        "description": "How effective fridges are at preserving food.",
+        "options": {
+          "1": {
+            "label": "Très peu efficace"
+          },
+          "2": {
+            "label": "Peu efficace"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Efficace"
+          },
+          "5": {
+            "label": "Très efficace"
+          },
+          "6": {
+            "label": "Ne pourrit jamais"
+          }
+        }
+      },
+      "StarterKit": {
+        "label": "Équipement de départ",
+        "description": "Spawn with chips, water bottle, backpack, bat, and hammer."
+      },
+      "CharacterFreePoints": {
+        "label": "Points de trait gratuits",
+        "description": "Extra free points during character creation."
+      },
+      "BoneFracture": {
+        "label": "Fractures",
+        "description": "Survivors can get broken limbs from impacts, falls, etc."
+      },
+      "InjurySeverity": {
+        "label": "Gravité des blessures",
+        "description": "Impact of injuries and healing time.",
+        "options": {
+          "1": {
+            "label": "Basse"
+          },
+          "2": {
+            "label": "Normale"
+          },
+          "3": {
+            "label": "Haute"
+          }
+        }
+      },
+      "EndRegen": {
+        "label": "Récupération d'endurance",
+        "description": "Recovery from tiredness after actions.",
+        "options": {
+          "1": {
+            "label": "Très rapide"
+          },
+          "2": {
+            "label": "Rapide"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Lente"
+          },
+          "5": {
+            "label": "Très lente"
+          }
+        }
+      },
+      "HoursForCorpseRemoval": {
+        "label": "Temps avant la disparition des cadavres",
+        "description": "Hours before zombie corpses disappear. 0 = no maggots spawn."
+      },
+      "DecayingCorpseHealthImpact": {
+        "label": "Impact des cadavres en décomposition sur la santé",
+        "description": "Impact of nearby decaying bodies on health/emotions.",
+        "options": {
+          "1": {
+            "label": "Aucun"
+          },
+          "2": {
+            "label": "Bas"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Haut"
+          },
+          "5": {
+            "label": "Extrême"
+          }
+        }
+      },
+      "ZombieHealthImpact": {
+        "label": "Impact des zombies à proximité sur la santé",
+        "description": "Whether living zombies also affect player health/emotions."
+      },
+      "BloodLevel": {
+        "label": "Quantité de sang",
+        "description": "How much blood sprays on surfaces.",
+        "options": {
+          "1": {
+            "label": "Pas de sang"
+          },
+          "2": {
+            "label": "Faible"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Élevée"
+          },
+          "5": {
+            "label": "Ultra Gore"
+          }
+        }
+      },
+      "ClothingDegradation": {
+        "label": "Dégradation des vêtements",
+        "description": "How quickly clothing degrades and gets dirty.",
+        "options": {
+          "1": {
+            "label": "Désactivée"
+          },
+          "2": {
+            "label": "Lente"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Rapide"
+          }
+        }
+      },
+      "DaysForRottenFoodRemoval": {
+        "label": "Disparition de la nourriture pourrie",
+        "description": "Days before rotten food is removed. -1 = never."
+      },
+      "AllClothesUnlocked": {
+        "label": "Tous les vêtements sont débloqués",
+        "description": "Select from every clothing item during character creation."
+      },
+      "EnableTaintedWaterText": {
+        "label": "Activer l'indicateur 'eau impure'",
+        "description": "Show warning marking tainted water."
+      },
+      "EnablePoisoning": {
+        "label": "Activer l'empoisonnement",
+        "description": "Whether poison can be added to food.",
+        "options": {
+          "1": {
+            "label": "Oui"
+          },
+          "2": {
+            "label": "Non"
+          },
+          "3": {
+            "label": "Seul l'empoisonnement à la javel est désactivé"
+          }
+        }
+      },
+      "MaggotSpawn": {
+        "label": "Apparition d'asticots sur les cadavres",
+        "description": "When maggots spawn in corpses.",
+        "options": {
+          "1": {
+            "label": "Dans les cadavres et autour"
+          },
+          "2": {
+            "label": "Dans les cadavres uniquement"
+          },
+          "3": {
+            "label": "Jamais"
+          }
+        }
+      },
+      "MuscleStrainFactor": {
+        "label": "Facteur de courbature",
+        "description": "Multiplier for muscle strain from swinging weapons or carrying heavy loads."
+      },
+      "DiscomfortFactor": {
+        "label": "Facteur d'inconfort",
+        "description": "Multiplier for discomfort from worn items."
+      },
+      "WoundInfectionFactor": {
+        "label": "Facteur de dégâts d'une blessure infectée",
+        "description": "Damage from serious wound infections. 0 = disabled."
+      },
+      "NoBlackClothes": {
+        "label": "Pas de vêtements noirs",
+        "description": "Prevent randomized clothing from becoming near-black."
+      },
+      "EasyClimbing": {
+        "label": "Escalade facile",
+        "description": "Disable failure chances when climbing sheet ropes or walls."
+      },
+      "NegativeTraitsPenalty": {
+        "label": "Pénalité de traits négatifs",
+        "description": "Diminishing returns on bonus points from negative traits.",
+        "options": {
+          "1": {
+            "label": "Aucune"
+          },
+          "2": {
+            "label": "1 point de pénalité tous les 3 traits négatifs sélectionnés"
+          },
+          "3": {
+            "label": "1 point de pénalité tous les 2 traits négatifs sélectionnés"
+          },
+          "4": {
+            "label": "1 point de pénalité pour chaque trait négatif sélectionné après le premier"
+          }
+        }
+      },
+      "MinutesPerPage": {
+        "label": "Minutes par page",
+        "description": "In-game minutes to read one page of a skill book."
+      },
+      "LiteratureCooldown": {
+        "label": "Temps avant relecture",
+        "description": "Days before previously read literature can benefit again."
+      },
+      "LevelForMediaXPCutoff": {
+        "label": "Level d'exp max des médias",
+        "description": "Skill level at which TV/VHS/media no longer provides XP."
+      },
+      "LevelForDismantleXPCutoff": {
+        "label": "Level d'exp max de démontage",
+        "description": "Skill level at which scrapping furniture gives no XP."
+      },
+      "BloodSplatLifespanDays": {
+        "label": "Disparition des tâches de sang",
+        "description": "Days before blood splats disappear. 0 = never."
+      },
+      "MetaKnowledge": {
+        "label": "Liste de connaissances (méta-médias)",
+        "description": "How unseen/unread media is displayed.",
+        "options": {
+          "1": {
+            "label": "Afficher en entier"
+          },
+          "2": {
+            "label": "Afficher des ???"
+          },
+          "3": {
+            "label": "Cacher la totalité"
+          }
+        }
+      },
+      "SeeNotLearntRecipe": {
+        "label": "Voir les recettes non apprises",
+        "description": "See station recipes even if not yet learned."
+      },
+      "LightBulbLifespan": {
+        "label": "Durée de vie des ampoules",
+        "description": "Higher = bulbs last longer. 0 = never break."
+      },
+      "MaximumFireFuelHours": {
+        "label": "Heures max de combustible",
+        "description": "Max hours of fuel for campfires, wood stoves, etc."
+      },
+      "Alarm": {
+        "label": "Fréquence des alarmes de maison",
+        "description": "Frequency of residential alarms.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Très rarement"
+          },
+          "3": {
+            "label": "Rarement"
+          },
+          "4": {
+            "label": "Parfois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Très souvent"
+          }
+        }
+      },
+      "LockedHouses": {
+        "label": "Fréquence de verrouillage des maisons",
+        "description": "Frequency of locked houses.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Très rarement"
+          },
+          "3": {
+            "label": "Rarement"
+          },
+          "4": {
+            "label": "Parfois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Très souvent"
+          }
+        }
+      },
+      "Helicopter": {
+        "label": "Hélicoptère",
+        "description": "Helicopter frequency.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Une fois"
+          },
+          "3": {
+            "label": "De temps en temps"
+          },
+          "4": {
+            "label": "Souvent"
+          }
+        }
+      },
+      "MetaEvent": {
+        "label": "Évènements sonores",
+        "description": "Distant gunshots, screams, etc.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "De temps en temps"
+          },
+          "3": {
+            "label": "Souvent"
+          }
+        }
+      },
+      "SleepingEvent": {
+        "label": "Évènements durant le sommeil",
+        "description": "Events that happen while sleeping.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "De temps en temps"
+          },
+          "3": {
+            "label": "Souvent"
+          }
+        }
+      },
+      "NatureAbundance": {
+        "label": "Abondance de la nature",
+        "description": "Governs abundance of wild foods, medicinal plants, etc.",
+        "options": {
+          "1": {
+            "label": "Très pauvre"
+          },
+          "2": {
+            "label": "Pauvre"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Abondante"
+          },
+          "5": {
+            "label": "Très abondante"
+          }
+        }
+      },
+      "FishAbundance": {
+        "label": "Abondance de poissons",
+        "description": "Governs abundance of fish.",
+        "options": {
+          "1": {
+            "label": "Très pauvre"
+          },
+          "2": {
+            "label": "Pauvre"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Abondante"
+          },
+          "5": {
+            "label": "Très abondante"
+          }
+        }
+      },
+      "AnnotatedMapChance": {
+        "label": "Apparition des cartes annotées",
+        "description": "Chance of finding maps annotated with local features.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Très rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Parfois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Très souvent"
+          }
+        }
+      },
+      "ConstructionBonusPoints": {
+        "label": "Durabilité des constructions de joueurs",
+        "description": "Extra points for carpentry/metalworking constructions."
+      },
+      "GeneratorSpawning": {
+        "label": "Groupes électrogènes",
+        "description": "How many generators spawn in the world.",
+        "options": {
+          "1": {
+            "label": "Aucun (non recommandé)"
+          },
+          "2": {
+            "label": "Extrêmement rare"
+          },
+          "3": {
+            "label": "Très rare"
+          },
+          "4": {
+            "label": "Rare"
+          },
+          "5": {
+            "label": "Normal"
+          },
+          "6": {
+            "label": "Commun"
+          },
+          "7": {
+            "label": "Abondant"
+          }
+        }
+      },
+      "GeneratorFuelConsumption": {
+        "label": "Consommation d'essence des groupes électrogènes",
+        "description": "How fast generators consume fuel."
+      },
+      "AllowExteriorGenerator": {
+        "label": "Les groupes électrogènes fonctionnent en extérieur",
+        "description": "Generators can be placed outdoors and inside tents."
+      },
+      "GeneratorTileRange": {
+        "label": "Portée des groupes électrogènes (en tiles)",
+        "description": "Horizontal range of generators in tiles."
+      },
+      "GeneratorVerticalPowerRange": {
+        "label": "Portée verticale des groupes électrogènes",
+        "description": "Vertical range of generators in floors."
+      },
+      "CompostTime": {
+        "label": "Temps de compostage",
+        "description": "How long composting takes.",
+        "options": {
+          "1": {
+            "label": "1 semaine"
+          },
+          "2": {
+            "label": "2 semaines"
+          },
+          "3": {
+            "label": "3 semaines"
+          },
+          "4": {
+            "label": "4 semaines"
+          },
+          "5": {
+            "label": "6 semaines"
+          },
+          "6": {
+            "label": "8 semaines"
+          },
+          "7": {
+            "label": "10 semaines"
+          },
+          "8": {
+            "label": "12 semaines"
+          }
+        }
+      },
+      "AttackBlockMovements": {
+        "label": "Entrave des mouvements de mêlée",
+        "description": "Player can't move while performing melee attacks."
+      },
+      "WorldItemRemovalList": {
+        "label": "Liste des objets au sol à supprimer",
+        "description": "Types of items removed from world (comma separated, e.g. Base.Vest)."
+      },
+      "HoursForWorldItemRemoval": {
+        "label": "Temps avant suppression des objets au sol",
+        "description": "Hours before listed items disappear from world. 0 = disabled."
+      },
+      "ItemRemovalListBlacklistToggle": {
+        "label": "Basculer la liste des objets supprimés en objets conservés",
+        "description": "If true, removal list acts as blacklist (remove everything except listed). Default is whitelist."
+      }
+    },
+    "combat": {
+      "MultiHitZombies": {
+        "label": "Armes multi-coups",
+        "description": "A melee weapon can hit multiple zombies in one swing."
+      },
+      "RearVulnerability": {
+        "label": "Vulnérabilité de dos",
+        "description": "Zombies take more damage when attacked from behind.",
+        "options": {
+          "1": {
+            "label": "Basse"
+          },
+          "2": {
+            "label": "Moyenne"
+          },
+          "3": {
+            "label": "Haute"
+          }
+        }
+      },
+      "FirearmUseDamageChance": {
+        "label": "Chances d'infliger des dégâts",
+        "description": "Chance of weapon condition loss per use. 0 = never."
+      },
+      "FirearmNoiseMultiplier": {
+        "label": "Multiplicateur de bruit des armes à feu",
+        "description": "Multiplier for gun noise attracting zombies."
+      },
+      "FirearmJamMultiplier": {
+        "label": "Multiplicateur d'enrayement",
+        "description": "Multiplier for jamming chance."
+      },
+      "FirearmMoodleMultiplier": {
+        "label": "Multiplicateur de moodle sur les armes à feu",
+        "description": "Multiplier for panic/stress from gun use."
+      },
+      "FirearmWeatherMultiplier": {
+        "label": "Multiplicateur de la météo sur les armes à feu",
+        "description": "Multiplier for rain affecting gun condition."
+      },
+      "FirearmHeadGearEffect": {
+        "label": "Vision affectée par les éléments sur le visage",
+        "description": "How much head-covering gear like helmets affects firearm aim/shoulder."
+      }
+    },
+    "vehicles": {
+      "EnableVehicles": {
+        "label": "Véhicules",
+        "description": "Whether vehicles spawn and can be used."
+      },
+      "CarSpawnRate": {
+        "label": "Taux d'apparition des véhicules",
+        "description": "How many vehicles spawn.",
+        "options": {
+          "1": {
+            "label": "Aucun"
+          },
+          "2": {
+            "label": "Très bas"
+          },
+          "3": {
+            "label": "Bas"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Élevé"
+          }
+        }
+      },
+      "VehicleEasyUse": {
+        "label": "Utilisation simplifiée",
+        "description": "All vehicles are automatic and easy to start."
+      },
+      "InitialGas": {
+        "label": "Carburant de départ",
+        "description": "How full the gas tank of discovered vehicles will be.",
+        "options": {
+          "1": {
+            "label": "Très bas"
+          },
+          "2": {
+            "label": "Bas"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Haut"
+          },
+          "5": {
+            "label": "Très haut"
+          },
+          "6": {
+            "label": "Plein"
+          }
+        }
+      },
+      "FuelStationGasInfinite": {
+        "label": "Pompes à essence illimitées",
+        "description": "If enabled, gas pumps will never run out of fuel."
+      },
+      "FuelStationGasMin": {
+        "label": "Quantité initiale minimum de carburant des pompes",
+        "description": "The minimum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasMax": {
+        "label": "Quantité initiale maximum de carburant des pompes",
+        "description": "The maximum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasEmptyChance": {
+        "label": "Possibilité de pompes à essence vides",
+        "description": "The chance, as a percentage, that individual gas pumps will initially have no fuel."
+      },
+      "LockedCar": {
+        "label": "Fréquence de verrouillage",
+        "description": "Chance of vehicle doors being locked.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Très rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Parfois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Très souvent"
+          }
+        }
+      },
+      "CarGasConsumption": {
+        "label": "Consommation de carburant",
+        "description": "Rate of fuel consumption in vehicles."
+      },
+      "CarGeneralCondition": {
+        "label": "État général",
+        "description": "Initial condition of discovered vehicles.",
+        "options": {
+          "1": {
+            "label": "Très mauvais état"
+          },
+          "2": {
+            "label": "Mauvais état"
+          },
+          "3": {
+            "label": "État correct"
+          },
+          "4": {
+            "label": "Bon état"
+          },
+          "5": {
+            "label": "Très bon état"
+          }
+        }
+      },
+      "CarDamageOnImpact": {
+        "label": "Dégâts au véhicule à l'impact",
+        "description": "Damage vehicles take from collisions.",
+        "options": {
+          "1": {
+            "label": "Très bas"
+          },
+          "2": {
+            "label": "Bas"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Haut"
+          },
+          "5": {
+            "label": "Très haut"
+          }
+        }
+      },
+      "DamageToPlayerFromHitByACar": {
+        "label": "Dégâts de collision entre joueur et véhicule",
+        "description": "How much damage players receive from vehicle impacts.",
+        "options": {
+          "1": {
+            "label": "Aucun"
+          },
+          "2": {
+            "label": "Bas"
+          },
+          "3": {
+            "label": "Normaux"
+          },
+          "4": {
+            "label": "Élevés"
+          },
+          "5": {
+            "label": "Très élevés"
+          }
+        }
+      },
+      "TrafficJam": {
+        "label": "Embouteillages et carambolages",
+        "description": "Whether traffic jams spawn on roads."
+      },
+      "CarAlarm": {
+        "label": "Fréquence des alarmes de véhicules",
+        "description": "Chance of vehicles having active alarms.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Très rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Parfois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Très souvent"
+          }
+        }
+      },
+      "PlayerDamageFromCrash": {
+        "label": "Dégâts au joueur en cas d'accident",
+        "description": "If the player can get injured from being in a car accident."
+      },
+      "SirenShutoffHours": {
+        "label": "Heures avant extinction des alarmes",
+        "description": "Hours before vehicle siren batteries die. 0 = instant."
+      },
+      "ChanceHasGas": {
+        "label": "Véhicules contenant du carburant",
+        "description": "The chance of finding a vehicle with gas in its tank.",
+        "options": {
+          "1": {
+            "label": "Peu"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Beaucoup"
+          }
+        }
+      },
+      "RecentlySurvivorVehicles": {
+        "label": "Véhicules de survivants",
+        "description": "Whether a player can discover a car that has been cared for after the Knox infection struck.",
+        "options": {
+          "1": {
+            "label": "Aucun"
+          },
+          "2": {
+            "label": "Peu"
+          },
+          "3": {
+            "label": "Quelques-uns"
+          },
+          "4": {
+            "label": "Beaucoup"
+          }
+        }
+      },
+      "ZombieAttractionMultiplier": {
+        "label": "Multiplicateur d'attraction des zombies",
+        "description": "Multiplier for vehicle sounds attracting zombies."
+      },
+      "SirenEffectsZombies": {
+        "label": "Les alarmes des véhicules attirent les zombies",
+        "description": "If zombies will head towards the sound of vehicle sirens."
+      }
+    },
+    "animals": {
+      "AnimalStatsModifier": {
+        "label": "Vitesse de diminution des stats",
+        "description": "Speed at which animal stats (hunger, thirst etc.) reduce.",
+        "options": {
+          "1": {
+            "label": "Super rapide"
+          },
+          "2": {
+            "label": "Très rapide"
+          },
+          "3": {
+            "label": "Rapide"
+          },
+          "4": {
+            "label": "Normale"
+          },
+          "5": {
+            "label": "Lente"
+          },
+          "6": {
+            "label": "Très lente"
+          }
+        }
+      },
+      "AnimalMetaStatsModifier": {
+        "label": "Vitesse de diminution des stats dans le monde",
+        "description": "Speed at which animal stats reduce while in meta (overworld).",
+        "options": {
+          "1": {
+            "label": "Super rapide"
+          },
+          "2": {
+            "label": "Très rapide"
+          },
+          "3": {
+            "label": "Rapide"
+          },
+          "4": {
+            "label": "Normale"
+          },
+          "5": {
+            "label": "Lente"
+          },
+          "6": {
+            "label": "Très lente"
+          }
+        }
+      },
+      "AnimalPregnancyTime": {
+        "label": "Durée de la gestation",
+        "description": "How long animals will be pregnant for before giving birth.",
+        "options": {
+          "1": {
+            "label": "Super rapide"
+          },
+          "2": {
+            "label": "Très rapide"
+          },
+          "3": {
+            "label": "Rapide"
+          },
+          "4": {
+            "label": "Normale"
+          },
+          "5": {
+            "label": "Lente"
+          },
+          "6": {
+            "label": "Très lente"
+          }
+        }
+      },
+      "AnimalAgeModifier": {
+        "label": "Vitesse de vieillissement",
+        "description": "Speed at which animals age.",
+        "options": {
+          "1": {
+            "label": "Super rapide"
+          },
+          "2": {
+            "label": "Très rapide"
+          },
+          "3": {
+            "label": "Rapide"
+          },
+          "4": {
+            "label": "Normale"
+          },
+          "5": {
+            "label": "Lente"
+          },
+          "6": {
+            "label": "Très lente"
+          }
+        }
+      },
+      "AnimalMilkIncModifier": {
+        "label": "Vitesse de production du lait",
+        "description": "Speed of milk production.",
+        "options": {
+          "1": {
+            "label": "Super rapide"
+          },
+          "2": {
+            "label": "Très rapide"
+          },
+          "3": {
+            "label": "Rapide"
+          },
+          "4": {
+            "label": "Normale"
+          },
+          "5": {
+            "label": "Lente"
+          },
+          "6": {
+            "label": "Très lente"
+          }
+        }
+      },
+      "AnimalWoolIncModifier": {
+        "label": "Vitesse de production de laine",
+        "description": "Speed of wool production.",
+        "options": {
+          "1": {
+            "label": "Super rapide"
+          },
+          "2": {
+            "label": "Très rapide"
+          },
+          "3": {
+            "label": "Rapide"
+          },
+          "4": {
+            "label": "Normale"
+          },
+          "5": {
+            "label": "Lente"
+          },
+          "6": {
+            "label": "Très lente"
+          }
+        }
+      },
+      "AnimalRanchChance": {
+        "label": "Taux d'apparition des animaux",
+        "description": "The chance of finding animals in farms.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Extrêmement Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Quelque fois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Très souvent"
+          },
+          "7": {
+            "label": "Toujours"
+          }
+        }
+      },
+      "AnimalGrassRegrowTime": {
+        "label": "Temps de repousse de l'herbe",
+        "description": "The number of hours grass will regrow after being eaten by an animal or cut by the player."
+      },
+      "AnimalMetaPredator": {
+        "label": "Prédateurs méta",
+        "description": "If a meta fox may attack your chickens if the hutch door is left open at night."
+      },
+      "AnimalMatingSeason": {
+        "label": "Saison de reproduction",
+        "description": "Restrict mating to spring/early summer or allow year-round."
+      },
+      "AnimalEggHatch": {
+        "label": "Temps avant éclosion",
+        "description": "How long before baby animals will hatch from eggs.",
+        "options": {
+          "1": {
+            "label": "Super rapide"
+          },
+          "2": {
+            "label": "Très rapide"
+          },
+          "3": {
+            "label": "Rapide"
+          },
+          "4": {
+            "label": "Normale"
+          },
+          "5": {
+            "label": "Lente"
+          },
+          "6": {
+            "label": "Très lente"
+          }
+        }
+      },
+      "AnimalSoundAttractZombies": {
+        "label": "Zombies attirés par les animaux",
+        "description": "If true, animal calls will attract nearby zombies."
+      },
+      "AnimalTrackChance": {
+        "label": "Chance de traces d'animaux",
+        "description": "The chance of animals leaving tracks.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Très rarement"
+          },
+          "3": {
+            "label": "Rarement"
+          },
+          "4": {
+            "label": "Parfois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Très souvent"
+          }
+        }
+      },
+      "AnimalPathChance": {
+        "label": "Chance de passages d'animaux",
+        "description": "The chance of creating a path for animals to be hunted.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Très rarement"
+          },
+          "3": {
+            "label": "Rarement"
+          },
+          "4": {
+            "label": "Parfois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Très souvent"
+          }
+        }
+      },
+      "MaximumRatIndex": {
+        "label": "Indice maximale de vermine",
+        "description": "Maximum rat infestation level. 0 = no rats."
+      },
+      "DaysUntilMaximumRatIndex": {
+        "label": "Jours de l'indice maximale de vermine",
+        "description": "How many days until rat population peaks."
+      },
+      "Farming": {
+        "label": "Multiplicateur d'agriculture",
+        "description": "Rate at which Agriculture skill levels up.",
+        "options": {
+          "1": {
+            "label": "Très basse"
+          },
+          "2": {
+            "label": "Basse"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Haute"
+          },
+          "5": {
+            "label": "Très haute"
+          }
+        }
+      },
+      "PlantResilience": {
+        "label": "Ténacité des plantations",
+        "description": "How tough crops are.",
+        "options": {
+          "1": {
+            "label": "Très forte"
+          },
+          "2": {
+            "label": "Forte"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Basse"
+          },
+          "5": {
+            "label": "Très basse"
+          }
+        }
+      },
+      "PlantAbundance": {
+        "label": "Abondance des récoltes",
+        "description": "How much food crops produce.",
+        "options": {
+          "1": {
+            "label": "Très pauvre"
+          },
+          "2": {
+            "label": "Pauvre"
+          },
+          "3": {
+            "label": "Normale"
+          },
+          "4": {
+            "label": "Abondante"
+          },
+          "5": {
+            "label": "Très abondante"
+          }
+        }
+      },
+      "KillInsideCrops": {
+        "label": "Culture en intérieur impossible",
+        "description": "Whether stepping on indoor crops destroys them."
+      },
+      "PlantGrowingSeasons": {
+        "label": "Plantation selon la saison",
+        "description": "Restrict crop growth to appropriate seasons."
+      },
+      "PlaceDirtAboveground": {
+        "label": "Agriculture hors niveau du sol [!]",
+        "description": "Allow placing dirt on built floors above ground."
+      },
+      "FarmingSpeedNew": {
+        "label": "Vitesse d'agriculture",
+        "description": "Growth speed multiplier. Lower = faster."
+      },
+      "FarmingAmountNew": {
+        "label": "Abondance de l'agriculture",
+        "description": "Multiplier for number of crops harvested."
+      },
+      "ClayLakeChance": {
+        "label": "Sol argileux - Lac",
+        "description": "Chance of finding clay when digging near lakes."
+      },
+      "ClayRiverChance": {
+        "label": "Sol argileux - Rivière",
+        "description": "Chance of finding clay when digging near rivers."
+      }
+    },
+    "world": {
+      "SurvivorHouseChance": {
+        "label": "Chance de tomber sur des bâtiments d'histoire aléatoires",
+        "description": "Chance of finding survivor-modified houses.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Très rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Parfois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Très souvent"
+          },
+          "7": {
+            "label": "Le plus possible"
+          }
+        }
+      },
+      "VehicleStoryChance": {
+        "label": "Chance de tomber sur des histoires aléatoires sur la route",
+        "description": "Chance of finding story-decorated vehicles.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Très rarement"
+          },
+          "3": {
+            "label": "Rarement"
+          },
+          "4": {
+            "label": "Parfois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Très souvent"
+          }
+        }
+      },
+      "ZoneStoryChance": {
+        "label": "Chance de tomber sur une zone d'histoire aléatoire",
+        "description": "Chance of encountering zone-based story setups.",
+        "options": {
+          "1": {
+            "label": "Jamais"
+          },
+          "2": {
+            "label": "Très rarement"
+          },
+          "3": {
+            "label": "Rarement"
+          },
+          "4": {
+            "label": "Parfois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Très souvent"
+          }
+        }
+      }
+    },
+    "zombieLore": {
+      "Speed": {
+        "label": "Vitesse",
+        "description": "How fast zombies move.",
+        "options": {
+          "1": {
+            "label": "Sprinteur"
+          },
+          "2": {
+            "label": "Traîneur rapide"
+          },
+          "3": {
+            "label": "Traîneur"
+          },
+          "4": {
+            "label": "Aléatoire"
+          }
+        }
+      },
+      "Strength": {
+        "label": "Force",
+        "description": "How strong zombies are.",
+        "options": {
+          "1": {
+            "label": "Hors norme"
+          },
+          "2": {
+            "label": "Normale"
+          },
+          "3": {
+            "label": "Faibles"
+          },
+          "4": {
+            "label": "Aléatoire"
+          }
+        }
+      },
+      "Toughness": {
+        "label": "Résistance",
+        "description": "How tough zombies are to kill.",
+        "options": {
+          "1": {
+            "label": "Résistants"
+          },
+          "2": {
+            "label": "Normaux"
+          },
+          "3": {
+            "label": "Fragiles"
+          },
+          "4": {
+            "label": "Aléatoire"
+          }
+        }
+      },
+      "Transmission": {
+        "label": "Transmission",
+        "description": "How the zombie infection spreads.",
+        "options": {
+          "1": {
+            "label": "Sang et salive"
+          },
+          "2": {
+            "label": "Salive uniquement"
+          },
+          "3": {
+            "label": "Tout le monde est infecté"
+          },
+          "4": {
+            "label": "Aucune"
+          }
+        }
+      },
+      "Mortality": {
+        "label": "Mortalité de l'infection",
+        "description": "How deadly the infection is.",
+        "options": {
+          "1": {
+            "label": "Instantanée"
+          },
+          "2": {
+            "label": "0-30 secondes"
+          },
+          "3": {
+            "label": "0-1 minutes"
+          },
+          "4": {
+            "label": "0-12 heures"
+          },
+          "5": {
+            "label": "2-3 jours"
+          },
+          "6": {
+            "label": "1-2 semaines"
+          },
+          "7": {
+            "label": "Jamais"
+          }
+        }
+      },
+      "Cognition": {
+        "label": "Capacités cognitives",
+        "description": "What zombies can interact with.",
+        "options": {
+          "1": {
+            "label": "Se déplacer + ouvrir les portes"
+          },
+          "2": {
+            "label": "Se déplacer"
+          },
+          "3": {
+            "label": "Déplacements basiques"
+          },
+          "4": {
+            "label": "Aléatoire"
+          }
+        }
+      },
+      "Memory": {
+        "label": "Mémoire",
+        "description": "How long zombies remember where they last saw a target.",
+        "options": {
+          "1": {
+            "label": "Longue"
+          },
+          "2": {
+            "label": "Normale"
+          },
+          "3": {
+            "label": "Courte"
+          },
+          "4": {
+            "label": "Aucune"
+          },
+          "5": {
+            "label": "Aléatoire"
+          },
+          "6": {
+            "label": "Aléatoire entre Normale et Aucune"
+          }
+        }
+      },
+      "Sight": {
+        "label": "Vue",
+        "description": "How far zombies can see targets.",
+        "options": {
+          "1": {
+            "label": "Vue aiguisée"
+          },
+          "2": {
+            "label": "Normale"
+          },
+          "3": {
+            "label": "Pauvre"
+          },
+          "4": {
+            "label": "Aléatoire"
+          },
+          "5": {
+            "label": "Aléatoire entre Normale et Pauvre"
+          }
+        }
+      },
+      "Hearing": {
+        "label": "Ouïe",
+        "description": "How well zombies can hear sounds.",
+        "options": {
+          "1": {
+            "label": "Précise"
+          },
+          "2": {
+            "label": "Normale"
+          },
+          "3": {
+            "label": "Pauvre"
+          },
+          "4": {
+            "label": "Aléatoire"
+          },
+          "5": {
+            "label": "Aléatoire entre Normale et Pauvre"
+          }
+        }
+      },
+      "SpottedLogic": {
+        "label": "Nouveau système de furtivité",
+        "description": "How zombies decide to chase their targets."
+      },
+      "ThumpNoChasing": {
+        "label": "Attaques environnementales",
+        "description": "Zombies that weren't chasing a player will not thump constructions."
+      },
+      "ThumpOnConstruction": {
+        "label": "Dégâts des Z aux constructions",
+        "description": "Zombies thump player-built structures."
+      },
+      "ActiveOnly": {
+        "label": "Activité diurne/nocturne des zombies",
+        "description": "Zombies active during specific times.",
+        "options": {
+          "1": {
+            "label": "Les deux"
+          },
+          "2": {
+            "label": "Nocturne"
+          },
+          "3": {
+            "label": "Diurne"
+          }
+        }
+      },
+      "TriggerHouseAlarm": {
+        "label": "Activation des alarmes de maison par les Z",
+        "description": "Whether zombies can randomly trigger house alarms."
+      },
+      "ZombiesDragDown": {
+        "label": "Mise à terre",
+        "description": "Multiple zombies can pull player to ground."
+      },
+      "ZombiesCrawlersDragDown": {
+        "label": "Mise à terre par les rampants",
+        "description": "Crawlers can drag players down."
+      },
+      "ZombiesFenceLunge": {
+        "label": "Précipitation des zombies",
+        "description": "Zombies can lunge at you over fences."
+      },
+      "ZombiesArmorFactor": {
+        "label": "Facteur d'armure des zombies",
+        "description": "Multiplier for zombie armor from clothing. Higher = harder to kill."
+      },
+      "ZombiesMaxDefense": {
+        "label": "Défense maximum des armures de zombies",
+        "description": "Maximum defense value zombies can have."
+      },
+      "ChanceOfAttachedWeapon": {
+        "label": "Armes attachées aux zombies",
+        "description": "Chance a zombie has a weapon stuck in them."
+      },
+      "ZombiesFallDamage": {
+        "label": "Multiplicateur de dégâts de chute des Z",
+        "description": "Whether zombies can die from falling."
+      },
+      "DisableFakeDead": {
+        "label": "Zombies qui se réaniment",
+        "description": "No zombies will pretend to be dead.",
+        "options": {
+          "1": {
+            "label": "Zombies dans le monde"
+          },
+          "2": {
+            "label": "Zombie dans le monde et ceux tués"
+          },
+          "3": {
+            "label": "Jamais"
+          }
+        }
+      },
+      "PlayerSpawnZombieRemoval": {
+        "label": "Spawn Zone Clear",
+        "description": "Distance around spawn points cleared of zombies.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Small"
+          },
+          "3": {
+            "label": "Medium"
+          },
+          "4": {
+            "label": "Large"
+          },
+          "5": {
+            "label": "Very Large"
+          }
+        }
+      },
+      "FenceThumpersRequired": {
+        "label": "Nombre de Z pour endommager les clôtures",
+        "description": "Minimum zombies needed to damage a fence."
+      },
+      "FenceDamageMultiplier": {
+        "label": "Multiplicateur de dégâts aux clôtures",
+        "description": "Multiplier for damage zombies do to fences."
+      },
+      "DoorOpeningPercentage": {
+        "label": "Random Door Opening Amount",
+        "description": "Percentage of zombies that can open doors when cognition allows it."
+      },
+      "CrawlUnderVehicle": {
+        "label": "Zombies pouvant ramper sous les véhicules",
+        "description": "Crawler zombies can crawl under vehicles.",
+        "options": {
+          "1": {
+            "label": "Rampants uniquement"
+          },
+          "2": {
+            "label": "Quasiment aucun"
+          },
+          "3": {
+            "label": "Quelques rares"
+          },
+          "4": {
+            "label": "Parfois"
+          },
+          "5": {
+            "label": "Souvent"
+          },
+          "6": {
+            "label": "Énormément"
+          },
+          "7": {
+            "label": "Tous"
+          }
+        }
+      },
+      "SprinterPercentage": {
+        "label": "Random Sprinter Amount",
+        "description": "Percentage of sprinter zombies when Speed is set to Random."
+      },
+      "Reanimate": {
+        "label": "Temps de réanimation",
+        "description": "Dead zombies can get back up after being killed.",
+        "options": {
+          "1": {
+            "label": "Instantané"
+          },
+          "2": {
+            "label": "0-30 secondes"
+          },
+          "3": {
+            "label": "0-1 minutes"
+          },
+          "4": {
+            "label": "0-12 heures"
+          },
+          "5": {
+            "label": "2-3 jours"
+          },
+          "6": {
+            "label": "1-2 semaines"
+          }
+        }
+      }
+    },
+    "zombiePopulation": {
+      "PopulationMultiplier": {
+        "label": "Multiplicateur de population",
+        "description": "Overall zombie population multiplier."
+      },
+      "PopulationStartMultiplier": {
+        "label": "Multiplicateur de départ de la population",
+        "description": "Zombie population at game start."
+      },
+      "PopulationPeakMultiplier": {
+        "label": "Multiplicateur de pic de population",
+        "description": "Zombie population at peak day."
+      },
+      "PopulationPeakDay": {
+        "label": "Jour de pic de population",
+        "description": "Day when zombie population peaks."
+      },
+      "RespawnHours": {
+        "label": "Heures avant réapparition",
+        "description": "Hours before zombies respawn. 0 = disabled."
+      },
+      "RespawnUnseenHours": {
+        "label": "Heures de réapparition sans visite",
+        "description": "Hours a chunk must be unseen before respawn."
+      },
+      "RespawnMultiplier": {
+        "label": "Multiplicateur de réapparition",
+        "description": "Fraction of population that respawns."
+      },
+      "RedistributeHours": {
+        "label": "Heures avant migration",
+        "description": "Hours between zombie redistribution across the map."
+      },
+      "FollowSoundDistance": {
+        "label": "Distance de suivi du son",
+        "description": "How far zombies will follow sounds in cells."
+      },
+      "RallyGroupSize": {
+        "label": "Taille des groupes",
+        "description": "Base number of zombies in rally groups."
+      },
+      "RallyGroupSizeVariance": {
+        "label": "Variation de la taille des groupes",
+        "description": "The amount, as a percentage, that zombie groups can vary in size from the default (both larger and smaller)."
+      },
+      "RallyTravelDistance": {
+        "label": "Distance pour les rassemblements",
+        "description": "How far rally groups travel in cells."
+      },
+      "RallyGroupSeparation": {
+        "label": "Distance entre les groupes",
+        "description": "Minimum distance between rally groups."
+      },
+      "RallyGroupRadius": {
+        "label": "Rayon de rassemblement du groupe",
+        "description": "Radius of area a rally group spreads across."
+      },
+      "ZombiesCountBeforeDelete": {
+        "label": "Nombre de zombies avant suppression",
+        "description": "Minimum zombie count in a cell before deletion can occur."
+      }
+    },
+    "xpMultipliers": {
+      "Global": {
+        "label": "Multiplicateur global",
+        "description": "The rate at which all skills level up."
+      },
+      "GlobalToggle": {
+        "label": "Utiliser le multiplicateur global",
+        "description": "When enabled, all skills will use the Global Multiplier instead of individual values."
+      },
+      "Sprinting": {
+        "label": "Multiplicateur de course",
+        "description": "XP multiplier for Sprinting skill."
+      },
+      "Lightfoot": {
+        "label": "Multiplicateur de discrétion",
+        "description": "XP multiplier for Lightfoot skill."
+      },
+      "Nimble": {
+        "label": "Multiplicateur de vivacité",
+        "description": "XP multiplier for Nimble skill."
+      },
+      "Sneak": {
+        "label": "Multiplicateur de furtivité",
+        "description": "XP multiplier for Sneaking skill."
+      },
+      "Axe": {
+        "label": "Multiplicateur de hache",
+        "description": "XP multiplier for Axe skill."
+      },
+      "Blunt": {
+        "label": "Multiplicateur de contondant long",
+        "description": "XP multiplier for Blunt skill."
+      },
+      "SmallBlade": {
+        "label": "Multiplicateur de tranchant court",
+        "description": "XP multiplier for Small Blade skill."
+      },
+      "LongBlade": {
+        "label": "Multiplicateur de tranchant long",
+        "description": "XP multiplier for Long Blade skill."
+      },
+      "SmallBlunt": {
+        "label": "Multiplicateur de contondant court",
+        "description": "XP multiplier for Small Blunt skill."
+      },
+      "Aiming": {
+        "label": "Multiplicateur de visée",
+        "description": "XP multiplier for Aiming skill."
+      },
+      "Reloading": {
+        "label": "Multiplicateur de rechargement",
+        "description": "XP multiplier for Reloading skill."
+      },
+      "Fishing": {
+        "label": "Multiplicateur de pêche",
+        "description": "XP multiplier for Fishing skill."
+      },
+      "Trapping": {
+        "label": "Multiplicateur de piégeage",
+        "description": "XP multiplier for Trapping skill."
+      },
+      "Woodwork": {
+        "label": "Multiplicateur de menuiserie",
+        "description": "XP multiplier for Carpentry skill."
+      },
+      "Cooking": {
+        "label": "Multiplicateur de cuisine",
+        "description": "XP multiplier for Cooking skill."
+      },
+      "Farming": {
+        "label": "Multiplicateur d'XP d'agriculture",
+        "description": "XP multiplier for Farming skill."
+      },
+      "Doctor": {
+        "label": "Multiplicateur de premiers secours",
+        "description": "XP multiplier for First Aid skill."
+      },
+      "Electricity": {
+        "label": "Multiplicateur d'électricité",
+        "description": "XP multiplier for Electricity skill."
+      },
+      "MetalWelding": {
+        "label": "Multiplicateur de travail des métaux",
+        "description": "XP multiplier for Metalworking skill."
+      },
+      "Mechanics": {
+        "label": "Multiplicateur de mécanique",
+        "description": "XP multiplier for Mechanics skill."
+      },
+      "Tailoring": {
+        "label": "Multiplicateur de couture",
+        "description": "XP multiplier for Tailoring skill."
+      },
+      "Maintenance": {
+        "label": "Multiplicateur d'entretien",
+        "description": "XP multiplier for Maintenance skill."
+      },
+      "PlantScavenging": {
+        "label": "Multiplicateur de recherche",
+        "description": "XP multiplier for Foraging skill."
+      },
+      "Fitness": {
+        "label": "Multiplicateur de fitness",
+        "description": "XP multiplier for Fitness skill."
+      },
+      "Strength": {
+        "label": "Multiplicateur de force",
+        "description": "XP multiplier for Strength skill."
+      },
+      "FlintKnapping": {
+        "label": "Multiplicateur de taillage de pierre",
+        "description": "XP multiplier for Knapping skill."
+      },
+      "Carving": {
+        "label": "Multiplicateur de taillage",
+        "description": "XP multiplier for Carving skill."
+      },
+      "Tracking": {
+        "label": "Multiplicateur de pistage",
+        "description": "XP multiplier for Tracking skill."
+      },
+      "Butchering": {
+        "label": "Multiplicateur de dépeçage",
+        "description": "XP multiplier for Butchering skill."
+      },
+      "Glassmaking": {
+        "label": "Multiplicateur de verrerie",
+        "description": "XP multiplier for Glassmaking skill."
+      },
+      "Husbandry": {
+        "label": "Multiplicateur d'élevage",
+        "description": "XP multiplier for Animal Husbandry skill."
+      },
+      "Spear": {
+        "label": "Multiplicateur de lance",
+        "description": "XP multiplier for Spear skill."
+      },
+      "Masonry": {
+        "label": "Multiplicateur de maçonnerie",
+        "description": "XP multiplier for Masonry skill."
+      },
+      "Pottery": {
+        "label": "Multiplicateur de poterie",
+        "description": "XP multiplier for Pottery skill."
+      },
+      "Blacksmith": {
+        "label": "Multiplicateur de forge",
+        "description": "XP multiplier for Blacksmith skill."
+      }
+    },
+    "map": {
+      "AllowMiniMap": {
+        "label": "Autoriser la mini-carte",
+        "description": "Whether the in-game mini map is available."
+      },
+      "AllowWorldMap": {
+        "label": "Autoriser l'accès à la carte du monde",
+        "description": "Whether the in-game world map is available."
+      },
+      "MapAllKnown": {
+        "label": "Carte découverte dès le départ",
+        "description": "The entire map is revealed from the start."
+      },
+      "MapNeedsLight": {
+        "label": "Éclairage obligatoire pour regarder la carte",
+        "description": "Map can only be used when there is enough light."
+      }
+    },
+    "basement": {
+      "SpawnFrequency": {
+        "label": "Basement Spawn Frequency",
+        "description": "How often basements appear in buildings.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Very Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      }
+    }
+  },
+  "iniCategories": {
+    "general": {
+      "label": "General"
+    },
+    "network": {
+      "label": "Network & Ports"
+    },
+    "steam": {
+      "label": "Steam Integration"
+    },
+    "discord": {
+      "label": "Discord"
+    },
+    "rcon": {
+      "label": "RCON"
+    },
+    "voice": {
+      "label": "Voice Chat"
+    },
+    "players": {
+      "label": "Players & Accounts"
+    },
+    "safehouse": {
+      "label": "Safehouses"
+    },
+    "chat": {
+      "label": "Chat & Communication"
+    },
+    "pvp": {
+      "label": "PvP & Safety"
+    },
+    "moderation": {
+      "label": "Moderation"
+    },
+    "anticheat": {
+      "label": "Anti-Cheat"
+    },
+    "loot": {
+      "label": "Loot & Items"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "mods": {
+      "label": "Mods & Workshop"
+    },
+    "radio": {
+      "label": "Radio"
+    },
+    "war": {
+      "label": "Faction War"
+    },
+    "backups": {
+      "label": "Backups"
+    },
+    "logging": {
+      "label": "Logging"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
+  },
+  "iniCategoryGroups": {
+    "identity": {
+      "label": "Identity"
+    },
+    "connectivity": {
+      "label": "Connectivity"
+    },
+    "players": {
+      "label": "Players"
+    },
+    "gameplay": {
+      "label": "Gameplay"
+    },
+    "ops": {
+      "label": "Ops"
+    }
+  },
+  "sandboxCategories": {
+    "time": {
+      "label": "Time & Season"
+    },
+    "environment": {
+      "label": "Environment & Weather"
+    },
+    "world": {
+      "label": "World & Stories"
+    },
+    "map": {
+      "label": "Map & Navigation"
+    },
+    "zombieLore": {
+      "label": "Zombie Behavior"
+    },
+    "zombiePopulation": {
+      "label": "Zombie Population"
+    },
+    "population": {
+      "label": "Population & Distribution"
+    },
+    "survival": {
+      "label": "Survival & Health"
+    },
+    "combat": {
+      "label": "Combat & Firearms"
+    },
+    "loot": {
+      "label": "Loot & Resources"
+    },
+    "lootRarity": {
+      "label": "Loot Rarity"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "animals": {
+      "label": "Animals & Farming"
+    },
+    "xpMultipliers": {
+      "label": "XP Multipliers"
+    },
+    "basement": {
+      "label": "Basements"
+    }
+  },
+  "sandboxCategoryGroups": {
+    "world": {
+      "label": "World"
+    },
+    "zombies": {
+      "label": "Zombies"
+    },
+    "survival": {
+      "label": "Survival"
+    },
+    "resources": {
+      "label": "Resources"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
   }
 }

--- a/client/src/locales/ht/serverconfig.json
+++ b/client/src/locales/ht/serverconfig.json
@@ -386,5 +386,3651 @@
     "deletedTitle": "Efase",
     "templateDeletedDesc": "Konfigirasyon sove \"{{name}}\" efase",
     "deleteTemplateFailed": "Pa t kapab efase konfigirasyon sove a."
+  },
+  "iniSettings": {
+    "general": {
+      "PublicName": {
+        "label": "Server Name",
+        "description": "Your server name as shown to the public."
+      },
+      "PublicDescription": {
+        "label": "Server Description",
+        "description": "The description that people can see while browsing your server."
+      },
+      "Public": {
+        "label": "Public Server",
+        "description": "Can your server be seen on Steam server browser."
+      },
+      "Open": {
+        "label": "Open (No Whitelist)",
+        "description": "Open to all players without requiring whitelist."
+      },
+      "Password": {
+        "label": "Server Password",
+        "description": "Password required to join the server. Leave empty for no password."
+      },
+      "MaxPlayers": {
+        "label": "Max Players",
+        "description": "Maximum allowed number of players."
+      },
+      "PauseEmpty": {
+        "label": "Pause When Empty",
+        "description": "The server will pause when no players are logged in."
+      },
+      "ServerWelcomeMessage": {
+        "label": "Welcome Message",
+        "description": "The welcome message displayed to players after connecting. Use <LINE> for new lines."
+      },
+      "Map": {
+        "label": "Map",
+        "description": "The map you're playing on. Default is Muldraugh, KY."
+      },
+      "SaveWorldEveryMinutes": {
+        "label": "Auto-Save Interval",
+        "description": "Auto-save world every X minutes. 0 = never."
+      },
+      "AnnounceDeath": {
+        "label": "Announce Deaths",
+        "description": "Server-wide announcement when a character dies."
+      },
+      "AnnounceAnimalDeath": {
+        "label": "Announce Animal Deaths",
+        "description": "Display a global chat message when an animal dies."
+      },
+      "Seed": {
+        "label": "World Seed",
+        "description": "The worldgen seed used to generate the world. Changing this requires deleting map_worldgen.bin."
+      }
+    },
+    "network": {
+      "DefaultPort": {
+        "label": "Game Port",
+        "description": "The port players will use to connect to your server. Must be open on your router."
+      },
+      "UPnP": {
+        "label": "Enable UPnP",
+        "description": "Enable UPnP for automatic port forwarding."
+      },
+      "PingFrequency": {
+        "label": "Ping Frequency",
+        "description": "How often the server checks connection to players (seconds)."
+      },
+      "PingLimit": {
+        "label": "Ping Limit",
+        "description": "Ping limit before being kicked (milliseconds). 100 to disable."
+      },
+      "DenyLoginOnOverloadedServer": {
+        "label": "Deny Login When Overloaded",
+        "description": "Prevent new connections when server is overloaded."
+      },
+      "SpeedLimit": {
+        "label": "Speed Limit",
+        "description": "Maximum movement speed allowed."
+      },
+      "UseTCPForMapDownloads": {
+        "label": "Use TCP for Map Downloads",
+        "description": "Use TCP instead of UDP for map downloads."
+      },
+      "MaxPacketsPerSecond": {
+        "label": "Max Packets Per Second",
+        "description": "Cap on packets per second sent to a connected client. Higher values increase bandwidth use; lower values may cause stutter under load."
+      },
+      "UDPPort": {
+        "label": "UDP Port",
+        "description": "Second port used for UDP connections."
+      },
+      "LoginQueueEnabled": {
+        "label": "Login Queue",
+        "description": "Enable a login queue when the server is full."
+      },
+      "LoginQueueConnectTimeout": {
+        "label": "Login Queue Timeout",
+        "description": "Seconds before a queued connection times out."
+      },
+      "server_browser_announced_ip": {
+        "label": "Announced IP",
+        "description": "IP address broadcast to the server browser. For multi-IP setups like server farms."
+      },
+      "MultiplayerStatisticsPeriod": {
+        "label": "Statistics Period",
+        "description": "Multiplayer statistics update period in seconds. 0 = disabled."
+      }
+    },
+    "pvp": {
+      "PVP": {
+        "label": "Enable PvP",
+        "description": "Allow player vs player combat (each player can still toggle their own PvP)."
+      },
+      "SafetySystem": {
+        "label": "Safety System",
+        "description": "If PvP is enabled, allows players to toggle their own PvP on/off."
+      },
+      "ShowSafety": {
+        "label": "Show Safety Status",
+        "description": "Show skull icon for players with safety off."
+      },
+      "SafetyToggleTimer": {
+        "label": "Safety Toggle Timer",
+        "description": "Time in seconds to switch between PvP on and off."
+      },
+      "SafetyCooldownTimer": {
+        "label": "Safety Cooldown Timer",
+        "description": "Time in seconds before you can toggle safety again."
+      },
+      "PVPMeleeWhileHitReaction": {
+        "label": "Melee While Hit Reaction",
+        "description": "Allow melee attacks during hit reaction in PvP."
+      },
+      "PVPMeleeDamageModifier": {
+        "label": "PvP Melee Damage %",
+        "description": "Melee damage modifier for PvP (percentage)."
+      },
+      "PVPFirearmDamageModifier": {
+        "label": "PvP Firearm Damage %",
+        "description": "Firearm damage modifier for PvP (percentage)."
+      },
+      "PlayerBumpPlayer": {
+        "label": "Player Collision",
+        "description": "Players can bump into each other."
+      },
+      "PVPLogToolChat": {
+        "label": "Log PvP to Chat",
+        "description": "PvP events are logged to admin chat."
+      },
+      "PVPLogToolFile": {
+        "label": "Log PvP to File",
+        "description": "PvP events are logged to a file."
+      },
+      "SafetyDisconnectDelay": {
+        "label": "Safety Disconnect Delay",
+        "description": "Seconds before PvP safety mode resets on disconnect."
+      }
+    },
+    "chat": {
+      "GlobalChat": {
+        "label": "Enable Global Chat",
+        "description": "Enable /all command for server-wide chat."
+      },
+      "ChatStreams": {
+        "label": "Chat Streams",
+        "description": "Enabled chat streams: s=say, r=radio, a=admin, w=whisper, y=yell, sh=safehouse, f=faction, all=global."
+      },
+      "DisplayUserName": {
+        "label": "Display Usernames",
+        "description": "Show player usernames above their heads and in chat."
+      },
+      "ShowFirstAndLastName": {
+        "label": "Show Character Names",
+        "description": "Display character first and last name instead of username."
+      },
+      "MouseOverToSeeDisplayName": {
+        "label": "Mouse Over for Name",
+        "description": "Require mouse hover to see player names."
+      },
+      "HidePlayersBehindYou": {
+        "label": "Hide Players Behind You",
+        "description": "Hide player names for players behind your character."
+      },
+      "AllowNonAsciiUsername": {
+        "label": "Allow Non-ASCII Usernames",
+        "description": "Allow usernames with non-ASCII characters."
+      },
+      "BanKickGlobalSound": {
+        "label": "Ban/Kick Sound",
+        "description": "Play global sound when a player is banned or kicked."
+      },
+      "UsernameDisguises": {
+        "label": "Username Disguises",
+        "description": "Allow players to disguise their username."
+      },
+      "HideDisguisedUserName": {
+        "label": "Hide Disguised Names",
+        "description": "Hide the real username of disguised players."
+      },
+      "ChatMessageCharacterLimit": {
+        "label": "Chat Character Limit",
+        "description": "Maximum characters per chat message."
+      },
+      "ChatMessageSlowModeTime": {
+        "label": "Chat Slow Mode",
+        "description": "Seconds between allowed chat messages per player."
+      }
+    },
+    "players": {
+      "MaxAccountsPerUser": {
+        "label": "Max Accounts Per User",
+        "description": "Limit accounts per Steam user. 0 = unlimited."
+      },
+      "DropOffWhiteListAfterDeath": {
+        "label": "Remove From Whitelist On Death",
+        "description": "Remove player from whitelist if their character dies."
+      },
+      "KickFastPlayers": {
+        "label": "Kick Speed Hackers",
+        "description": "Kick players moving faster than possible. May be buggy."
+      },
+      "SpawnPoint": {
+        "label": "Spawn Point",
+        "description": "Custom spawn point coordinates (X,Y,Z). 0,0,0 for default."
+      },
+      "SpawnItems": {
+        "label": "Spawn Items",
+        "description": "Items new characters spawn with (comma-separated, e.g., Base.BaseballBat,Base.WaterBottleFull)."
+      },
+      "SleepAllowed": {
+        "label": "Allow Sleep",
+        "description": "Whether sleeping is allowed."
+      },
+      "SleepNeeded": {
+        "label": "Sleep Required",
+        "description": "Whether players need to sleep when exhausted."
+      },
+      "PlayerRespawnWithSelf": {
+        "label": "Respawn at Death Location",
+        "description": "Allow respawning at death location."
+      },
+      "PlayerRespawnWithOther": {
+        "label": "Respawn with Partner",
+        "description": "Enable spawning at splitscreen partner location."
+      },
+      "PlayerSaveOnDamage": {
+        "label": "Save on Damage",
+        "description": "Save player state when they take damage."
+      },
+      "Faction": {
+        "label": "Enable Factions",
+        "description": "Allow creation and use of factions."
+      },
+      "FactionDaySurvivedToCreate": {
+        "label": "Days to Create Faction",
+        "description": "Days a player must survive to create a faction."
+      },
+      "FactionPlayersRequiredForTag": {
+        "label": "Players for Faction Tag",
+        "description": "Players required in faction to show tag."
+      },
+      "AllowTradeUI": {
+        "label": "Allow Trading",
+        "description": "Allow players to directly trade with one another."
+      },
+      "AllowCoop": {
+        "label": "Allow Co-op",
+        "description": "Allow co-op/splitscreen players to join."
+      },
+      "KnockedDownAllowed": {
+        "label": "Knocked Down",
+        "description": "Allow players to be knocked down. WIP: may cause visual desync."
+      },
+      "SneakModeHideFromOtherPlayers": {
+        "label": "Sneak Hides From Players",
+        "description": "Players in sneak mode are hidden from other players."
+      },
+      "MapRemotePlayerVisibility": {
+        "label": "Map Player Visibility",
+        "description": "Who can see other players on the in-game map.",
+        "options": {
+          "1": {
+            "label": "Hidden"
+          },
+          "2": {
+            "label": "Friends Only"
+          },
+          "3": {
+            "label": "Friends and Nearby Players"
+          },
+          "4": {
+            "label": "Everyone"
+          }
+        }
+      },
+      "DisableScoreboard": {
+        "label": "Disable Scoreboard",
+        "description": "Disable the in-game scoreboard."
+      },
+      "HideAdminsInPlayerList": {
+        "label": "Hide Admins in Player List",
+        "description": "Hide admin accounts from the player list."
+      }
+    },
+    "safehouse": {
+      "PlayerSafehouse": {
+        "label": "Enable Safehouses",
+        "description": "Allow players to claim safehouses."
+      },
+      "AdminSafehouse": {
+        "label": "Admin Safehouses",
+        "description": "Allow admins to have safehouses."
+      },
+      "SafehouseAllowTrepass": {
+        "label": "Allow Trespass",
+        "description": "Allow non-members to enter safehouses without invite."
+      },
+      "SafehouseAllowFire": {
+        "label": "Allow Fire Damage",
+        "description": "Allow fire to damage safehouses."
+      },
+      "SafehouseAllowLoot": {
+        "label": "Allow Looting",
+        "description": "Allow non-members to take items from safehouses."
+      },
+      "SafehouseAllowRespawn": {
+        "label": "Allow Safehouse Respawn",
+        "description": "Players can respawn in their safehouse."
+      },
+      "SafehouseDaySurvivedToClaim": {
+        "label": "Days to Claim Safehouse",
+        "description": "Days a player must survive before claiming a safehouse."
+      },
+      "SafeHouseRemovalTime": {
+        "label": "Safehouse Removal Time",
+        "description": "Real-time hours of inactivity before removal from safehouse."
+      },
+      "DisableSafehouseWhenOwnerConnected": {
+        "label": "Disable When Owner Online",
+        "description": "Disable safehouse protection when the owner is connected. (Renamed from DisableSafehouseWhenPlayerConnected in the Dec 2025 MP patch.)"
+      },
+      "SafehouseAllowNonResidential": {
+        "label": "Allow Non-Residential",
+        "description": "Allow players to claim non-residential buildings as safehouses."
+      },
+      "SafehouseDisableDisguises": {
+        "label": "Disable Disguises in Safehouse",
+        "description": "Disable username disguises inside safehouses."
+      },
+      "MaxSafezoneSize": {
+        "label": "Max Safezone Size",
+        "description": "Maximum tile size for safezones."
+      }
+    },
+    "loot": {
+      "ItemNumbersLimitPerContainer": {
+        "label": "Container Item Limit",
+        "description": "Max items per container. 0 = unlimited."
+      },
+      "TrashDeleteAll": {
+        "label": "Delete All Trash",
+        "description": "Delete all items when placed in trash."
+      },
+      "RemovePlayerCorpsesOnCorpseRemoval": {
+        "label": "Remove Player Corpses",
+        "description": "Remove player corpses when corpse removal runs."
+      },
+      "AllowDestructionBySledgehammer": {
+        "label": "Sledgehammer Destruction",
+        "description": "Allow players to destroy world objects with sledgehammer."
+      },
+      "NoFire": {
+        "label": "Disable Fire",
+        "description": "Disable all fires except campfires."
+      },
+      "SafehousePreventsLootRespawn": {
+        "label": "Safehouse Blocks Loot Respawn",
+        "description": "Items will not respawn in buildings claimed as safehouses."
+      },
+      "SledgehammerOnlyInSafehouse": {
+        "label": "Sledgehammer Only in Safehouse",
+        "description": "Restrict sledgehammer destruction to safehouses only. Requires Sledgehammer Destruction enabled."
+      }
+    },
+    "mods": {
+      "Mods": {
+        "label": "Mods",
+        "description": "List of installed mod IDs (semicolon-separated)."
+      },
+      "WorkshopItems": {
+        "label": "Workshop Items",
+        "description": "Steam Workshop item IDs to download (semicolon-separated)."
+      },
+      "DoLuaChecksum": {
+        "label": "Lua Checksum",
+        "description": "Verify client Lua matches server. Must be disabled when using PanelBridge — the mod modifies server-side Lua files, which causes checksum mismatches and prevents players from connecting."
+      }
+    },
+    "steam": {
+      "SteamPort1": {
+        "label": "Steam Port 1",
+        "description": "First Steam port."
+      },
+      "SteamPort2": {
+        "label": "Steam Port 2",
+        "description": "Second Steam port."
+      },
+      "SteamScoreboard": {
+        "label": "Steam Scoreboard",
+        "description": "Show Steam usernames and avatars. true/false/admin.",
+        "options": {
+          "true": {
+            "label": "Everyone"
+          },
+          "false": {
+            "label": "No One"
+          },
+          "admin": {
+            "label": "Admins Only"
+          }
+        }
+      },
+      "SteamVAC": {
+        "label": "VAC Ban Check",
+        "description": "Check if connecting players have VAC bans."
+      }
+    },
+    "voice": {
+      "VoiceEnable": {
+        "label": "Enable Voice Chat",
+        "description": "Enable in-game voice chat."
+      },
+      "Voice3D": {
+        "label": "3D Voice",
+        "description": "Enable 3D positional voice chat."
+      },
+      "VoiceMinDistance": {
+        "label": "Voice Min Distance",
+        "description": "Minimum voice distance."
+      },
+      "VoiceMaxDistance": {
+        "label": "Voice Max Distance",
+        "description": "Maximum voice distance."
+      }
+    },
+    "discord": {
+      "DiscordEnable": {
+        "label": "Enable Discord",
+        "description": "Enable built-in Discord integration."
+      },
+      "DiscordToken": {
+        "label": "Discord Token",
+        "description": "Discord bot token."
+      },
+      "DiscordChannel": {
+        "label": "Discord Channel",
+        "description": "Discord channel name."
+      },
+      "DiscordChannelID": {
+        "label": "Discord Channel ID",
+        "description": "Discord channel ID."
+      },
+      "DiscordChatChannel": {
+        "label": "Discord Chat Channel",
+        "description": "The Discord channel name for game chat."
+      },
+      "DiscordLogChannel": {
+        "label": "Discord Log Channel",
+        "description": "The Discord channel name for server logs."
+      },
+      "DiscordCommandChannel": {
+        "label": "Discord Command Channel",
+        "description": "The Discord channel name for commands."
+      },
+      "WebhookAddress": {
+        "label": "Webhook URL",
+        "description": "Slack/Discord incoming webhook URL for notifications."
+      }
+    },
+    "rcon": {
+      "RCONPort": {
+        "label": "RCON Port",
+        "description": "Port for RCON connections."
+      },
+      "RCONPassword": {
+        "label": "RCON Password",
+        "description": "Password for RCON connections."
+      }
+    },
+    "advanced": {
+      "ResetID": {
+        "label": "Reset ID",
+        "description": "Removing this resets zombies and loot (not time)."
+      },
+      "ServerPlayerID": {
+        "label": "Server Player ID",
+        "description": "Identifies if character is from another server."
+      },
+      "PhysicsDelay": {
+        "label": "Physics Delay",
+        "description": "Physics update delay in milliseconds."
+      },
+      "FastForwardMultiplier": {
+        "label": "Fast Forward Multiplier",
+        "description": "Speed multiplier when fast-forwarding."
+      },
+      "CarEngineAttractionModifier": {
+        "label": "Car Engine Attraction",
+        "description": "Modifier for zombie attraction to car engines."
+      },
+      "ZombieUpdateMaxHighPriority": {
+        "label": "Zombie High Priority Updates",
+        "description": "Max high priority zombie updates per tick."
+      },
+      "ZombieUpdateDelta": {
+        "label": "Zombie Update Delta",
+        "description": "Zombie update time delta."
+      },
+      "SwitchZombiesOwnershipEachUpdate": {
+        "label": "Switch Zombie Ownership",
+        "description": "Switch zombie ownership between players each update tick."
+      },
+      "UltraSpeedDoesnotAffectToAnimals": {
+        "label": "Ultra Speed Ignores Animals",
+        "description": "Ultra speed mode does not affect animal simulation."
+      },
+      "UsePhysicsHitReaction": {
+        "label": "Physics Hit Reaction",
+        "description": "Use physics-based hit reactions."
+      }
+    },
+    "war": {
+      "War": {
+        "label": "Enable Faction War",
+        "description": "Enable faction war system. (Disabled by default since the Dec 2025 MP patch.)"
+      },
+      "WarStartDelay": {
+        "label": "War Start Delay",
+        "description": "Seconds before war starts after being declared."
+      },
+      "WarDuration": {
+        "label": "War Duration",
+        "description": "War duration in seconds."
+      },
+      "WarSafehouseHitPoints": {
+        "label": "War Safehouse Hit Points",
+        "description": "Safehouse hit points during faction war."
+      }
+    },
+    "radio": {
+      "DisableRadioStaff": {
+        "label": "Disable Radio for Staff",
+        "description": "Disable radio transmissions from staff access level."
+      },
+      "DisableRadioAdmin": {
+        "label": "Disable Radio for Admins",
+        "description": "Disable radio transmissions from admin access level."
+      },
+      "DisableRadioGM": {
+        "label": "Disable Radio for GMs",
+        "description": "Disable radio transmissions from GM access level."
+      },
+      "DisableRadioOverseer": {
+        "label": "Disable Radio for Overseers",
+        "description": "Disable radio transmissions from overseer access level."
+      },
+      "DisableRadioModerator": {
+        "label": "Disable Radio for Moderators",
+        "description": "Disable radio transmissions from moderator access level."
+      },
+      "DisableRadioInvisible": {
+        "label": "Disable Radio for Invisible",
+        "description": "Disable radio transmissions from invisible players."
+      }
+    },
+    "backups": {
+      "BackupsCount": {
+        "label": "Backup Count",
+        "description": "Number of backup copies to keep."
+      },
+      "BackupsOnStart": {
+        "label": "Backup on Start",
+        "description": "Create a backup when the server starts."
+      },
+      "BackupsOnVersionChange": {
+        "label": "Backup on Version Change",
+        "description": "Create a backup when the game version changes."
+      },
+      "BackupsPeriod": {
+        "label": "Backup Period",
+        "description": "Minutes between automatic backups. 0 = disabled."
+      }
+    },
+    "vehicles": {
+      "DisableVehicleTowing": {
+        "label": "Disable Vehicle Towing",
+        "description": "Disable vehicle towing."
+      },
+      "DisableTrailerTowing": {
+        "label": "Disable Trailer Towing",
+        "description": "Disable trailer towing."
+      },
+      "DisableBurntTowing": {
+        "label": "Disable Burnt Vehicle Towing",
+        "description": "Disable towing of burnt vehicles."
+      }
+    },
+    "moderation": {
+      "BadWordListFile": {
+        "label": "Bad Word List File",
+        "description": "Path to file with prohibited words, one per line."
+      },
+      "GoodWordListFile": {
+        "label": "Good Word List File",
+        "description": "Path to file with allowed words that may contain bad words, one per line."
+      },
+      "BadWordPolicy": {
+        "label": "Bad Word Policy",
+        "description": "Action taken when a bad word is detected in chat.",
+        "options": {
+          "1": {
+            "label": "Ban"
+          },
+          "2": {
+            "label": "Kick"
+          },
+          "3": {
+            "label": "Record Violation"
+          },
+          "4": {
+            "label": "Mute"
+          }
+        }
+      },
+      "BadWordReplacement": {
+        "label": "Bad Word Replacement",
+        "description": "Text that replaces bad words in chat."
+      }
+    },
+    "anticheat": {
+      "AntiCheatSafety": {
+        "label": "Safety",
+        "description": "Anti-cheat protection for the safety system.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSpeed": {
+        "label": "Speed",
+        "description": "Anti-cheat protection for player speed.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatNoClip": {
+        "label": "No Clip",
+        "description": "Anti-cheat protection against moving through solid objects.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatHit": {
+        "label": "Hit Detection",
+        "description": "Anti-cheat protection for character hits.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPacketException": {
+        "label": "Packet Exceptions",
+        "description": "Anti-cheat protection for invalid network packets.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPermission": {
+        "label": "Permissions",
+        "description": "Anti-cheat protection for player permissions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatXP": {
+        "label": "XP Validation",
+        "description": "Anti-cheat protection for player XP.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSafeHouse": {
+        "label": "Safehouse Protection",
+        "description": "Anti-cheat protection for safehouses.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPlayer": {
+        "label": "Player Validation",
+        "description": "Anti-cheat protection for player actions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatChecksum": {
+        "label": "Checksum Validation",
+        "description": "Anti-cheat protection for file checksums.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      }
+    },
+    "logging": {
+      "ClientCommandFilter": {
+        "label": "Command Log Filter",
+        "description": "Semicolon-separated list of commands to exclude from cmd.txt log. Use -vehicle.* to exclude all vehicle, +vehicle.installPart to include specific."
+      },
+      "ClientActionLogs": {
+        "label": "Client Action Logs",
+        "description": "Semicolon-separated list of actions written to ClientActionLogs.txt."
+      },
+      "PerkLogs": {
+        "label": "Perk Level Logging",
+        "description": "Track changes in player perk levels in PerkLog.txt."
+      }
+    }
+  },
+  "sandboxSettings": {
+    "time": {
+      "DayLength": {
+        "label": "Day Length",
+        "description": "How long a day lasts.",
+        "options": {
+          "1": {
+            "label": "15 Minutes"
+          },
+          "2": {
+            "label": "30 Minutes"
+          },
+          "3": {
+            "label": "1 Hour"
+          },
+          "4": {
+            "label": "1 Hour, 30 Minutes"
+          },
+          "5": {
+            "label": "2 Hours"
+          },
+          "6": {
+            "label": "3 Hours"
+          },
+          "7": {
+            "label": "4 Hours"
+          },
+          "8": {
+            "label": "5 Hours"
+          },
+          "9": {
+            "label": "6 Hours"
+          },
+          "10": {
+            "label": "7 Hours"
+          },
+          "11": {
+            "label": "8 Hours"
+          },
+          "12": {
+            "label": "9 Hours"
+          },
+          "13": {
+            "label": "10 Hours"
+          },
+          "14": {
+            "label": "11 Hours"
+          },
+          "15": {
+            "label": "12 Hours"
+          },
+          "16": {
+            "label": "13 Hours"
+          },
+          "17": {
+            "label": "14 Hours"
+          },
+          "18": {
+            "label": "15 Hours"
+          },
+          "19": {
+            "label": "16 Hours"
+          },
+          "20": {
+            "label": "17 Hours"
+          },
+          "21": {
+            "label": "18 Hours"
+          },
+          "22": {
+            "label": "19 Hours"
+          },
+          "23": {
+            "label": "20 Hours"
+          },
+          "24": {
+            "label": "21 Hours"
+          },
+          "25": {
+            "label": "22 Hours"
+          },
+          "26": {
+            "label": "23 Hours"
+          },
+          "27": {
+            "label": "Real-time"
+          }
+        }
+      },
+      "StartYear": {
+        "label": "Start Year",
+        "description": "Which year the game starts in."
+      },
+      "StartMonth": {
+        "label": "Start Month",
+        "description": "Which month the game starts in (1=Jan, 12=Dec).",
+        "options": {
+          "1": {
+            "label": "January"
+          },
+          "2": {
+            "label": "February"
+          },
+          "3": {
+            "label": "March"
+          },
+          "4": {
+            "label": "April"
+          },
+          "5": {
+            "label": "May"
+          },
+          "6": {
+            "label": "June"
+          },
+          "7": {
+            "label": "July"
+          },
+          "8": {
+            "label": "August"
+          },
+          "9": {
+            "label": "September"
+          },
+          "10": {
+            "label": "October"
+          },
+          "11": {
+            "label": "November"
+          },
+          "12": {
+            "label": "December"
+          }
+        }
+      },
+      "StartDay": {
+        "label": "Start Day",
+        "description": "Which day of the month the game starts on."
+      },
+      "StartTime": {
+        "label": "Start Time",
+        "description": "What time of day the game starts.",
+        "options": {
+          "1": {
+            "label": "7 AM"
+          },
+          "2": {
+            "label": "9 AM"
+          },
+          "3": {
+            "label": "12 PM"
+          },
+          "4": {
+            "label": "2 PM"
+          },
+          "5": {
+            "label": "5 PM"
+          },
+          "6": {
+            "label": "9 PM"
+          },
+          "7": {
+            "label": "12 AM"
+          },
+          "8": {
+            "label": "2 AM"
+          },
+          "9": {
+            "label": "5 AM"
+          }
+        }
+      }
+    },
+    "population": {
+      "Zombies": {
+        "label": "Zombie Count",
+        "description": "Initial zombie population level. Also sets Population Multiplier in Advanced Zombie Options.",
+        "options": {
+          "1": {
+            "label": "Insane"
+          },
+          "2": {
+            "label": "Very High"
+          },
+          "3": {
+            "label": "High"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Low"
+          },
+          "6": {
+            "label": "None"
+          }
+        }
+      },
+      "Distribution": {
+        "label": "Distribution",
+        "description": "How zombies are distributed across the map.",
+        "options": {
+          "1": {
+            "label": "Urban Focused"
+          },
+          "2": {
+            "label": "Uniform"
+          }
+        }
+      },
+      "ZombieVoronoiNoise": {
+        "label": "Randomize Distribution",
+        "description": "Apply randomization to zombie distribution."
+      },
+      "ZombieRespawn": {
+        "label": "Zombie Respawn",
+        "description": "How frequently new zombies are added to the world.",
+        "options": {
+          "1": {
+            "label": "High"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Low"
+          },
+          "4": {
+            "label": "None"
+          }
+        }
+      },
+      "ZombieMigrate": {
+        "label": "Zombie Migration",
+        "description": "Zombies can migrate to empty cells."
+      }
+    },
+    "loot": {
+      "LootItemRemovalList": {
+        "label": "Loot Item Removal List",
+        "description": "Comma-separated item types removed from the world by the loot cleanup system."
+      },
+      "FoodLootNew": {
+        "label": "Food Loot",
+        "description": "Any food that can rot or spoil."
+      },
+      "CannedFoodLootNew": {
+        "label": "Canned Food Loot",
+        "description": "Canned and dried food, beverages."
+      },
+      "LiteratureLootNew": {
+        "label": "Literature Loot",
+        "description": "All readable items including books, fliers, and newspapers."
+      },
+      "SkillBookLoot": {
+        "label": "Skill Book Loot",
+        "description": "Books that provide skill XP multipliers."
+      },
+      "RecipeResourceLoot": {
+        "label": "Recipe Loot",
+        "description": "Items that teach recipes."
+      },
+      "MedicalLootNew": {
+        "label": "Medical Loot",
+        "description": "Medicine, bandages, and first aid tools."
+      },
+      "SurvivalGearsLootNew": {
+        "label": "Survival Gear Loot",
+        "description": "Fishing rods, tents, camping gear."
+      },
+      "WeaponLootNew": {
+        "label": "Melee Weapon Loot",
+        "description": "Weapons that are not tools in other categories."
+      },
+      "RangedWeaponLootNew": {
+        "label": "Ranged Weapon Loot",
+        "description": "Ranged weapons and weapon attachments."
+      },
+      "AmmoLootNew": {
+        "label": "Ammo Loot",
+        "description": "Loose ammo, boxes, and magazines."
+      },
+      "MechanicsLootNew": {
+        "label": "Mechanics Loot",
+        "description": "Vehicle parts and installation tools."
+      },
+      "ClothingLootNew": {
+        "label": "Clothing Loot",
+        "description": "All wearable items that are not containers."
+      },
+      "ContainerLootNew": {
+        "label": "Container Loot",
+        "description": "Backpacks and wearable/equippable containers."
+      },
+      "KeyLootNew": {
+        "label": "Key Loot",
+        "description": "Keys for buildings/cars, key rings, and locks."
+      },
+      "MediaLootNew": {
+        "label": "Media Loot",
+        "description": "VHS tapes and CDs."
+      },
+      "MementoLootNew": {
+        "label": "Memento Loot",
+        "description": "Spiffo items, plushies, and collectible keepsakes."
+      },
+      "CookwareLootNew": {
+        "label": "Cookware Loot",
+        "description": "Cooking items including those that can be weapons. Does not include food."
+      },
+      "MaterialLootNew": {
+        "label": "Material Loot",
+        "description": "Crafting and building materials."
+      },
+      "FarmingLootNew": {
+        "label": "Farming Loot",
+        "description": "Seeds, trowels, shovels, and agriculture tools."
+      },
+      "ToolLootNew": {
+        "label": "Tool Loot",
+        "description": "Tools not in other categories like Mechanics or Farming."
+      },
+      "OtherLootNew": {
+        "label": "Other Loot",
+        "description": "Everything else. Also affects foraging in Town/Road zones."
+      },
+      "RollsMultiplier": {
+        "label": "Rolls Multiplier",
+        "description": "Multiplier for loot table rolls. Higher values may affect performance. NOT recommended to change."
+      },
+      "RemoveStoryLoot": {
+        "label": "Remove Story Loot",
+        "description": "Items on the removal list will not spawn in world stories."
+      },
+      "RemoveZombieLoot": {
+        "label": "Remove Zombie Loot",
+        "description": "Items on the removal list will not spawn on zombies."
+      },
+      "ZombiePopLootEffect": {
+        "label": "Zombie Pop Loot Effect",
+        "description": "If > 0, loot increases relative to nearby zombies, multiplied by this value."
+      },
+      "HoursForLootRespawn": {
+        "label": "Loot Respawn Hours",
+        "description": "Hours after which containers respawn loot. 0 = never."
+      },
+      "MaxItemsForLootRespawn": {
+        "label": "Max Items for Respawn",
+        "description": "Containers with this many items or more will not respawn loot."
+      },
+      "ConstructionPreventsLootRespawn": {
+        "label": "Construction Blocks Respawn",
+        "description": "Player constructions near containers prevent loot respawn."
+      },
+      "SeenHoursPreventLootRespawn": {
+        "label": "Seen Hours Prevent Respawn",
+        "description": "Hours a zone must be unvisited before loot respawns. 0 = disabled."
+      }
+    },
+    "lootRarity": {
+      "InsaneLootFactor": {
+        "label": "Insane Rarity Factor",
+        "description": "Spawn rate for Insane rarity items."
+      },
+      "ExtremeLootFactor": {
+        "label": "Extreme Rarity Factor",
+        "description": "Spawn rate for Extreme rarity items."
+      },
+      "RareLootFactor": {
+        "label": "Rare Rarity Factor",
+        "description": "Spawn rate for Rare rarity items."
+      },
+      "NormalLootFactor": {
+        "label": "Normal Rarity Factor",
+        "description": "Spawn rate for Normal rarity items."
+      },
+      "CommonLootFactor": {
+        "label": "Common Rarity Factor",
+        "description": "Spawn rate for Common rarity items."
+      },
+      "AbundantLootFactor": {
+        "label": "Abundant Rarity Factor",
+        "description": "Spawn rate for Abundant rarity items."
+      },
+      "MaximumLooted": {
+        "label": "Max Looted Building Chance",
+        "description": "Chance that any building is already looted when found."
+      },
+      "DaysUntilMaximumLooted": {
+        "label": "Days Until Max Looted",
+        "description": "Days before Maximum Looted Building Chance is reached."
+      },
+      "RuralLooted": {
+        "label": "Rural Looted Chance",
+        "description": "Chance that any rural building is already looted."
+      },
+      "MaximumDiminishedLoot": {
+        "label": "Max Diminished Loot %",
+        "description": "Maximum loot that won't spawn when diminished days reached."
+      },
+      "DaysUntilMaximumDiminishedLoot": {
+        "label": "Days Until Max Diminished",
+        "description": "Days before Maximum Diminished Loot is reached."
+      },
+      "MaximumLootedBuildingRooms": {
+        "label": "Max Looted Building Rooms",
+        "description": "Buildings with more than this many rooms will not be auto-looted."
+      }
+    },
+    "environment": {
+      "DayNightCycle": {
+        "label": "Day/Night Cycle",
+        "description": "Whether time of day changes naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Endless Day"
+          },
+          "3": {
+            "label": "Endless Night"
+          }
+        }
+      },
+      "ClimateCycle": {
+        "label": "Weather Cycle",
+        "description": "Whether weather changes or remains fixed.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "No Weather"
+          },
+          "3": {
+            "label": "Endless Rain"
+          },
+          "4": {
+            "label": "Endless Storm"
+          },
+          "5": {
+            "label": "Endless Snow"
+          },
+          "6": {
+            "label": "Endless Blizzard"
+          }
+        }
+      },
+      "FogCycle": {
+        "label": "Fog Cycle",
+        "description": "Whether fog occurs naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "No Fog"
+          },
+          "3": {
+            "label": "Endless Fog"
+          }
+        }
+      },
+      "WaterShut": {
+        "label": "Water Shutoff",
+        "description": "When plumbing fixtures stop being infinite water sources.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0 - 30 Days"
+          },
+          "3": {
+            "label": "0 - 2 Months"
+          },
+          "4": {
+            "label": "0 - 6 Months"
+          },
+          "5": {
+            "label": "0 - 1 Year"
+          },
+          "6": {
+            "label": "0 - 5 Years"
+          },
+          "7": {
+            "label": "2 - 6 Months"
+          },
+          "8": {
+            "label": "6 - 12 Months"
+          },
+          "9": {
+            "label": "Disabled"
+          }
+        }
+      },
+      "ElecShut": {
+        "label": "Electricity Shutoff",
+        "description": "When the world's electricity turns off.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "14 - 30 Days"
+          },
+          "3": {
+            "label": "14 Days - 2 Months"
+          },
+          "4": {
+            "label": "14 Days - 6 Months"
+          },
+          "5": {
+            "label": "14 Days - 1 Year"
+          },
+          "6": {
+            "label": "14 Days - 5 Years"
+          },
+          "7": {
+            "label": "2 - 6 Months"
+          },
+          "8": {
+            "label": "6 - 12 Months"
+          },
+          "9": {
+            "label": "Disabled"
+          }
+        }
+      },
+      "AlarmDecay": {
+        "label": "Alarm Battery Decay",
+        "description": "How long alarm batteries last after power shuts off.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0 - 30 Days"
+          },
+          "3": {
+            "label": "0 - 2 Months"
+          },
+          "4": {
+            "label": "0 - 6 Months"
+          },
+          "5": {
+            "label": "0 - 1 Year"
+          },
+          "6": {
+            "label": "0 - 5 Years"
+          },
+          "7": {
+            "label": "2 - 6 Months"
+          },
+          "8": {
+            "label": "6 - 12 Months"
+          },
+          "9": {
+            "label": "Disabled"
+          }
+        }
+      },
+      "WaterShutModifier": {
+        "label": "Water Shutoff Modifier",
+        "description": "Fine-tune water shutoff timing in days."
+      },
+      "ElecShutModifier": {
+        "label": "Electricity Shutoff Modifier",
+        "description": "Fine-tune electricity shutoff timing in days."
+      },
+      "AlarmDecayModifier": {
+        "label": "Alarm Decay Modifier",
+        "description": "Fine-tune alarm battery decay timing in days."
+      },
+      "Temperature": {
+        "label": "Temperature",
+        "description": "Global temperature setting.",
+        "options": {
+          "1": {
+            "label": "Very Cold"
+          },
+          "2": {
+            "label": "Cold"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hot"
+          },
+          "5": {
+            "label": "Very Hot"
+          }
+        }
+      },
+      "Rain": {
+        "label": "Rainfall",
+        "description": "How often it rains.",
+        "options": {
+          "1": {
+            "label": "Very Dry"
+          },
+          "2": {
+            "label": "Dry"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Rainy"
+          },
+          "5": {
+            "label": "Very Rainy"
+          }
+        }
+      },
+      "ErosionSpeed": {
+        "label": "Erosion Speed",
+        "description": "How fast nature reclaims the world.",
+        "options": {
+          "1": {
+            "label": "Very Fast (20 Days)"
+          },
+          "2": {
+            "label": "Fast (50 Days)"
+          },
+          "3": {
+            "label": "Normal (100 Days)"
+          },
+          "4": {
+            "label": "Slow (200 Days)"
+          },
+          "5": {
+            "label": "Very Slow (500 Days)"
+          }
+        }
+      },
+      "ErosionDays": {
+        "label": "Custom Erosion Days",
+        "description": "Custom erosion days. 0 = use Erosion Speed option."
+      },
+      "MaxFogIntensity": {
+        "label": "Max Fog Intensity",
+        "description": "Maximum intensity of fog.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Moderate"
+          },
+          "3": {
+            "label": "Low"
+          },
+          "4": {
+            "label": "None"
+          }
+        }
+      },
+      "MaxRainFxIntensity": {
+        "label": "Max Rain FX Intensity",
+        "description": "Maximum intensity of rain effects.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Moderate"
+          },
+          "3": {
+            "label": "Low"
+          }
+        }
+      },
+      "EnableSnowOnGround": {
+        "label": "Snow on Ground",
+        "description": "Whether snow accumulates on the ground."
+      },
+      "NightDarkness": {
+        "label": "Night Darkness",
+        "description": "Ambient lighting level at night.",
+        "options": {
+          "1": {
+            "label": "Pitch Black"
+          },
+          "2": {
+            "label": "Dark"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Bright"
+          }
+        }
+      },
+      "NightLength": {
+        "label": "Night Length",
+        "description": "Duration from dusk to dawn.",
+        "options": {
+          "1": {
+            "label": "Always Night"
+          },
+          "2": {
+            "label": "Long"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Short"
+          },
+          "5": {
+            "label": "Always Day"
+          }
+        }
+      },
+      "TimeSinceApo": {
+        "label": "Time Since Apocalypse",
+        "description": "How long after the apocalypse the game begins. Affects erosion and food spoilage.",
+        "options": {
+          "1": {
+            "label": "0"
+          },
+          "2": {
+            "label": "1"
+          },
+          "3": {
+            "label": "2"
+          },
+          "4": {
+            "label": "3"
+          },
+          "5": {
+            "label": "4"
+          },
+          "6": {
+            "label": "5"
+          },
+          "7": {
+            "label": "6"
+          },
+          "8": {
+            "label": "7"
+          },
+          "9": {
+            "label": "8"
+          },
+          "10": {
+            "label": "9"
+          },
+          "11": {
+            "label": "10"
+          },
+          "12": {
+            "label": "11"
+          },
+          "13": {
+            "label": "12"
+          }
+        }
+      },
+      "FireSpread": {
+        "label": "Fire Spread",
+        "description": "Whether fires spread when started."
+      }
+    },
+    "survival": {
+      "StatsDecrease": {
+        "label": "Stats Decrease",
+        "description": "How fast hunger, thirst, and fatigue decrease.",
+        "options": {
+          "1": {
+            "label": "Very Fast"
+          },
+          "2": {
+            "label": "Fast"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Slow"
+          },
+          "5": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "Nutrition": {
+        "label": "Nutrition",
+        "description": "Food nutrition affects player weight and condition."
+      },
+      "FoodRotSpeed": {
+        "label": "Food Rot Speed",
+        "description": "How fast food spoils.",
+        "options": {
+          "1": {
+            "label": "Very Fast"
+          },
+          "2": {
+            "label": "Fast"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Slow"
+          },
+          "5": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "FridgeFactor": {
+        "label": "Fridge Effectiveness",
+        "description": "How effective fridges are at preserving food.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          },
+          "6": {
+            "label": "No decay"
+          }
+        }
+      },
+      "StarterKit": {
+        "label": "Starter Kit",
+        "description": "Spawn with chips, water bottle, backpack, bat, and hammer."
+      },
+      "CharacterFreePoints": {
+        "label": "Free Character Points",
+        "description": "Extra free points during character creation."
+      },
+      "BoneFracture": {
+        "label": "Bone Fractures",
+        "description": "Survivors can get broken limbs from impacts, falls, etc."
+      },
+      "InjurySeverity": {
+        "label": "Injury Severity",
+        "description": "Impact of injuries and healing time.",
+        "options": {
+          "1": {
+            "label": "Low"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "High"
+          }
+        }
+      },
+      "EndRegen": {
+        "label": "Endurance Recovery",
+        "description": "Recovery from tiredness after actions.",
+        "options": {
+          "1": {
+            "label": "Very Fast"
+          },
+          "2": {
+            "label": "Fast"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Slow"
+          },
+          "5": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "HoursForCorpseRemoval": {
+        "label": "Corpse Removal Hours",
+        "description": "Hours before zombie corpses disappear. 0 = no maggots spawn."
+      },
+      "DecayingCorpseHealthImpact": {
+        "label": "Corpse Health Impact",
+        "description": "Impact of nearby decaying bodies on health/emotions.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Insane"
+          }
+        }
+      },
+      "ZombieHealthImpact": {
+        "label": "Zombie Health Impact",
+        "description": "Whether living zombies also affect player health/emotions."
+      },
+      "BloodLevel": {
+        "label": "Blood Level",
+        "description": "How much blood sprays on surfaces.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Ultra Gore"
+          }
+        }
+      },
+      "ClothingDegradation": {
+        "label": "Clothing Degradation",
+        "description": "How quickly clothing degrades and gets dirty.",
+        "options": {
+          "1": {
+            "label": "Disabled"
+          },
+          "2": {
+            "label": "Slow"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Fast"
+          }
+        }
+      },
+      "DaysForRottenFoodRemoval": {
+        "label": "Rotten Food Removal Days",
+        "description": "Days before rotten food is removed. -1 = never."
+      },
+      "AllClothesUnlocked": {
+        "label": "All Clothes Unlocked",
+        "description": "Select from every clothing item during character creation."
+      },
+      "EnableTaintedWaterText": {
+        "label": "Tainted Water Warning",
+        "description": "Show warning marking tainted water."
+      },
+      "EnablePoisoning": {
+        "label": "Enable Poisoning",
+        "description": "Whether poison can be added to food.",
+        "options": {
+          "1": {
+            "label": "True"
+          },
+          "2": {
+            "label": "False"
+          },
+          "3": {
+            "label": "Only bleach poisoning is disabled"
+          }
+        }
+      },
+      "MaggotSpawn": {
+        "label": "Maggot Spawn",
+        "description": "When maggots spawn in corpses.",
+        "options": {
+          "1": {
+            "label": "In and Around Bodies"
+          },
+          "2": {
+            "label": "In Bodies Only"
+          },
+          "3": {
+            "label": "Never"
+          }
+        }
+      },
+      "MuscleStrainFactor": {
+        "label": "Muscle Strain Factor",
+        "description": "Multiplier for muscle strain from swinging weapons or carrying heavy loads."
+      },
+      "DiscomfortFactor": {
+        "label": "Discomfort Factor",
+        "description": "Multiplier for discomfort from worn items."
+      },
+      "WoundInfectionFactor": {
+        "label": "Wound Infection Factor",
+        "description": "Damage from serious wound infections. 0 = disabled."
+      },
+      "NoBlackClothes": {
+        "label": "No Black Clothes",
+        "description": "Prevent randomized clothing from becoming near-black."
+      },
+      "EasyClimbing": {
+        "label": "Easy Climbing",
+        "description": "Disable failure chances when climbing sheet ropes or walls."
+      },
+      "NegativeTraitsPenalty": {
+        "label": "Negative Traits Penalty",
+        "description": "Diminishing returns on bonus points from negative traits.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "1 point penalty for every 3 negative traits selected"
+          },
+          "3": {
+            "label": "1 point penalty for every 2 negative traits selected"
+          },
+          "4": {
+            "label": "1 point penalty for every negative trait selected after the first"
+          }
+        }
+      },
+      "MinutesPerPage": {
+        "label": "Minutes Per Page",
+        "description": "In-game minutes to read one page of a skill book."
+      },
+      "LiteratureCooldown": {
+        "label": "Literature Cooldown",
+        "description": "Days before previously read literature can benefit again."
+      },
+      "LevelForMediaXPCutoff": {
+        "label": "Media XP Cutoff Level",
+        "description": "Skill level at which TV/VHS/media no longer provides XP."
+      },
+      "LevelForDismantleXPCutoff": {
+        "label": "Dismantle XP Cutoff Level",
+        "description": "Skill level at which scrapping furniture gives no XP."
+      },
+      "BloodSplatLifespanDays": {
+        "label": "Blood Splat Lifespan",
+        "description": "Days before blood splats disappear. 0 = never."
+      },
+      "MetaKnowledge": {
+        "label": "Meta Knowledge",
+        "description": "How unseen/unread media is displayed.",
+        "options": {
+          "1": {
+            "label": "Fully revealed"
+          },
+          "2": {
+            "label": "Shown as ???"
+          },
+          "3": {
+            "label": "Completely hidden"
+          }
+        }
+      },
+      "SeeNotLearntRecipe": {
+        "label": "See Unlearned Recipes",
+        "description": "See station recipes even if not yet learned."
+      },
+      "LightBulbLifespan": {
+        "label": "Light Bulb Lifespan",
+        "description": "Higher = bulbs last longer. 0 = never break."
+      },
+      "MaximumFireFuelHours": {
+        "label": "Max Fire Fuel Hours",
+        "description": "Max hours of fuel for campfires, wood stoves, etc."
+      },
+      "Alarm": {
+        "label": "House Alarms",
+        "description": "Frequency of residential alarms.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "LockedHouses": {
+        "label": "Locked Houses",
+        "description": "Frequency of locked houses.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "Helicopter": {
+        "label": "Helicopter Events",
+        "description": "Helicopter frequency.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Once"
+          },
+          "3": {
+            "label": "Sometimes"
+          },
+          "4": {
+            "label": "Often"
+          }
+        }
+      },
+      "MetaEvent": {
+        "label": "Meta Events",
+        "description": "Distant gunshots, screams, etc.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Sometimes"
+          },
+          "3": {
+            "label": "Often"
+          }
+        }
+      },
+      "SleepingEvent": {
+        "label": "Sleeping Events",
+        "description": "Events that happen while sleeping.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Sometimes"
+          },
+          "3": {
+            "label": "Often"
+          }
+        }
+      },
+      "NatureAbundance": {
+        "label": "Nature Abundance",
+        "description": "Governs abundance of wild foods, medicinal plants, etc.",
+        "options": {
+          "1": {
+            "label": "Very Poor"
+          },
+          "2": {
+            "label": "Poor"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundant"
+          },
+          "5": {
+            "label": "Very Abundant"
+          }
+        }
+      },
+      "FishAbundance": {
+        "label": "Fish Abundance",
+        "description": "Governs abundance of fish.",
+        "options": {
+          "1": {
+            "label": "Very Poor"
+          },
+          "2": {
+            "label": "Poor"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundant"
+          },
+          "5": {
+            "label": "Very Abundant"
+          }
+        }
+      },
+      "AnnotatedMapChance": {
+        "label": "Annotated Map Chance",
+        "description": "Chance of finding maps annotated with local features.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "ConstructionBonusPoints": {
+        "label": "Construction Bonus Points",
+        "description": "Extra points for carpentry/metalworking constructions."
+      },
+      "GeneratorSpawning": {
+        "label": "Generator Spawning",
+        "description": "How many generators spawn in the world.",
+        "options": {
+          "1": {
+            "label": "None (not recommended)"
+          },
+          "2": {
+            "label": "Insanely Rare"
+          },
+          "3": {
+            "label": "Extremely Rare"
+          },
+          "4": {
+            "label": "Rare"
+          },
+          "5": {
+            "label": "Normal"
+          },
+          "6": {
+            "label": "Common"
+          },
+          "7": {
+            "label": "Abundant"
+          }
+        }
+      },
+      "GeneratorFuelConsumption": {
+        "label": "Generator Fuel Consumption",
+        "description": "How fast generators consume fuel."
+      },
+      "AllowExteriorGenerator": {
+        "label": "Allow Exterior Generator",
+        "description": "Generators can be placed outdoors and inside tents."
+      },
+      "GeneratorTileRange": {
+        "label": "Generator Tile Range",
+        "description": "Horizontal range of generators in tiles."
+      },
+      "GeneratorVerticalPowerRange": {
+        "label": "Generator Vertical Range",
+        "description": "Vertical range of generators in floors."
+      },
+      "CompostTime": {
+        "label": "Compost Time",
+        "description": "How long composting takes.",
+        "options": {
+          "1": {
+            "label": "1 Week"
+          },
+          "2": {
+            "label": "2 Weeks"
+          },
+          "3": {
+            "label": "3 Weeks"
+          },
+          "4": {
+            "label": "4 Weeks"
+          },
+          "5": {
+            "label": "6 Weeks"
+          },
+          "6": {
+            "label": "8 Weeks"
+          },
+          "7": {
+            "label": "10 Weeks"
+          },
+          "8": {
+            "label": "12 Weeks"
+          }
+        }
+      },
+      "AttackBlockMovements": {
+        "label": "Attack Block Movements",
+        "description": "Player can't move while performing melee attacks."
+      },
+      "WorldItemRemovalList": {
+        "label": "World Item Removal List",
+        "description": "Types of items removed from world (comma separated, e.g. Base.Vest)."
+      },
+      "HoursForWorldItemRemoval": {
+        "label": "World Item Removal Hours",
+        "description": "Hours before listed items disappear from world. 0 = disabled."
+      },
+      "ItemRemovalListBlacklistToggle": {
+        "label": "Item Removal Blacklist Toggle",
+        "description": "If true, removal list acts as blacklist (remove everything except listed). Default is whitelist."
+      }
+    },
+    "combat": {
+      "MultiHitZombies": {
+        "label": "Multi-Hit Zombies",
+        "description": "A melee weapon can hit multiple zombies in one swing."
+      },
+      "RearVulnerability": {
+        "label": "Rear Vulnerability",
+        "description": "Zombies take more damage when attacked from behind.",
+        "options": {
+          "1": {
+            "label": "Low"
+          },
+          "2": {
+            "label": "Medium"
+          },
+          "3": {
+            "label": "High"
+          }
+        }
+      },
+      "FirearmUseDamageChance": {
+        "label": "Firearm Use Damage Chance",
+        "description": "Chance of weapon condition loss per use. 0 = never."
+      },
+      "FirearmNoiseMultiplier": {
+        "label": "Firearm Noise Multiplier",
+        "description": "Multiplier for gun noise attracting zombies."
+      },
+      "FirearmJamMultiplier": {
+        "label": "Firearm Jam Multiplier",
+        "description": "Multiplier for jamming chance."
+      },
+      "FirearmMoodleMultiplier": {
+        "label": "Firearm Moodle Multiplier",
+        "description": "Multiplier for panic/stress from gun use."
+      },
+      "FirearmWeatherMultiplier": {
+        "label": "Firearm Weather Multiplier",
+        "description": "Multiplier for rain affecting gun condition."
+      },
+      "FirearmHeadGearEffect": {
+        "label": "Firearm Head Gear Effect",
+        "description": "How much head-covering gear like helmets affects firearm aim/shoulder."
+      }
+    },
+    "vehicles": {
+      "EnableVehicles": {
+        "label": "Enable Vehicles",
+        "description": "Whether vehicles spawn and can be used."
+      },
+      "CarSpawnRate": {
+        "label": "Car Spawn Rate",
+        "description": "How many vehicles spawn.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Very Low"
+          },
+          "3": {
+            "label": "Low"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "High"
+          }
+        }
+      },
+      "VehicleEasyUse": {
+        "label": "Vehicle Easy Use",
+        "description": "All vehicles are automatic and easy to start."
+      },
+      "InitialGas": {
+        "label": "Initial Vehicle Gas",
+        "description": "How full the gas tank of discovered vehicles will be.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          },
+          "6": {
+            "label": "Full"
+          }
+        }
+      },
+      "FuelStationGasInfinite": {
+        "label": "Infinite Fuel Station Gas",
+        "description": "If enabled, gas pumps will never run out of fuel."
+      },
+      "FuelStationGasMin": {
+        "label": "Fuel Station Gas Min",
+        "description": "The minimum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasMax": {
+        "label": "Fuel Station Gas Max",
+        "description": "The maximum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasEmptyChance": {
+        "label": "Fuel Station Empty Chance",
+        "description": "The chance, as a percentage, that individual gas pumps will initially have no fuel."
+      },
+      "LockedCar": {
+        "label": "Locked Car Chance",
+        "description": "Chance of vehicle doors being locked.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "CarGasConsumption": {
+        "label": "Gas Consumption",
+        "description": "Rate of fuel consumption in vehicles."
+      },
+      "CarGeneralCondition": {
+        "label": "Car General Condition",
+        "description": "Initial condition of discovered vehicles.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "CarDamageOnImpact": {
+        "label": "Car Damage on Impact",
+        "description": "Damage vehicles take from collisions.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "DamageToPlayerFromHitByACar": {
+        "label": "Car Damage to Player",
+        "description": "How much damage players receive from vehicle impacts.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "TrafficJam": {
+        "label": "Traffic Jams",
+        "description": "Whether traffic jams spawn on roads."
+      },
+      "CarAlarm": {
+        "label": "Car Alarms",
+        "description": "Chance of vehicles having active alarms.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "PlayerDamageFromCrash": {
+        "label": "Crash Damage to Player",
+        "description": "If the player can get injured from being in a car accident."
+      },
+      "SirenShutoffHours": {
+        "label": "Siren Shutoff Hours",
+        "description": "Hours before vehicle siren batteries die. 0 = instant."
+      },
+      "ChanceHasGas": {
+        "label": "Chance Has Gas",
+        "description": "The chance of finding a vehicle with gas in its tank.",
+        "options": {
+          "1": {
+            "label": "Low"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "High"
+          }
+        }
+      },
+      "RecentlySurvivorVehicles": {
+        "label": "Recently Survivor Vehicles",
+        "description": "Whether a player can discover a car that has been cared for after the Knox infection struck.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          }
+        }
+      },
+      "ZombieAttractionMultiplier": {
+        "label": "Vehicle Zombie Attraction",
+        "description": "Multiplier for vehicle sounds attracting zombies."
+      },
+      "SirenEffectsZombies": {
+        "label": "Siren Effects Zombies",
+        "description": "If zombies will head towards the sound of vehicle sirens."
+      }
+    },
+    "animals": {
+      "AnimalStatsModifier": {
+        "label": "Animal Stats Speed",
+        "description": "Speed at which animal stats (hunger, thirst etc.) reduce.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalMetaStatsModifier": {
+        "label": "Animal Meta Stats Speed",
+        "description": "Speed at which animal stats reduce while in meta (overworld).",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalPregnancyTime": {
+        "label": "Animal Pregnancy Time",
+        "description": "How long animals will be pregnant for before giving birth.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalAgeModifier": {
+        "label": "Animal Aging Speed",
+        "description": "Speed at which animals age.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalMilkIncModifier": {
+        "label": "Milk Production Speed",
+        "description": "Speed of milk production.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalWoolIncModifier": {
+        "label": "Wool Production Speed",
+        "description": "Speed of wool production.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalRanchChance": {
+        "label": "Animal Ranch Chance",
+        "description": "The chance of finding animals in farms.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      },
+      "AnimalGrassRegrowTime": {
+        "label": "Grass Regrow Time",
+        "description": "The number of hours grass will regrow after being eaten by an animal or cut by the player."
+      },
+      "AnimalMetaPredator": {
+        "label": "Meta Predator",
+        "description": "If a meta fox may attack your chickens if the hutch door is left open at night."
+      },
+      "AnimalMatingSeason": {
+        "label": "Mating Season",
+        "description": "Restrict mating to spring/early summer or allow year-round."
+      },
+      "AnimalEggHatch": {
+        "label": "Egg Hatch Time",
+        "description": "How long before baby animals will hatch from eggs.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalSoundAttractZombies": {
+        "label": "Animal Sound Attracts Zombies",
+        "description": "If true, animal calls will attract nearby zombies."
+      },
+      "AnimalTrackChance": {
+        "label": "Animal Track Chance",
+        "description": "The chance of animals leaving tracks.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "AnimalPathChance": {
+        "label": "Animal Path Chance",
+        "description": "The chance of creating a path for animals to be hunted.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "MaximumRatIndex": {
+        "label": "Maximum Rat Index",
+        "description": "Maximum rat infestation level. 0 = no rats."
+      },
+      "DaysUntilMaximumRatIndex": {
+        "label": "Days Until Max Rat Index",
+        "description": "How many days until rat population peaks."
+      },
+      "Farming": {
+        "label": "Agriculture Multiplier",
+        "description": "Rate at which Agriculture skill levels up.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "PlantResilience": {
+        "label": "Plant Resilience",
+        "description": "How tough crops are.",
+        "options": {
+          "1": {
+            "label": "Very High"
+          },
+          "2": {
+            "label": "High"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Low"
+          },
+          "5": {
+            "label": "Very Low"
+          }
+        }
+      },
+      "PlantAbundance": {
+        "label": "Plant Abundance",
+        "description": "How much food crops produce.",
+        "options": {
+          "1": {
+            "label": "Very Poor"
+          },
+          "2": {
+            "label": "Poor"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundant"
+          },
+          "5": {
+            "label": "Very Abundant"
+          }
+        }
+      },
+      "KillInsideCrops": {
+        "label": "Kill Indoor Crops",
+        "description": "Whether stepping on indoor crops destroys them."
+      },
+      "PlantGrowingSeasons": {
+        "label": "Plant Growing Seasons",
+        "description": "Restrict crop growth to appropriate seasons."
+      },
+      "PlaceDirtAboveground": {
+        "label": "Place Dirt Aboveground",
+        "description": "Allow placing dirt on built floors above ground."
+      },
+      "FarmingSpeedNew": {
+        "label": "Farming Speed",
+        "description": "Growth speed multiplier. Lower = faster."
+      },
+      "FarmingAmountNew": {
+        "label": "Farming Amount",
+        "description": "Multiplier for number of crops harvested."
+      },
+      "ClayLakeChance": {
+        "label": "Clay Lake Chance",
+        "description": "Chance of finding clay when digging near lakes."
+      },
+      "ClayRiverChance": {
+        "label": "Clay River Chance",
+        "description": "Chance of finding clay when digging near rivers."
+      }
+    },
+    "world": {
+      "SurvivorHouseChance": {
+        "label": "Survivor House Chance",
+        "description": "Chance of finding survivor-modified houses.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always Tries"
+          }
+        }
+      },
+      "VehicleStoryChance": {
+        "label": "Vehicle Story Chance",
+        "description": "Chance of finding story-decorated vehicles.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "ZoneStoryChance": {
+        "label": "Zone Story Chance",
+        "description": "Chance of encountering zone-based story setups.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      }
+    },
+    "zombieLore": {
+      "Speed": {
+        "label": "Zombie Speed",
+        "description": "How fast zombies move.",
+        "options": {
+          "1": {
+            "label": "Sprinters"
+          },
+          "2": {
+            "label": "Fast Shamblers"
+          },
+          "3": {
+            "label": "Shamblers"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Strength": {
+        "label": "Strength",
+        "description": "How strong zombies are.",
+        "options": {
+          "1": {
+            "label": "Superhuman"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Weak"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Toughness": {
+        "label": "Toughness",
+        "description": "How tough zombies are to kill.",
+        "options": {
+          "1": {
+            "label": "Tough"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Fragile"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Transmission": {
+        "label": "Transmission",
+        "description": "How the zombie infection spreads.",
+        "options": {
+          "1": {
+            "label": "Blood and Saliva"
+          },
+          "2": {
+            "label": "Saliva Only"
+          },
+          "3": {
+            "label": "Everyone's Infected"
+          },
+          "4": {
+            "label": "None"
+          }
+        }
+      },
+      "Mortality": {
+        "label": "Infection Mortality",
+        "description": "How deadly the infection is.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0-30 Seconds"
+          },
+          "3": {
+            "label": "0-1 Minutes"
+          },
+          "4": {
+            "label": "0-12 Hours"
+          },
+          "5": {
+            "label": "2-3 Days"
+          },
+          "6": {
+            "label": "1-2 Weeks"
+          },
+          "7": {
+            "label": "Never"
+          }
+        }
+      },
+      "Cognition": {
+        "label": "Cognition",
+        "description": "What zombies can interact with.",
+        "options": {
+          "1": {
+            "label": "Navigate and Use Doors"
+          },
+          "2": {
+            "label": "Navigate"
+          },
+          "3": {
+            "label": "Basic Navigation"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Memory": {
+        "label": "Memory",
+        "description": "How long zombies remember where they last saw a target.",
+        "options": {
+          "1": {
+            "label": "Long"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Short"
+          },
+          "4": {
+            "label": "None"
+          },
+          "5": {
+            "label": "Random"
+          },
+          "6": {
+            "label": "Random between Normal and None"
+          }
+        }
+      },
+      "Sight": {
+        "label": "Sight",
+        "description": "How far zombies can see targets.",
+        "options": {
+          "1": {
+            "label": "Eagle"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Poor"
+          },
+          "4": {
+            "label": "Random"
+          },
+          "5": {
+            "label": "Random between Normal and Poor"
+          }
+        }
+      },
+      "Hearing": {
+        "label": "Hearing",
+        "description": "How well zombies can hear sounds.",
+        "options": {
+          "1": {
+            "label": "Pinpoint"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Poor"
+          },
+          "4": {
+            "label": "Random"
+          },
+          "5": {
+            "label": "Random between Normal and Poor"
+          }
+        }
+      },
+      "SpottedLogic": {
+        "label": "New Stealth System",
+        "description": "How zombies decide to chase their targets."
+      },
+      "ThumpNoChasing": {
+        "label": "Environmental Attacks",
+        "description": "Zombies that weren't chasing a player will not thump constructions."
+      },
+      "ThumpOnConstruction": {
+        "label": "Damage Construction",
+        "description": "Zombies thump player-built structures."
+      },
+      "ActiveOnly": {
+        "label": "Day/Night Zombie Speed Effect",
+        "description": "Zombies active during specific times.",
+        "options": {
+          "1": {
+            "label": "Both"
+          },
+          "2": {
+            "label": "Night"
+          },
+          "3": {
+            "label": "Day"
+          }
+        }
+      },
+      "TriggerHouseAlarm": {
+        "label": "Zombie House Alarm Triggering",
+        "description": "Whether zombies can randomly trigger house alarms."
+      },
+      "ZombiesDragDown": {
+        "label": "Zombies Drag Down",
+        "description": "Multiple zombies can pull player to ground."
+      },
+      "ZombiesCrawlersDragDown": {
+        "label": "Crawlers Drag Down",
+        "description": "Crawlers can drag players down."
+      },
+      "ZombiesFenceLunge": {
+        "label": "Fence Lunge",
+        "description": "Zombies can lunge at you over fences."
+      },
+      "ZombiesArmorFactor": {
+        "label": "Zombies Armor Factor",
+        "description": "Multiplier for zombie armor from clothing. Higher = harder to kill."
+      },
+      "ZombiesMaxDefense": {
+        "label": "Maximum Zombie Armor Defense",
+        "description": "Maximum defense value zombies can have."
+      },
+      "ChanceOfAttachedWeapon": {
+        "label": "Chance Of Attached Weapon",
+        "description": "Chance a zombie has a weapon stuck in them."
+      },
+      "ZombiesFallDamage": {
+        "label": "Zombie Fall Damage Multiplier",
+        "description": "Whether zombies can die from falling."
+      },
+      "DisableFakeDead": {
+        "label": "Fake Dead Zombie Reanimation",
+        "description": "No zombies will pretend to be dead.",
+        "options": {
+          "1": {
+            "label": "World Zombies"
+          },
+          "2": {
+            "label": "World and Combat Zombies"
+          },
+          "3": {
+            "label": "Never"
+          }
+        }
+      },
+      "PlayerSpawnZombieRemoval": {
+        "label": "Spawn Zone Clear",
+        "description": "Distance around spawn points cleared of zombies.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Small"
+          },
+          "3": {
+            "label": "Medium"
+          },
+          "4": {
+            "label": "Large"
+          },
+          "5": {
+            "label": "Very Large"
+          }
+        }
+      },
+      "FenceThumpersRequired": {
+        "label": "Zombies To Damage Fences",
+        "description": "Minimum zombies needed to damage a fence."
+      },
+      "FenceDamageMultiplier": {
+        "label": "Fence Damage Multiplier",
+        "description": "Multiplier for damage zombies do to fences."
+      },
+      "DoorOpeningPercentage": {
+        "label": "Random Door Opening Amount",
+        "description": "Percentage of zombies that can open doors when cognition allows it."
+      },
+      "CrawlUnderVehicle": {
+        "label": "Crawl Under Vehicle",
+        "description": "Crawler zombies can crawl under vehicles.",
+        "options": {
+          "1": {
+            "label": "Crawlers Only"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      },
+      "SprinterPercentage": {
+        "label": "Random Sprinter Amount",
+        "description": "Percentage of sprinter zombies when Speed is set to Random."
+      },
+      "Reanimate": {
+        "label": "Reanimate Time",
+        "description": "Dead zombies can get back up after being killed.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0-30 Seconds"
+          },
+          "3": {
+            "label": "0-1 Minutes"
+          },
+          "4": {
+            "label": "0-12 Hours"
+          },
+          "5": {
+            "label": "2-3 Days"
+          },
+          "6": {
+            "label": "1-2 Weeks"
+          }
+        }
+      }
+    },
+    "zombiePopulation": {
+      "PopulationMultiplier": {
+        "label": "Population Multiplier",
+        "description": "Overall zombie population multiplier."
+      },
+      "PopulationStartMultiplier": {
+        "label": "Start Multiplier",
+        "description": "Zombie population at game start."
+      },
+      "PopulationPeakMultiplier": {
+        "label": "Peak Multiplier",
+        "description": "Zombie population at peak day."
+      },
+      "PopulationPeakDay": {
+        "label": "Peak Day",
+        "description": "Day when zombie population peaks."
+      },
+      "RespawnHours": {
+        "label": "Respawn Hours",
+        "description": "Hours before zombies respawn. 0 = disabled."
+      },
+      "RespawnUnseenHours": {
+        "label": "Unseen Hours",
+        "description": "Hours a chunk must be unseen before respawn."
+      },
+      "RespawnMultiplier": {
+        "label": "Respawn Multiplier",
+        "description": "Fraction of population that respawns."
+      },
+      "RedistributeHours": {
+        "label": "Redistribute Hours",
+        "description": "Hours between zombie redistribution across the map."
+      },
+      "FollowSoundDistance": {
+        "label": "Follow Sound Distance",
+        "description": "How far zombies will follow sounds in cells."
+      },
+      "RallyGroupSize": {
+        "label": "Rally Group Size",
+        "description": "Base number of zombies in rally groups."
+      },
+      "RallyGroupSizeVariance": {
+        "label": "Rally Group Size Variance",
+        "description": "The amount, as a percentage, that zombie groups can vary in size from the default (both larger and smaller)."
+      },
+      "RallyTravelDistance": {
+        "label": "Rally Travel Distance",
+        "description": "How far rally groups travel in cells."
+      },
+      "RallyGroupSeparation": {
+        "label": "Rally Group Separation",
+        "description": "Minimum distance between rally groups."
+      },
+      "RallyGroupRadius": {
+        "label": "Rally Group Radius",
+        "description": "Radius of area a rally group spreads across."
+      },
+      "ZombiesCountBeforeDelete": {
+        "label": "Zombies Count Before Delete",
+        "description": "Minimum zombie count in a cell before deletion can occur."
+      }
+    },
+    "xpMultipliers": {
+      "Global": {
+        "label": "Global XP Multiplier",
+        "description": "The rate at which all skills level up."
+      },
+      "GlobalToggle": {
+        "label": "Use Global Multiplier For All Skills",
+        "description": "When enabled, all skills will use the Global Multiplier instead of individual values."
+      },
+      "Sprinting": {
+        "label": "Sprinting XP",
+        "description": "XP multiplier for Sprinting skill."
+      },
+      "Lightfoot": {
+        "label": "Lightfoot XP",
+        "description": "XP multiplier for Lightfoot skill."
+      },
+      "Nimble": {
+        "label": "Nimble XP",
+        "description": "XP multiplier for Nimble skill."
+      },
+      "Sneak": {
+        "label": "Sneaking XP",
+        "description": "XP multiplier for Sneaking skill."
+      },
+      "Axe": {
+        "label": "Axe XP",
+        "description": "XP multiplier for Axe skill."
+      },
+      "Blunt": {
+        "label": "Blunt XP",
+        "description": "XP multiplier for Blunt skill."
+      },
+      "SmallBlade": {
+        "label": "Small Blade XP",
+        "description": "XP multiplier for Small Blade skill."
+      },
+      "LongBlade": {
+        "label": "Long Blade XP",
+        "description": "XP multiplier for Long Blade skill."
+      },
+      "SmallBlunt": {
+        "label": "Small Blunt XP",
+        "description": "XP multiplier for Small Blunt skill."
+      },
+      "Aiming": {
+        "label": "Aiming XP",
+        "description": "XP multiplier for Aiming skill."
+      },
+      "Reloading": {
+        "label": "Reloading XP",
+        "description": "XP multiplier for Reloading skill."
+      },
+      "Fishing": {
+        "label": "Fishing XP",
+        "description": "XP multiplier for Fishing skill."
+      },
+      "Trapping": {
+        "label": "Trapping XP",
+        "description": "XP multiplier for Trapping skill."
+      },
+      "Woodwork": {
+        "label": "Carpentry XP",
+        "description": "XP multiplier for Carpentry skill."
+      },
+      "Cooking": {
+        "label": "Cooking XP",
+        "description": "XP multiplier for Cooking skill."
+      },
+      "Farming": {
+        "label": "Farming XP",
+        "description": "XP multiplier for Farming skill."
+      },
+      "Doctor": {
+        "label": "First Aid XP",
+        "description": "XP multiplier for First Aid skill."
+      },
+      "Electricity": {
+        "label": "Electricity XP",
+        "description": "XP multiplier for Electricity skill."
+      },
+      "MetalWelding": {
+        "label": "Metalworking XP",
+        "description": "XP multiplier for Metalworking skill."
+      },
+      "Mechanics": {
+        "label": "Mechanics XP",
+        "description": "XP multiplier for Mechanics skill."
+      },
+      "Tailoring": {
+        "label": "Tailoring XP",
+        "description": "XP multiplier for Tailoring skill."
+      },
+      "Maintenance": {
+        "label": "Maintenance XP",
+        "description": "XP multiplier for Maintenance skill."
+      },
+      "PlantScavenging": {
+        "label": "Foraging XP",
+        "description": "XP multiplier for Foraging skill."
+      },
+      "Fitness": {
+        "label": "Fitness XP",
+        "description": "XP multiplier for Fitness skill."
+      },
+      "Strength": {
+        "label": "Strength XP",
+        "description": "XP multiplier for Strength skill."
+      },
+      "FlintKnapping": {
+        "label": "Knapping XP",
+        "description": "XP multiplier for Knapping skill."
+      },
+      "Carving": {
+        "label": "Carving XP",
+        "description": "XP multiplier for Carving skill."
+      },
+      "Tracking": {
+        "label": "Tracking XP",
+        "description": "XP multiplier for Tracking skill."
+      },
+      "Butchering": {
+        "label": "Butchering XP",
+        "description": "XP multiplier for Butchering skill."
+      },
+      "Glassmaking": {
+        "label": "Glassmaking XP",
+        "description": "XP multiplier for Glassmaking skill."
+      },
+      "Husbandry": {
+        "label": "Animal Husbandry XP",
+        "description": "XP multiplier for Animal Husbandry skill."
+      },
+      "Spear": {
+        "label": "Spear XP",
+        "description": "XP multiplier for Spear skill."
+      },
+      "Masonry": {
+        "label": "Masonry XP",
+        "description": "XP multiplier for Masonry skill."
+      },
+      "Pottery": {
+        "label": "Pottery XP",
+        "description": "XP multiplier for Pottery skill."
+      },
+      "Blacksmith": {
+        "label": "Blacksmith XP",
+        "description": "XP multiplier for Blacksmith skill."
+      }
+    },
+    "map": {
+      "AllowMiniMap": {
+        "label": "Allow Mini Map",
+        "description": "Whether the in-game mini map is available."
+      },
+      "AllowWorldMap": {
+        "label": "Allow World Map",
+        "description": "Whether the in-game world map is available."
+      },
+      "MapAllKnown": {
+        "label": "Map All Known",
+        "description": "The entire map is revealed from the start."
+      },
+      "MapNeedsLight": {
+        "label": "Map Needs Light",
+        "description": "Map can only be used when there is enough light."
+      }
+    },
+    "basement": {
+      "SpawnFrequency": {
+        "label": "Basement Spawn Frequency",
+        "description": "How often basements appear in buildings.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Very Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      }
+    }
+  },
+  "iniCategories": {
+    "general": {
+      "label": "General"
+    },
+    "network": {
+      "label": "Network & Ports"
+    },
+    "steam": {
+      "label": "Steam Integration"
+    },
+    "discord": {
+      "label": "Discord"
+    },
+    "rcon": {
+      "label": "RCON"
+    },
+    "voice": {
+      "label": "Voice Chat"
+    },
+    "players": {
+      "label": "Players & Accounts"
+    },
+    "safehouse": {
+      "label": "Safehouses"
+    },
+    "chat": {
+      "label": "Chat & Communication"
+    },
+    "pvp": {
+      "label": "PvP & Safety"
+    },
+    "moderation": {
+      "label": "Moderation"
+    },
+    "anticheat": {
+      "label": "Anti-Cheat"
+    },
+    "loot": {
+      "label": "Loot & Items"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "mods": {
+      "label": "Mods & Workshop"
+    },
+    "radio": {
+      "label": "Radio"
+    },
+    "war": {
+      "label": "Faction War"
+    },
+    "backups": {
+      "label": "Backups"
+    },
+    "logging": {
+      "label": "Logging"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
+  },
+  "iniCategoryGroups": {
+    "identity": {
+      "label": "Identity"
+    },
+    "connectivity": {
+      "label": "Connectivity"
+    },
+    "players": {
+      "label": "Players"
+    },
+    "gameplay": {
+      "label": "Gameplay"
+    },
+    "ops": {
+      "label": "Ops"
+    }
+  },
+  "sandboxCategories": {
+    "time": {
+      "label": "Time & Season"
+    },
+    "environment": {
+      "label": "Environment & Weather"
+    },
+    "world": {
+      "label": "World & Stories"
+    },
+    "map": {
+      "label": "Map & Navigation"
+    },
+    "zombieLore": {
+      "label": "Zombie Behavior"
+    },
+    "zombiePopulation": {
+      "label": "Zombie Population"
+    },
+    "population": {
+      "label": "Population & Distribution"
+    },
+    "survival": {
+      "label": "Survival & Health"
+    },
+    "combat": {
+      "label": "Combat & Firearms"
+    },
+    "loot": {
+      "label": "Loot & Resources"
+    },
+    "lootRarity": {
+      "label": "Loot Rarity"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "animals": {
+      "label": "Animals & Farming"
+    },
+    "xpMultipliers": {
+      "label": "XP Multipliers"
+    },
+    "basement": {
+      "label": "Basements"
+    }
+  },
+  "sandboxCategoryGroups": {
+    "world": {
+      "label": "World"
+    },
+    "zombies": {
+      "label": "Zombies"
+    },
+    "survival": {
+      "label": "Survival"
+    },
+    "resources": {
+      "label": "Resources"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
   }
 }

--- a/client/src/locales/zh-CN/serverconfig.json
+++ b/client/src/locales/zh-CN/serverconfig.json
@@ -386,5 +386,3651 @@
     "title": "恢复此备份？",
     "description": "将当前文件替换为“{{filename}}”？实时配置中未保存的更改将丢失。",
     "confirmLabel": "恢复"
+  },
+  "iniSettings": {
+    "general": {
+      "PublicName": {
+        "label": "服务器公开名称",
+        "description": "显示在 Steam 服务器浏览器中的名称。"
+      },
+      "PublicDescription": {
+        "label": "服务器公开简介",
+        "description": "服务器列表中给玩家看的说明。"
+      },
+      "Public": {
+        "label": "公开服务器",
+        "description": "控制服务器是否出现在 Steam 公共列表。"
+      },
+      "Open": {
+        "label": "无需白名单开放",
+        "description": "开启后未加入白名单的玩家也能尝试进入。"
+      },
+      "Password": {
+        "label": "加入密码",
+        "description": "玩家连接服务器时输入的密码；留空表示无密码。"
+      },
+      "MaxPlayers": {
+        "label": "最大玩家数",
+        "description": "允许同时在线的玩家上限。"
+      },
+      "PauseEmpty": {
+        "label": "无人在线时暂停",
+        "description": "无人在线时停止世界时间推进。"
+      },
+      "ServerWelcomeMessage": {
+        "label": "欢迎消息",
+        "description": "玩家进入后显示的消息；用 <LINE> 换行。"
+      },
+      "Map": {
+        "label": "加载地图",
+        "description": "服务器启动时加载的地图及地图模组顺序。"
+      },
+      "SaveWorldEveryMinutes": {
+        "label": "自动存档间隔",
+        "description": "每隔多少分钟保存世界；0 表示关闭定时存档。"
+      },
+      "AnnounceDeath": {
+        "label": "玩家死亡公告",
+        "description": "角色死亡时向全服发送公告。"
+      },
+      "AnnounceAnimalDeath": {
+        "label": "动物死亡公告",
+        "description": "动物死亡时向全服发送公告。"
+      },
+      "Seed": {
+        "label": "世界种子",
+        "description": "新建世界时影响随机生成结果；已有世界不要随意改。"
+      }
+    },
+    "network": {
+      "DefaultPort": {
+        "label": "游戏主端口",
+        "description": "玩家连接和 Steam 握手使用的主 UDP 端口。"
+      },
+      "UPnP": {
+        "label": "自动端口映射",
+        "description": "尝试通过路由器 UPnP 自动开放端口。"
+      },
+      "PingFrequency": {
+        "label": "延迟检测频率",
+        "description": "服务器每隔多少秒检测一次客户端连接。"
+      },
+      "PingLimit": {
+        "label": "延迟踢出阈值",
+        "description": "玩家延迟超过多少毫秒时处理；源码说明 100 可禁用限制。"
+      },
+      "DenyLoginOnOverloadedServer": {
+        "label": "过载时拒绝登录",
+        "description": "服务器负载过高时阻止新玩家加入。"
+      },
+      "SpeedLimit": {
+        "label": "移动速度上限",
+        "description": "反作弊使用的玩家最大移动速度阈值。"
+      },
+      "UseTCPForMapDownloads": {
+        "label": "地图下载使用 TCP",
+        "description": "将地图数据下载从 UDP 改用 TCP。"
+      },
+      "MaxPacketsPerSecond": {
+        "label": "每秒最大数据包",
+        "description": "单个客户端每秒最多接收的数据包数量。"
+      },
+      "UDPPort": {
+        "label": "第二 UDP 端口",
+        "description": "Build 42 联机额外使用的 UDP 端口，通常为 16262。"
+      },
+      "LoginQueueEnabled": {
+        "label": "启用登录队列",
+        "description": "多人同时进入时启用排队机制。"
+      },
+      "LoginQueueConnectTimeout": {
+        "label": "登录队列超时",
+        "description": "排队连接允许等待的秒数。"
+      },
+      "server_browser_announced_ip": {
+        "label": "服务器公告 IP",
+        "description": "向服务器浏览器公布的外网 IP。"
+      },
+      "MultiplayerStatisticsPeriod": {
+        "label": "多人统计周期",
+        "description": "控制多人统计信息的采样/发送周期。"
+      }
+    },
+    "pvp": {
+      "PVP": {
+        "label": "启用 PvP",
+        "description": "允许玩家互相造成伤害。"
+      },
+      "SafetySystem": {
+        "label": "PvP 安全模式",
+        "description": "PvP 开启时允许玩家切换安全状态。"
+      },
+      "ShowSafety": {
+        "label": "显示安全状态",
+        "description": "显示玩家是否关闭安全模式的图标。"
+      },
+      "SafetyToggleTimer": {
+        "label": "安全模式切换耗时",
+        "description": "切换 PvP 安全状态所需秒数。"
+      },
+      "SafetyCooldownTimer": {
+        "label": "安全模式切换冷却",
+        "description": "两次切换之间必须等待的秒数。"
+      },
+      "PVPMeleeWhileHitReaction": {
+        "label": "受击硬直时允许近战",
+        "description": "PvP 受击硬直期间仍可发起近战攻击。"
+      },
+      "PVPMeleeDamageModifier": {
+        "label": "PvP 近战伤害百分比",
+        "description": "玩家对玩家近战伤害倍率百分比。"
+      },
+      "PVPFirearmDamageModifier": {
+        "label": "PvP 枪械伤害百分比",
+        "description": "玩家对玩家枪械伤害倍率百分比。"
+      },
+      "PlayerBumpPlayer": {
+        "label": "玩家碰撞",
+        "description": "玩家之间可以互相挤碰。"
+      },
+      "PVPLogToolChat": {
+        "label": "PvP 记录到聊天",
+        "description": "将 PvP 事件输出到管理聊天。"
+      },
+      "PVPLogToolFile": {
+        "label": "PvP 记录到文件",
+        "description": "将 PvP 事件写入日志文件。"
+      },
+      "SafetyDisconnectDelay": {
+        "label": "关闭安全模式后的退出延迟",
+        "description": "玩家关闭安全模式后需等待多久才能安全退出。"
+      }
+    },
+    "chat": {
+      "GlobalChat": {
+        "label": "启用全局聊天",
+        "description": "允许使用 /all 全服聊天。"
+      },
+      "ChatStreams": {
+        "label": "启用的聊天频道",
+        "description": "控制 say、radio、admin、whisper、yell、安全屋、阵营、全局频道。"
+      },
+      "DisplayUserName": {
+        "label": "显示用户名",
+        "description": "在人物头顶和聊天中显示账号名。"
+      },
+      "ShowFirstAndLastName": {
+        "label": "显示角色姓名",
+        "description": "优先显示角色名而不是账号名。"
+      },
+      "MouseOverToSeeDisplayName": {
+        "label": "悬停才显示名称",
+        "description": "鼠标移到角色上时才显示名字。"
+      },
+      "HidePlayersBehindYou": {
+        "label": "隐藏身后玩家名称",
+        "description": "看不见身后角色时也隐藏其名字。"
+      },
+      "AllowNonAsciiUsername": {
+        "label": "允许非 ASCII 用户名",
+        "description": "允许中文等非 ASCII 字符出现在用户名中。"
+      },
+      "BanKickGlobalSound": {
+        "label": "封禁/踢出全局音效",
+        "description": "执行封禁或踢出时播放全服音效。"
+      },
+      "UsernameDisguises": {
+        "label": "允许用户名伪装",
+        "description": "允许玩家使用伪装名称。"
+      },
+      "HideDisguisedUserName": {
+        "label": "隐藏被伪装的真实用户名",
+        "description": "启用伪装后不显示真实账号名。"
+      },
+      "ChatMessageCharacterLimit": {
+        "label": "聊天字数上限",
+        "description": "单条聊天消息允许的最大字符数。"
+      },
+      "ChatMessageSlowModeTime": {
+        "label": "聊天慢速模式",
+        "description": "玩家连续发言之间的最短秒数。"
+      }
+    },
+    "players": {
+      "MaxAccountsPerUser": {
+        "label": "每位 Steam 用户最大账号数",
+        "description": "限制一个 Steam 用户能创建的服务器账号数量；0 不限。"
+      },
+      "DropOffWhiteListAfterDeath": {
+        "label": "死亡后移出白名单",
+        "description": "角色死亡后自动删除该玩家的白名单资格。"
+      },
+      "KickFastPlayers": {
+        "label": "踢出异常高速玩家",
+        "description": "检测并踢出速度异常的玩家；上游注明可能误判。"
+      },
+      "SpawnPoint": {
+        "label": "固定出生坐标",
+        "description": "自定义出生坐标 X,Y,Z；0,0,0 使用默认出生规则。"
+      },
+      "SpawnItems": {
+        "label": "新角色出生物品",
+        "description": "新角色获得的物品类型，以英文逗号分隔。"
+      },
+      "SleepAllowed": {
+        "label": "允许睡眠",
+        "description": "允许多人游戏中的角色睡觉。"
+      },
+      "SleepNeeded": {
+        "label": "必须睡眠",
+        "description": "开启后角色会因疲劳需要睡眠。"
+      },
+      "PlayerRespawnWithSelf": {
+        "label": "在死亡地点重生",
+        "description": "允许玩家新角色在自己的死亡地点附近出生。"
+      },
+      "PlayerRespawnWithOther": {
+        "label": "在同伴附近重生",
+        "description": "允许分屏/合作玩家在同伴位置出生。"
+      },
+      "PlayerSaveOnDamage": {
+        "label": "受伤时保存玩家",
+        "description": "角色受到伤害时立即保存玩家状态。"
+      },
+      "Faction": {
+        "label": "启用阵营",
+        "description": "允许玩家创建和使用阵营。"
+      },
+      "FactionDaySurvivedToCreate": {
+        "label": "创建阵营所需生存天数",
+        "description": "玩家至少生存多少天才能创建阵营。"
+      },
+      "FactionPlayersRequiredForTag": {
+        "label": "显示阵营标签所需人数",
+        "description": "阵营达到多少成员后显示标签。"
+      },
+      "AllowTradeUI": {
+        "label": "允许玩家交易",
+        "description": "开放玩家之间的直接交易界面。"
+      },
+      "AllowCoop": {
+        "label": "允许合作模式",
+        "description": "允许合作/分屏相关联机功能。"
+      },
+      "KnockedDownAllowed": {
+        "label": "允许击倒玩家",
+        "description": "控制玩家是否会被其他玩家撞倒/击倒。"
+      },
+      "SneakModeHideFromOtherPlayers": {
+        "label": "潜行时对玩家隐藏",
+        "description": "潜行状态下减少其他玩家对角色的可见性。"
+      },
+      "MapRemotePlayerVisibility": {
+        "label": "地图上的远程玩家可见性",
+        "description": "控制世界地图上其他玩家的位置显示范围。",
+        "options": {
+          "1": {
+            "label": "隐藏"
+          },
+          "2": {
+            "label": "仅好友"
+          },
+          "3": {
+            "label": "好友和附近玩家"
+          },
+          "4": {
+            "label": "所有人"
+          }
+        }
+      },
+      "DisableScoreboard": {
+        "label": "禁用玩家列表",
+        "description": "关闭游戏内玩家/计分板列表。"
+      },
+      "HideAdminsInPlayerList": {
+        "label": "玩家列表隐藏管理员",
+        "description": "普通玩家列表中不显示管理员。"
+      }
+    },
+    "safehouse": {
+      "PlayerSafehouse": {
+        "label": "允许玩家认领安全屋",
+        "description": "开放普通玩家的安全屋认领。"
+      },
+      "AdminSafehouse": {
+        "label": "允许管理员安全屋",
+        "description": "允许管理员拥有或认领安全屋。"
+      },
+      "SafehouseAllowTrepass": {
+        "label": "允许闯入安全屋",
+        "description": "允许非成员进入安全屋。"
+      },
+      "SafehouseAllowFire": {
+        "label": "安全屋允许火焰伤害",
+        "description": "允许火焰破坏安全屋区域。"
+      },
+      "SafehouseAllowLoot": {
+        "label": "允许搜刮安全屋",
+        "description": "允许非成员拿取安全屋内物品。"
+      },
+      "SafehouseAllowRespawn": {
+        "label": "允许在安全屋重生",
+        "description": "安全屋成员死亡后可以选择安全屋出生。"
+      },
+      "SafehouseDaySurvivedToClaim": {
+        "label": "认领安全屋所需天数",
+        "description": "玩家需生存多少游戏日后才能认领。"
+      },
+      "SafeHouseRemovalTime": {
+        "label": "安全屋回收时间",
+        "description": "成员离线多少现实小时后自动解除安全屋；0 通常表示不回收。"
+      },
+      "DisableSafehouseWhenOwnerConnected": {
+        "label": "屋主在线时取消保护",
+        "description": "屋主在线时临时关闭安全屋保护。"
+      },
+      "SafehouseAllowNonResidential": {
+        "label": "允许非住宅安全屋",
+        "description": "允许仓库、商店等非住宅建筑被认领。"
+      },
+      "SafehouseDisableDisguises": {
+        "label": "安全屋内禁用伪装",
+        "description": "进入安全屋时不允许用户名伪装。"
+      },
+      "MaxSafezoneSize": {
+        "label": "最大安全区面积",
+        "description": "限制安全区/安全屋可覆盖的最大范围。"
+      }
+    },
+    "loot": {
+      "ItemNumbersLimitPerContainer": {
+        "label": "容器物品数量上限",
+        "description": "单个容器允许的物品条目上限；0 不限。"
+      },
+      "TrashDeleteAll": {
+        "label": "垃圾桶立即删除",
+        "description": "放入垃圾容器的物品可被直接清空。"
+      },
+      "RemovePlayerCorpsesOnCorpseRemoval": {
+        "label": "清理玩家尸体",
+        "description": "尸体清理任务是否包括玩家尸体。"
+      },
+      "AllowDestructionBySledgehammer": {
+        "label": "允许大锤拆除",
+        "description": "允许玩家用大锤破坏世界物件。"
+      },
+      "NoFire": {
+        "label": "禁用普通火焰",
+        "description": "除营火外禁止其他火焰。"
+      },
+      "SafehousePreventsLootRespawn": {
+        "label": "安全屋阻止物资刷新",
+        "description": "安全屋范围内的容器不会刷新战利品。"
+      },
+      "SledgehammerOnlyInSafehouse": {
+        "label": "只在安全屋内允许大锤",
+        "description": "把大锤拆除限制在玩家自己的安全屋。"
+      }
+    },
+    "mods": {
+      "Mods": {
+        "label": "启用的 MOD ID",
+        "description": "分号分隔的 Mod ID 列表；不是 Workshop 数字 ID。"
+      },
+      "WorkshopItems": {
+        "label": "创意工坊物品 ID",
+        "description": "分号分隔的 Steam Workshop 数字 ID 列表。"
+      },
+      "DoLuaChecksum": {
+        "label": "Lua 文件校验",
+        "description": "检查客户端与服务端 Lua 是否一致；使用 PanelBridge 时必须关闭。"
+      }
+    },
+    "steam": {
+      "SteamPort1": {
+        "label": "Steam 端口 1",
+        "description": "Steam 服务通信使用的第一个端口。"
+      },
+      "SteamPort2": {
+        "label": "Steam 端口 2",
+        "description": "Steam 服务通信使用的第二个端口。"
+      },
+      "SteamScoreboard": {
+        "label": "Steam 计分板可见范围",
+        "description": "控制谁能看到 Steam 用户名和头像。",
+        "options": {
+          "true": {
+            "label": "所有人"
+          },
+          "false": {
+            "label": "无人"
+          },
+          "admin": {
+            "label": "仅管理员"
+          }
+        }
+      },
+      "SteamVAC": {
+        "label": "Steam VAC 检查",
+        "description": "检查加入玩家是否受 VAC 反作弊封禁。"
+      }
+    },
+    "voice": {
+      "VoiceEnable": {
+        "label": "启用游戏内语音",
+        "description": "允许玩家使用游戏内语音聊天。"
+      },
+      "Voice3D": {
+        "label": "3D 方位语音",
+        "description": "按玩家位置和方向计算语音效果。"
+      },
+      "VoiceMinDistance": {
+        "label": "语音最小距离",
+        "description": "近距离语音的最小衰减距离。"
+      },
+      "VoiceMaxDistance": {
+        "label": "语音最大距离",
+        "description": "超过该距离将听不到玩家语音。"
+      }
+    },
+    "discord": {
+      "DiscordEnable": {
+        "label": "启用 Discord 集成",
+        "description": "开启游戏内置 Discord 机器人集成。"
+      },
+      "DiscordToken": {
+        "label": "Discord 机器人令牌",
+        "description": "Discord Bot Token，属于敏感凭据。"
+      },
+      "DiscordChannel": {
+        "label": "Discord 频道名",
+        "description": "旧式 Discord 集成使用的频道名称。"
+      },
+      "DiscordChannelID": {
+        "label": "Discord 频道 ID",
+        "description": "Discord 目标频道的数字 ID。"
+      },
+      "DiscordChatChannel": {
+        "label": "Discord 聊天频道",
+        "description": "转发普通聊天的 Discord 频道。"
+      },
+      "DiscordLogChannel": {
+        "label": "Discord 日志频道",
+        "description": "发送服务器日志的 Discord 频道。"
+      },
+      "DiscordCommandChannel": {
+        "label": "Discord 命令频道",
+        "description": "接受管理命令的 Discord 频道。"
+      },
+      "WebhookAddress": {
+        "label": "Webhook 地址",
+        "description": "向外部服务推送事件的 Webhook URL。"
+      }
+    },
+    "rcon": {
+      "RCONPort": {
+        "label": "RCON 端口",
+        "description": "面板远程控制游戏服务器使用的 TCP 端口。"
+      },
+      "RCONPassword": {
+        "label": "RCON 密码",
+        "description": "面板连接游戏服务器的远程控制密码。"
+      }
+    },
+    "advanced": {
+      "ResetID": {
+        "label": "世界重置 ID",
+        "description": "删除或改变它会重置僵尸和战利品，但不会重置时间。"
+      },
+      "ServerPlayerID": {
+        "label": "服务器玩家 ID",
+        "description": "用于判断角色是否来自另一个服务器。"
+      },
+      "PhysicsDelay": {
+        "label": "物理更新延迟",
+        "description": "物理系统更新间隔，单位毫秒。"
+      },
+      "FastForwardMultiplier": {
+        "label": "快进倍率",
+        "description": "睡眠等快进状态下的时间加速倍率。"
+      },
+      "CarEngineAttractionModifier": {
+        "label": "引擎吸引僵尸倍率",
+        "description": "车辆引擎噪声吸引僵尸的倍率。"
+      },
+      "ZombieUpdateMaxHighPriority": {
+        "label": "高优先级僵尸更新上限",
+        "description": "每次更新可处理的高优先级僵尸数量。"
+      },
+      "ZombieUpdateDelta": {
+        "label": "僵尸更新间隔",
+        "description": "僵尸状态同步/更新的时间步长。"
+      },
+      "SwitchZombiesOwnershipEachUpdate": {
+        "label": "每次更新切换僵尸归属",
+        "description": "在玩家客户端之间频繁重新分配僵尸模拟归属。"
+      },
+      "UltraSpeedDoesnotAffectToAnimals": {
+        "label": "超高速不影响动物",
+        "description": "服务器快进时不加速动物模拟。"
+      },
+      "UsePhysicsHitReaction": {
+        "label": "物理受击反应",
+        "description": "使用基于物理的受击反馈。"
+      }
+    },
+    "war": {
+      "War": {
+        "label": "启用阵营战争",
+        "description": "允许阵营之间发起战争。"
+      },
+      "WarStartDelay": {
+        "label": "战争开始延迟",
+        "description": "宣战后等待多少秒正式开始。"
+      },
+      "WarDuration": {
+        "label": "战争持续时间",
+        "description": "阵营战争持续的秒数。"
+      },
+      "WarSafehouseHitPoints": {
+        "label": "战争安全屋耐久",
+        "description": "战争期间安全屋可承受的攻击次数。"
+      }
+    },
+    "radio": {
+      "DisableRadioStaff": {
+        "label": "对工作人员禁用无线电",
+        "description": "禁止 staff 权限角色使用无线电。"
+      },
+      "DisableRadioAdmin": {
+        "label": "对管理员禁用无线电",
+        "description": "禁止 admin 权限角色使用无线电。"
+      },
+      "DisableRadioGM": {
+        "label": "对 GM 禁用无线电",
+        "description": "禁止 GM 权限角色使用无线电。"
+      },
+      "DisableRadioOverseer": {
+        "label": "对监督员禁用无线电",
+        "description": "禁止 overseer 权限角色使用无线电。"
+      },
+      "DisableRadioModerator": {
+        "label": "对版主禁用无线电",
+        "description": "禁止 moderator 权限角色使用无线电。"
+      },
+      "DisableRadioInvisible": {
+        "label": "对隐身人员禁用无线电",
+        "description": "禁止隐身管理人员使用无线电。"
+      }
+    },
+    "backups": {
+      "BackupsCount": {
+        "label": "备份保留份数",
+        "description": "游戏自身循环保留的备份数量。"
+      },
+      "BackupsOnStart": {
+        "label": "启动时备份",
+        "description": "每次服务器启动前创建备份。"
+      },
+      "BackupsOnVersionChange": {
+        "label": "版本变化时备份",
+        "description": "检测到游戏版本变化时创建备份。"
+      },
+      "BackupsPeriod": {
+        "label": "定时备份周期",
+        "description": "游戏自身定时备份的分钟数；0 表示关闭。"
+      }
+    },
+    "vehicles": {
+      "DisableVehicleTowing": {
+        "label": "禁用车辆拖拽",
+        "description": "禁止车辆拖曳其他车辆。"
+      },
+      "DisableTrailerTowing": {
+        "label": "禁用拖车拖拽",
+        "description": "禁止拖曳挂车。"
+      },
+      "DisableBurntTowing": {
+        "label": "禁用烧毁车辆拖拽",
+        "description": "禁止拖曳烧毁的车辆。"
+      }
+    },
+    "moderation": {
+      "BadWordListFile": {
+        "label": "屏蔽词文件",
+        "description": "指定需要过滤的词语列表文件。"
+      },
+      "GoodWordListFile": {
+        "label": "白名单词文件",
+        "description": "指定过滤器允许通过的例外词语文件。"
+      },
+      "BadWordPolicy": {
+        "label": "敏感词处理策略",
+        "description": "选择记录、替换或禁用敏感词过滤。",
+        "options": {
+          "1": {
+            "label": "封禁"
+          },
+          "2": {
+            "label": "踢出"
+          },
+          "3": {
+            "label": "仅记录违规"
+          },
+          "4": {
+            "label": "禁言"
+          }
+        }
+      },
+      "BadWordReplacement": {
+        "label": "敏感词替换文字",
+        "description": "命中敏感词后显示的替代文本。"
+      }
+    },
+    "anticheat": {
+      "AntiCheatSafety": {
+        "label": "安全模式反作弊",
+        "description": "控制安全模式反作弊的处理策略：1 封禁、2 踢出、3 仅记录、4 禁用。",
+        "options": {
+          "1": {
+            "label": "封禁"
+          },
+          "2": {
+            "label": "踢出"
+          },
+          "3": {
+            "label": "仅记录"
+          },
+          "4": {
+            "label": "禁用"
+          }
+        }
+      },
+      "AntiCheatSpeed": {
+        "label": "移动速度反作弊",
+        "description": "控制移动速度反作弊的处理策略：1 封禁、2 踢出、3 仅记录、4 禁用。",
+        "options": {
+          "1": {
+            "label": "封禁"
+          },
+          "2": {
+            "label": "踢出"
+          },
+          "3": {
+            "label": "仅记录"
+          },
+          "4": {
+            "label": "禁用"
+          }
+        }
+      },
+      "AntiCheatNoClip": {
+        "label": "穿墙反作弊",
+        "description": "控制穿墙反作弊的处理策略：1 封禁、2 踢出、3 仅记录、4 禁用。",
+        "options": {
+          "1": {
+            "label": "封禁"
+          },
+          "2": {
+            "label": "踢出"
+          },
+          "3": {
+            "label": "仅记录"
+          },
+          "4": {
+            "label": "禁用"
+          }
+        }
+      },
+      "AntiCheatHit": {
+        "label": "命中检测反作弊",
+        "description": "控制命中检测反作弊的处理策略：1 封禁、2 踢出、3 仅记录、4 禁用。",
+        "options": {
+          "1": {
+            "label": "封禁"
+          },
+          "2": {
+            "label": "踢出"
+          },
+          "3": {
+            "label": "仅记录"
+          },
+          "4": {
+            "label": "禁用"
+          }
+        }
+      },
+      "AntiCheatPacketException": {
+        "label": "异常数据包反作弊",
+        "description": "控制异常数据包反作弊的处理策略：1 封禁、2 踢出、3 仅记录、4 禁用。",
+        "options": {
+          "1": {
+            "label": "封禁"
+          },
+          "2": {
+            "label": "踢出"
+          },
+          "3": {
+            "label": "仅记录"
+          },
+          "4": {
+            "label": "禁用"
+          }
+        }
+      },
+      "AntiCheatPermission": {
+        "label": "权限反作弊",
+        "description": "控制权限反作弊的处理策略：1 封禁、2 踢出、3 仅记录、4 禁用。",
+        "options": {
+          "1": {
+            "label": "封禁"
+          },
+          "2": {
+            "label": "踢出"
+          },
+          "3": {
+            "label": "仅记录"
+          },
+          "4": {
+            "label": "禁用"
+          }
+        }
+      },
+      "AntiCheatXP": {
+        "label": "经验值反作弊",
+        "description": "控制经验值反作弊的处理策略：1 封禁、2 踢出、3 仅记录、4 禁用。",
+        "options": {
+          "1": {
+            "label": "封禁"
+          },
+          "2": {
+            "label": "踢出"
+          },
+          "3": {
+            "label": "仅记录"
+          },
+          "4": {
+            "label": "禁用"
+          }
+        }
+      },
+      "AntiCheatSafeHouse": {
+        "label": "安全屋反作弊",
+        "description": "控制安全屋反作弊的处理策略：1 封禁、2 踢出、3 仅记录、4 禁用。",
+        "options": {
+          "1": {
+            "label": "封禁"
+          },
+          "2": {
+            "label": "踢出"
+          },
+          "3": {
+            "label": "仅记录"
+          },
+          "4": {
+            "label": "禁用"
+          }
+        }
+      },
+      "AntiCheatPlayer": {
+        "label": "玩家行为反作弊",
+        "description": "控制玩家行为反作弊的处理策略：1 封禁、2 踢出、3 仅记录、4 禁用。",
+        "options": {
+          "1": {
+            "label": "封禁"
+          },
+          "2": {
+            "label": "踢出"
+          },
+          "3": {
+            "label": "仅记录"
+          },
+          "4": {
+            "label": "禁用"
+          }
+        }
+      },
+      "AntiCheatChecksum": {
+        "label": "文件校验反作弊",
+        "description": "控制文件校验反作弊的处理策略：1 封禁、2 踢出、3 仅记录、4 禁用。",
+        "options": {
+          "1": {
+            "label": "封禁"
+          },
+          "2": {
+            "label": "踢出"
+          },
+          "3": {
+            "label": "仅记录"
+          },
+          "4": {
+            "label": "禁用"
+          }
+        }
+      }
+    },
+    "logging": {
+      "ClientCommandFilter": {
+        "label": "命令日志过滤器",
+        "description": "用分号和 +/- 规则控制 cmd.txt 中记录哪些客户端命令。"
+      },
+      "ClientActionLogs": {
+        "label": "客户端动作日志",
+        "description": "指定写入 ClientActionLogs.txt 的动作名称。"
+      },
+      "PerkLogs": {
+        "label": "技能等级日志",
+        "description": "把玩家技能等级变化写入 PerkLog.txt。"
+      }
+    }
+  },
+  "sandboxSettings": {
+    "time": {
+      "DayLength": {
+        "label": "一天长度",
+        "description": "一天在现实时间中持续多久。",
+        "options": {
+          "1": {
+            "label": "15 分钟"
+          },
+          "2": {
+            "label": "30 分钟"
+          },
+          "3": {
+            "label": "1 小时"
+          },
+          "4": {
+            "label": "1 小时 30 分钟"
+          },
+          "5": {
+            "label": "2 小时"
+          },
+          "6": {
+            "label": "3 小时"
+          },
+          "7": {
+            "label": "4 小时"
+          },
+          "8": {
+            "label": "5 小时"
+          },
+          "9": {
+            "label": "6 小时"
+          },
+          "10": {
+            "label": "7 小时"
+          },
+          "11": {
+            "label": "8 小时"
+          },
+          "12": {
+            "label": "9 小时"
+          },
+          "13": {
+            "label": "10 小时"
+          },
+          "14": {
+            "label": "11 小时"
+          },
+          "15": {
+            "label": "12 小时"
+          },
+          "16": {
+            "label": "13 小时"
+          },
+          "17": {
+            "label": "14 小时"
+          },
+          "18": {
+            "label": "15 小时"
+          },
+          "19": {
+            "label": "16 小时"
+          },
+          "20": {
+            "label": "17 小时"
+          },
+          "21": {
+            "label": "18 小时"
+          },
+          "22": {
+            "label": "19 小时"
+          },
+          "23": {
+            "label": "20 小时"
+          },
+          "24": {
+            "label": "21 小时"
+          },
+          "25": {
+            "label": "22 小时"
+          },
+          "26": {
+            "label": "23 小时"
+          },
+          "27": {
+            "label": "24 小时"
+          }
+        }
+      },
+      "StartYear": {
+        "label": "开局年份",
+        "description": "游戏开始的年份。"
+      },
+      "StartMonth": {
+        "label": "开局月份",
+        "description": "游戏开始的月份。",
+        "options": {
+          "1": {
+            "label": "一月"
+          },
+          "2": {
+            "label": "二月"
+          },
+          "3": {
+            "label": "三月"
+          },
+          "4": {
+            "label": "四月"
+          },
+          "5": {
+            "label": "五月"
+          },
+          "6": {
+            "label": "六月"
+          },
+          "7": {
+            "label": "七月"
+          },
+          "8": {
+            "label": "八月"
+          },
+          "9": {
+            "label": "九月"
+          },
+          "10": {
+            "label": "十月"
+          },
+          "11": {
+            "label": "十一月"
+          },
+          "12": {
+            "label": "十二月"
+          }
+        }
+      },
+      "StartDay": {
+        "label": "开局日子",
+        "description": "游戏开始的月份中的日期。"
+      },
+      "StartTime": {
+        "label": "开局时间",
+        "description": "游戏开始的当天小时数。",
+        "options": {
+          "1": {
+            "label": "早上 7 点"
+          },
+          "2": {
+            "label": "早上 9 点"
+          },
+          "3": {
+            "label": "中午 12 点"
+          },
+          "4": {
+            "label": "下午 2 点"
+          },
+          "5": {
+            "label": "下午 5 点"
+          },
+          "6": {
+            "label": "晚上 9 点"
+          },
+          "7": {
+            "label": "凌晨 12 点"
+          },
+          "8": {
+            "label": "深夜 2 点"
+          },
+          "9": {
+            "label": "早晨 5 点"
+          }
+        }
+      }
+    },
+    "population": {
+      "Zombies": {
+        "label": "僵尸数量",
+        "description": "修改此项会改变高级设置中\"人口倍率\"的设定。",
+        "options": {
+          "1": {
+            "label": "疯狂"
+          },
+          "2": {
+            "label": "非常多"
+          },
+          "3": {
+            "label": "多"
+          },
+          "4": {
+            "label": "普通"
+          },
+          "5": {
+            "label": "少"
+          },
+          "6": {
+            "label": "没有"
+          }
+        }
+      },
+      "Distribution": {
+        "label": "僵尸分布",
+        "description": "僵尸如何在地图上分布。",
+        "options": {
+          "1": {
+            "label": "城镇集中"
+          },
+          "2": {
+            "label": "各地分散"
+          }
+        }
+      },
+      "ZombieVoronoiNoise": {
+        "label": "随机噪声分布",
+        "description": "控制是否对僵尸分布应用随机化算法。"
+      },
+      "ZombieRespawn": {
+        "label": "僵尸刷新",
+        "description": "这将改变游戏中僵尸刷新的时间。",
+        "options": {
+          "1": {
+            "label": "高"
+          },
+          "2": {
+            "label": "普通"
+          },
+          "3": {
+            "label": "低"
+          },
+          "4": {
+            "label": "无"
+          }
+        }
+      },
+      "ZombieMigrate": {
+        "label": "僵尸迁移",
+        "description": "允许僵尸迁移到空区块。"
+      }
+    },
+    "loot": {
+      "LootItemRemovalList": {
+        "label": "物品物品移除列表",
+        "description": "一个逗号分隔的物品类型列表， 这些物品不会作为普通物品生成。"
+      },
+      "FoodLootNew": {
+        "label": "易腐烂食物",
+        "description": "所有会腐烂变质的食物。"
+      },
+      "CannedFoodLootNew": {
+        "label": "不易腐烂食物",
+        "description": "罐头和脱水食品， 饮料。"
+      },
+      "LiteratureLootNew": {
+        "label": "其他书籍",
+        "description": "其他能读的东西， 包括书， 传单和报纸。"
+      },
+      "SkillBookLoot": {
+        "label": "技能书",
+        "description": "提供经验倍率的书。"
+      },
+      "RecipeResourceLoot": {
+        "label": "配方书",
+        "description": "教配方的书。"
+      },
+      "MedicalLootNew": {
+        "label": "医疗",
+        "description": "药品， 绷带和急救工具。"
+      },
+      "SurvivalGearsLootNew": {
+        "label": "生存必需品",
+        "description": "鱼竿， 帐篷， 野营装备等。"
+      },
+      "WeaponLootNew": {
+        "label": "近战武器",
+        "description": "不属于其他类别的武器。"
+      },
+      "RangedWeaponLootNew": {
+        "label": "远程武器",
+        "description": "还包括武器配件。"
+      },
+      "AmmoLootNew": {
+        "label": "弹药",
+        "description": "散装弹药， 盒装弹药和弹匣。"
+      },
+      "MechanicsLootNew": {
+        "label": "机械",
+        "description": "车辆零件及安装工具。"
+      },
+      "ClothingLootNew": {
+        "label": "服装",
+        "description": "所有非容器的可穿戴物品。"
+      },
+      "ContainerLootNew": {
+        "label": "背包",
+        "description": "背包和其他可穿戴/可装备的容器， 例如箱子。"
+      },
+      "KeyLootNew": {
+        "label": "钥匙",
+        "description": "建筑物/汽车的钥匙， 钥匙圈和锁。"
+      },
+      "MediaLootNew": {
+        "label": "媒体",
+        "description": "录像带和 CD。"
+      },
+      "MementoLootNew": {
+        "label": "纪念品",
+        "description": "精美物品， 毛绒玩具和其他可收藏的纪念品， 例如照片。"
+      },
+      "CookwareLootNew": {
+        "label": "烹饪",
+        "description": "用于烹饪的物品， 包括那些可以作为武器的物品 (例如， 刀)。 不包括食物。 包括可用和不可用的物品。"
+      },
+      "MaterialLootNew": {
+        "label": "材料",
+        "description": "用于制作或建筑的物品和武器。 这是一个通用类别， 不包括属于其他类别的物品， 如烹饪用具或医疗用品。 不包括工具。"
+      },
+      "FarmingLootNew": {
+        "label": "农业",
+        "description": "用于动植物农业的物品和武器， 例如种子， 小铲子或铁锹。"
+      },
+      "ToolLootNew": {
+        "label": "工具",
+        "description": "属于工具的物品和武器， 但不包括机械或农业等其他类别。"
+      },
+      "OtherLootNew": {
+        "label": "其他",
+        "description": "其他所有物品。 同样影响城镇/道路区域的所有物品的搜寻。"
+      },
+      "RollsMultiplier": {
+        "label": "掷骰子倍率 [!]",
+        "description": "[!] 建议不要更改此设置。 [!] 可用于调整生成物品时在物品表上进行的掷骰子次数。 不会将掷骰子次数减少到 1 以下。 如果设置为高值， 可能会对性能产生负面影响。 强烈建议不要更改此设置。"
+      },
+      "RemoveStoryLoot": {
+        "label": "移除不需要的故事物品",
+        "description": "如果启用， 物品物品移除列表上的物品， 或者将稀有度设置为'无'的物品， 将不会在随机世界故事中生成。"
+      },
+      "RemoveZombieLoot": {
+        "label": "移除不需要的僵尸物品",
+        "description": "如果启用， 物品物品移除列表上的物品， 或者将稀有度设置为\"无\"的物品， 将不会穿戴在僵尸身上， 或附着在僵尸上。"
+      },
+      "ZombiePopLootEffect": {
+        "label": "僵尸数量物品影响",
+        "description": "如果大于 0， 物品的生成将根据附近僵尸的数量增加， 效果将乘以这个数字。"
+      },
+      "HoursForLootRespawn": {
+        "label": "物品刷新小时数",
+        "description": "如果此参数大于 0， 在 X 小时后， 世界上城镇和拖车公园中的所有容器将重新生成物品。 要生成物品， 容器必须至少被搜刮过一次。 物品刷新不受可见性或后续搜刮的影响。"
+      },
+      "MaxItemsForLootRespawn": {
+        "label": "最大物品刷新数量",
+        "description": "当容器中的物品数量大于或等于此设置时， 将不会刷新。"
+      },
+      "ConstructionPreventsLootRespawn": {
+        "label": "玩家建筑阻止物品刷新",
+        "description": "玩家加固或建造的建筑物中的物品将不会刷新。"
+      },
+      "SeenHoursPreventLootRespawn": {
+        "label": "物品重生阻止时间",
+        "description": "当 > 0时，物品将不会在此小时内访问过的区域中重新生成。"
+      }
+    },
+    "lootRarity": {
+      "InsaneLootFactor": {
+        "label": "战利品极度罕见",
+        "description": "极度罕见物品的生成倍率。"
+      },
+      "ExtremeLootFactor": {
+        "label": "战利品特别稀少",
+        "description": "特别稀少物品的生成倍率。"
+      },
+      "RareLootFactor": {
+        "label": "战利品很少",
+        "description": "稀有物品的生成倍率。"
+      },
+      "NormalLootFactor": {
+        "label": "战利品正常",
+        "description": "普通物品的生成倍率。"
+      },
+      "CommonLootFactor": {
+        "label": "战利品常见",
+        "description": "常见物品的生成倍率。"
+      },
+      "AbundantLootFactor": {
+        "label": "战利品非常丰富",
+        "description": "丰富物品的生成倍率。"
+      },
+      "MaximumLooted": {
+        "label": "最大被掠夺建筑几率",
+        "description": "任何建筑在被发现时已经被掠夺的几率。 勾选下方的\"高级\"选项以使用自定义数字。"
+      },
+      "DaysUntilMaximumLooted": {
+        "label": "达到最大被掠夺建筑几率的天数",
+        "description": "达到最大被掠夺建筑几率所需的时间。"
+      },
+      "RuralLooted": {
+        "label": "乡村建筑被掠夺几率倍率",
+        "description": "任何乡村建筑在被发现时已经被掠夺的几率。 勾选下方的\"高级\"选项以使用自定义数字。"
+      },
+      "MaximumDiminishedLoot": {
+        "label": "最大减少物品百分比",
+        "description": "当达到最大减少物品天数时， 将不会生成的最大物品。 勾选下方的\"高级\"选项以使用确切的百分比。"
+      },
+      "DaysUntilMaximumDiminishedLoot": {
+        "label": "达到最大减少物品的天数",
+        "description": "达到最大减少物品所需的天数。"
+      },
+      "MaximumLootedBuildingRooms": {
+        "label": "最大已掠夺建筑房间数",
+        "description": "若建筑物的房间数量超过此数值， 则不会被掠夺。"
+      }
+    },
+    "environment": {
+      "DayNightCycle": {
+        "label": "昼夜循环模式",
+        "description": "控制游戏内时间是否自然流逝， 或保持永昼/永夜状态。",
+        "options": {
+          "1": {
+            "label": "正常循环"
+          },
+          "2": {
+            "label": "永昼模式"
+          },
+          "3": {
+            "label": "永夜模式"
+          }
+        }
+      },
+      "ClimateCycle": {
+        "label": "气候循环模式",
+        "description": "控制天气是否动态变化或保持固定状态。",
+        "options": {
+          "1": {
+            "label": "正常气候"
+          },
+          "2": {
+            "label": "无天气变化"
+          },
+          "3": {
+            "label": "无尽雨天"
+          },
+          "4": {
+            "label": "无尽暴风雨"
+          },
+          "5": {
+            "label": "无尽雪天"
+          },
+          "6": {
+            "label": "无尽暴风雪"
+          }
+        }
+      },
+      "FogCycle": {
+        "label": "雾气循环模式",
+        "description": "控制雾气是否自然生成， 永不出现或持续存在。",
+        "options": {
+          "1": {
+            "label": "正常雾气"
+          },
+          "2": {
+            "label": "无雾气"
+          },
+          "3": {
+            "label": "无尽雾气"
+          }
+        }
+      },
+      "WaterShut": {
+        "label": "停水时间",
+        "description": "默认开始日期 (1993年7月9日) 后多久， 水管装置 (例如水槽) 不再无限供水。",
+        "options": {
+          "1": {
+            "label": "立即"
+          },
+          "2": {
+            "label": "0-30 天"
+          },
+          "3": {
+            "label": "0-2 个月"
+          },
+          "4": {
+            "label": "0-6 个月"
+          },
+          "5": {
+            "label": "0-1 年"
+          },
+          "6": {
+            "label": "0-5 年"
+          },
+          "7": {
+            "label": "2-6 个月"
+          },
+          "8": {
+            "label": "6-12 个月"
+          },
+          "9": {
+            "label": "禁用"
+          }
+        }
+      },
+      "ElecShut": {
+        "label": "停电时间",
+        "description": "默认开始日期 (1993年7月9日) 后多久， 世界电力永久关闭。",
+        "options": {
+          "1": {
+            "label": "立即"
+          },
+          "2": {
+            "label": "14-30 天"
+          },
+          "3": {
+            "label": "14 天 - 2 个月"
+          },
+          "4": {
+            "label": "14 天 - 6 个月"
+          },
+          "5": {
+            "label": "14 天 - 1 年"
+          },
+          "6": {
+            "label": "14 天 - 5 年"
+          },
+          "7": {
+            "label": "2 - 6 个月"
+          },
+          "8": {
+            "label": "6 - 12 个月"
+          },
+          "9": {
+            "label": "禁用"
+          }
+        }
+      },
+      "AlarmDecay": {
+        "label": "房屋警报电池衰减",
+        "description": "停电后， 防屋警报的电池可以维持房屋警报工作的天数。",
+        "options": {
+          "1": {
+            "label": "立即"
+          },
+          "2": {
+            "label": "0-30 天"
+          },
+          "3": {
+            "label": "0-2 个月"
+          },
+          "4": {
+            "label": "0-6 个月"
+          },
+          "5": {
+            "label": "0-1 年"
+          },
+          "6": {
+            "label": "0-5 年"
+          },
+          "7": {
+            "label": "2-6 个月"
+          },
+          "8": {
+            "label": "6-12 个月"
+          },
+          "9": {
+            "label": "禁用"
+          }
+        }
+      },
+      "WaterShutModifier": {
+        "label": "停水调整",
+        "description": "以游戏天数精确调整停水时间。"
+      },
+      "ElecShutModifier": {
+        "label": "停电调整",
+        "description": "以游戏天数精确调整停电时间。"
+      },
+      "AlarmDecayModifier": {
+        "label": "警报电池衰减天数",
+        "description": "以游戏天数精确调整警报器电池耗尽时间。"
+      },
+      "Temperature": {
+        "label": "温度",
+        "description": "全地图温度。",
+        "options": {
+          "1": {
+            "label": "非常冷"
+          },
+          "2": {
+            "label": "冷"
+          },
+          "3": {
+            "label": "正常"
+          },
+          "4": {
+            "label": "热"
+          },
+          "5": {
+            "label": "非常热"
+          }
+        }
+      },
+      "Rain": {
+        "label": "降水量",
+        "description": "降雨频率。",
+        "options": {
+          "1": {
+            "label": "非常干旱"
+          },
+          "2": {
+            "label": "干旱"
+          },
+          "3": {
+            "label": "正常"
+          },
+          "4": {
+            "label": "多雨"
+          },
+          "5": {
+            "label": "非常多雨"
+          }
+        }
+      },
+      "ErosionSpeed": {
+        "label": "侵蚀速度",
+        "description": "发展到100%所需的天数。",
+        "options": {
+          "1": {
+            "label": "非常快 (20 天)"
+          },
+          "2": {
+            "label": "快 (50 天)"
+          },
+          "3": {
+            "label": "正常 (100 天)"
+          },
+          "4": {
+            "label": "慢 (200 天)"
+          },
+          "5": {
+            "label": "非常慢 (500 天)"
+          }
+        }
+      },
+      "ErosionDays": {
+        "label": "侵蚀天数",
+        "description": "侵蚀达到100%的天数。 -1表示不会生长。 0表示使用侵蚀速度的设置。 最大值 36,500 (100 年)。"
+      },
+      "MaxFogIntensity": {
+        "label": "雾气强度",
+        "description": "雾气最大强度。",
+        "options": {
+          "1": {
+            "label": "正常"
+          },
+          "2": {
+            "label": "中等"
+          },
+          "3": {
+            "label": "弱"
+          },
+          "4": {
+            "label": "无"
+          }
+        }
+      },
+      "MaxRainFxIntensity": {
+        "label": "最大降雨特效强度",
+        "description": "降雨最大强度。",
+        "options": {
+          "1": {
+            "label": "正常"
+          },
+          "2": {
+            "label": "中等"
+          },
+          "3": {
+            "label": "弱"
+          }
+        }
+      },
+      "EnableSnowOnGround": {
+        "label": "启用地面积雪",
+        "description": "如果禁用，积雪将不会积聚在地面上，但在植被和屋顶上仍然可以看到。"
+      },
+      "NightDarkness": {
+        "label": "夜间亮度",
+        "description": "夜间的光亮度。",
+        "options": {
+          "1": {
+            "label": "漆黑"
+          },
+          "2": {
+            "label": "黑暗"
+          },
+          "3": {
+            "label": "正常"
+          },
+          "4": {
+            "label": "明亮"
+          }
+        }
+      },
+      "NightLength": {
+        "label": "夜晚时长",
+        "description": "夜间至天明的时间。",
+        "options": {
+          "1": {
+            "label": "永夜"
+          },
+          "2": {
+            "label": "长"
+          },
+          "3": {
+            "label": "普通"
+          },
+          "4": {
+            "label": "短"
+          },
+          "5": {
+            "label": "永昼"
+          }
+        }
+      },
+      "TimeSinceApo": {
+        "label": "大灾变后第几个月",
+        "description": "这将影响开局时的世界腐蚀和食物变质。",
+        "options": {
+          "1": {
+            "label": "0"
+          },
+          "2": {
+            "label": "1"
+          },
+          "3": {
+            "label": "2"
+          },
+          "4": {
+            "label": "3"
+          },
+          "5": {
+            "label": "4"
+          },
+          "6": {
+            "label": "5"
+          },
+          "7": {
+            "label": "6"
+          },
+          "8": {
+            "label": "7"
+          },
+          "9": {
+            "label": "8"
+          },
+          "10": {
+            "label": "9"
+          },
+          "11": {
+            "label": "10"
+          },
+          "12": {
+            "label": "11"
+          },
+          "13": {
+            "label": "12"
+          }
+        }
+      },
+      "FireSpread": {
+        "label": "火势蔓延",
+        "description": "如果火灾开始后会蔓延。"
+      }
+    },
+    "survival": {
+      "StatsDecrease": {
+        "label": "角色生理需求下降速度",
+        "description": "角色的饥饿，口渴和疲劳会以多快的速度减少。",
+        "options": {
+          "1": {
+            "label": "非常快"
+          },
+          "2": {
+            "label": "快"
+          },
+          "3": {
+            "label": "正常"
+          },
+          "4": {
+            "label": "慢"
+          },
+          "5": {
+            "label": "非常慢"
+          }
+        }
+      },
+      "Nutrition": {
+        "label": "营养",
+        "description": "食物的营养价值影响玩家的身体状况。"
+      },
+      "FoodRotSpeed": {
+        "label": "食物变质速度",
+        "description": "决定食物在冰箱里/外有多快会变质。",
+        "options": {
+          "1": {
+            "label": "非常快"
+          },
+          "2": {
+            "label": "快"
+          },
+          "3": {
+            "label": "正常"
+          },
+          "4": {
+            "label": "慢"
+          },
+          "5": {
+            "label": "非常慢"
+          }
+        }
+      },
+      "FridgeFactor": {
+        "label": "冷藏效率",
+        "description": "决定冰箱的效果有多强劲。",
+        "options": {
+          "1": {
+            "label": "很低"
+          },
+          "2": {
+            "label": "较低"
+          },
+          "3": {
+            "label": "正常"
+          },
+          "4": {
+            "label": "较高"
+          },
+          "5": {
+            "label": "很高"
+          },
+          "6": {
+            "label": "永不腐烂"
+          }
+        }
+      },
+      "StarterKit": {
+        "label": "新手包",
+        "description": "带着薯片， 水瓶， 书包， 棒球棒和铁锤开局。"
+      },
+      "CharacterFreePoints": {
+        "label": "自由特征点",
+        "description": "在角色创建期间追加的自由点数。"
+      },
+      "BoneFracture": {
+        "label": "骨折",
+        "description": "当幸存者受到撞击，僵尸伤害和跌落的伤害时，启用或禁用断肢。"
+      },
+      "InjurySeverity": {
+        "label": "损伤严重程度",
+        "description": "增加和减少伤害对你身体的影响，以及它们的愈合时间。",
+        "options": {
+          "1": {
+            "label": "低"
+          },
+          "2": {
+            "label": "正常"
+          },
+          "3": {
+            "label": "高"
+          }
+        }
+      },
+      "EndRegen": {
+        "label": "耐力恢复速度",
+        "description": "影响体力恢复速度",
+        "options": {
+          "1": {
+            "label": "非常快"
+          },
+          "2": {
+            "label": "快"
+          },
+          "3": {
+            "label": "正常"
+          },
+          "4": {
+            "label": "慢"
+          },
+          "5": {
+            "label": "非常慢"
+          }
+        }
+      },
+      "HoursForCorpseRemoval": {
+        "label": "尸体移除前的时间",
+        "description": "僵尸尸体移除的游戏时间。"
+      },
+      "DecayingCorpseHealthImpact": {
+        "label": "腐烂尸体对健康的影响",
+        "description": "控制附近腐烂的尸体对玩家健康和情绪的影响。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "低"
+          },
+          "3": {
+            "label": "一般"
+          },
+          "4": {
+            "label": "高"
+          },
+          "5": {
+            "label": "疯狂"
+          }
+        }
+      },
+      "ZombieHealthImpact": {
+        "label": "僵尸对玩家影响",
+        "description": "附近的\"活\"僵尸是否对玩家的健康和情绪有相同的影响。"
+      },
+      "BloodLevel": {
+        "label": "血腥等级",
+        "description": "溅射在 地板/墙壁 上的血量。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "低"
+          },
+          "3": {
+            "label": "一般"
+          },
+          "4": {
+            "label": "高"
+          },
+          "5": {
+            "label": "极度血腥"
+          }
+        }
+      },
+      "ClothingDegradation": {
+        "label": "衣物劣化",
+        "description": "控制衣物劣化，变脏和血迹斑斑的速度。",
+        "options": {
+          "1": {
+            "label": "禁用"
+          },
+          "2": {
+            "label": "慢"
+          },
+          "3": {
+            "label": "正常"
+          },
+          "4": {
+            "label": "快"
+          }
+        }
+      },
+      "DaysForRottenFoodRemoval": {
+        "label": "腐烂食物移除",
+        "description": "将腐烂的食物从地图上移除之前的游戏天数。 -1表示永不移除腐烂的食物。"
+      },
+      "AllClothesUnlocked": {
+        "label": "服装全解锁",
+        "description": "允许你在自定义角色时从游戏中的所有服装中选择"
+      },
+      "EnableTaintedWaterText": {
+        "label": "启用 污染的水 提示",
+        "description": "如果禁用，污染的水将不会有警告标志"
+      },
+      "EnablePoisoning": {
+        "label": "启用投毒",
+        "description": "管理是否启用中毒食物",
+        "options": {
+          "1": {
+            "label": "启用"
+          },
+          "2": {
+            "label": "关闭"
+          },
+          "3": {
+            "label": "只禁用漂白剂的中毒"
+          }
+        }
+      },
+      "MaggotSpawn": {
+        "label": "尸体蛆虫",
+        "description": "蛆可以在尸体中生成的条件。",
+        "options": {
+          "1": {
+            "label": "尸体和周围"
+          },
+          "2": {
+            "label": "只在尸体上"
+          },
+          "3": {
+            "label": "不产生蛆虫"
+          }
+        }
+      },
+      "MuscleStrainFactor": {
+        "label": "肌肉拉伤因素",
+        "description": "作为挥舞武器或搬运重物时施加肌肉拉伤的倍率。"
+      },
+      "DiscomfortFactor": {
+        "label": "不适系数",
+        "description": "在应用穿着物品的不适感时作为乘数使用。"
+      },
+      "WoundInfectionFactor": {
+        "label": "伤口感染伤害因素",
+        "description": "如果大于零， 则可能因严重伤口感染而受到伤害。"
+      },
+      "NoBlackClothes": {
+        "label": "无黑色服装",
+        "description": "如果为真， 随机色调的服装不会暗到几乎是黑色。"
+      },
+      "EasyClimbing": {
+        "label": "简易攀爬",
+        "description": "禁用攀爬绳索或翻越墙壁时的失败几率。"
+      },
+      "NegativeTraitsPenalty": {
+        "label": "负面特质惩罚",
+        "description": "如果选择多个负面特质， 那么获得的额外特质点数会衰减。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "每选择 3 个负面特质则减少 1 点"
+          },
+          "3": {
+            "label": "每选择 2 个负面特质则减少 1 点"
+          },
+          "4": {
+            "label": "在选择第一个负面特质后, 每选择一个负面特质则减少 1 点"
+          }
+        }
+      },
+      "MinutesPerPage": {
+        "label": "阅读每页书籍所需分钟数",
+        "description": "在游戏中阅读每一页书籍所需的分钟数。"
+      },
+      "LiteratureCooldown": {
+        "label": "文学作品冷却天数",
+        "description": "在能够从阅读以前阅读过的文学作品中重新获益之前的天数。"
+      },
+      "LevelForMediaXPCutoff": {
+        "label": "阅读媒体所能达到的最高经验等级",
+        "description": "当技能达到此等级或以上时， 电视/VHS录像带/其他媒体 将不再为其提供经验。"
+      },
+      "LevelForDismantleXPCutoff": {
+        "label": "拆解所能达到的最高经验等级",
+        "description": "当技能达到此等级或以上时， 拆除家具不再为相关技能提供经验。 不适用于电工。"
+      },
+      "BloodSplatLifespanDays": {
+        "label": "移除血迹天数",
+        "description": "旧血迹被移除前的天数。 当地图块被加载时发生移除。 0 表示它们永远不会消失。"
+      },
+      "MetaKnowledge": {
+        "label": "媒体内容显示",
+        "description": "如果媒体内容没有被完全观看或阅读， 此设置决定是否将媒体内容完全显示， 显示为 \"???\" 或完全隐藏。",
+        "options": {
+          "1": {
+            "label": "完全显示"
+          },
+          "2": {
+            "label": "显示为 ???"
+          },
+          "3": {
+            "label": "完全隐藏"
+          }
+        }
+      },
+      "SeeNotLearntRecipe": {
+        "label": "查看未知配方",
+        "description": "如果开启， 即便没有阅读相关配方杂志， 你也能查看可以制作的任何配方。"
+      },
+      "LightBulbLifespan": {
+        "label": "灯泡寿命",
+        "description": "数值越高，灯泡在损坏前持续的时间越长；如果是0，灯泡将永远不会坏；不会影响车辆灯"
+      },
+      "MaximumFireFuelHours": {
+        "label": "最大火焰燃料小时数",
+        "description": "可以放入篝火， 木炉等的最大燃料小时数。"
+      },
+      "Alarm": {
+        "label": "房屋警报频率",
+        "description": "玩家在闯入新房子时激活房屋警报的可能性。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "极稀少"
+          },
+          "3": {
+            "label": "稀少"
+          },
+          "4": {
+            "label": "偶尔"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常频繁"
+          }
+        }
+      },
+      "LockedHouses": {
+        "label": "上锁房屋频率",
+        "description": "决定房屋门窗上锁几率。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "极稀少"
+          },
+          "3": {
+            "label": "稀少"
+          },
+          "4": {
+            "label": "偶尔"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常频繁"
+          }
+        }
+      },
+      "Helicopter": {
+        "label": "直升机",
+        "description": "直升机在活动区域上空飞过的频率。",
+        "options": {
+          "1": {
+            "label": "永不"
+          },
+          "2": {
+            "label": "一次"
+          },
+          "3": {
+            "label": "偶尔"
+          },
+          "4": {
+            "label": "经常"
+          }
+        }
+      },
+      "MetaEvent": {
+        "label": "元事件",
+        "description": "僵尸吸引元游戏事件的频率有多高，比如远处的枪声。",
+        "options": {
+          "1": {
+            "label": "永不"
+          },
+          "2": {
+            "label": "偶尔"
+          },
+          "3": {
+            "label": "经常"
+          }
+        }
+      },
+      "SleepingEvent": {
+        "label": "睡眠事件",
+        "description": "控制玩家睡眠期间的夜间元游戏事件。",
+        "options": {
+          "1": {
+            "label": "永不"
+          },
+          "2": {
+            "label": "偶尔"
+          },
+          "3": {
+            "label": "经常"
+          }
+        }
+      },
+      "NatureAbundance": {
+        "label": "自然采集资源丰富度",
+        "description": "影响钓鱼/搜寻的难度。",
+        "options": {
+          "1": {
+            "label": "非常贫瘠"
+          },
+          "2": {
+            "label": "贫瘠"
+          },
+          "3": {
+            "label": "普通"
+          },
+          "4": {
+            "label": "丰富"
+          },
+          "5": {
+            "label": "非常丰富"
+          }
+        }
+      },
+      "FishAbundance": {
+        "label": "鱼类资源丰富度",
+        "description": "河流和湖泊中鱼类的丰富程度。",
+        "options": {
+          "1": {
+            "label": "非常贫瘠"
+          },
+          "2": {
+            "label": "贫瘠"
+          },
+          "3": {
+            "label": "普通"
+          },
+          "4": {
+            "label": "丰富"
+          },
+          "5": {
+            "label": "非常丰富"
+          }
+        }
+      },
+      "AnnotatedMapChance": {
+        "label": "注释地图几率",
+        "description": "影响一张被搜刮到的地图上有已故幸存者标记注释的频率。",
+        "options": {
+          "1": {
+            "label": "永不"
+          },
+          "2": {
+            "label": "特别稀少"
+          },
+          "3": {
+            "label": "稀少"
+          },
+          "4": {
+            "label": "偶尔"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常频繁"
+          }
+        }
+      },
+      "ConstructionBonusPoints": {
+        "label": "玩家建筑物强度",
+        "description": "给玩家建造的建筑额外的生命值，使它们更能抵抗僵尸的伤害。"
+      },
+      "GeneratorSpawning": {
+        "label": "发电机生成",
+        "description": "增加/减少发电机在地图上生成的机会。",
+        "options": {
+          "1": {
+            "label": "极度稀少"
+          },
+          "2": {
+            "label": "稀少"
+          },
+          "3": {
+            "label": "偶尔"
+          },
+          "4": {
+            "label": "经常"
+          },
+          "5": {
+            "label": "非常频繁"
+          },
+          "6": {
+            "label": "常见"
+          },
+          "7": {
+            "label": "丰富"
+          }
+        }
+      },
+      "GeneratorFuelConsumption": {
+        "label": "发电机油耗",
+        "description": "影响发电机每小时消耗多少燃料。"
+      },
+      "AllowExteriorGenerator": {
+        "label": "发电机在野外工作",
+        "description": "如果启用，发电机将在野外的地砖上工作，例如允许为油泵供电。"
+      },
+      "GeneratorTileRange": {
+        "label": "发电机供电范围",
+        "description": "发电机的水平供电范围，单位为地图格。"
+      },
+      "GeneratorVerticalPowerRange": {
+        "label": "发电机垂直供电范围",
+        "description": "发电机能够供电的上下楼层数。"
+      },
+      "CompostTime": {
+        "label": "堆肥时间",
+        "description": "堆肥箱中食物分解的时间。",
+        "options": {
+          "1": {
+            "label": "1 周"
+          },
+          "2": {
+            "label": "2 周"
+          },
+          "3": {
+            "label": "3 周"
+          },
+          "4": {
+            "label": "4 周"
+          },
+          "5": {
+            "label": "6 周"
+          },
+          "6": {
+            "label": "8 周"
+          },
+          "7": {
+            "label": "10 周"
+          },
+          "8": {
+            "label": "12 周"
+          }
+        }
+      },
+      "AttackBlockMovements": {
+        "label": "不可移动攻击",
+        "description": "若禁用则近战攻击不影响行走。"
+      },
+      "WorldItemRemovalList": {
+        "label": "世界物品移除列表",
+        "description": "将在 移除清单的时间 设置的小时后删除。 以逗号分隔的项目类型列表。"
+      },
+      "HoursForWorldItemRemoval": {
+        "label": "移除清单的时间",
+        "description": "物品掉落在地上的小时数，然后才会被移除。 物品会在下次加载地图的那个部分时被移除。 数值 0 意味着物品不会被移除。"
+      },
+      "ItemRemovalListBlacklistToggle": {
+        "label": "移除列表为白名单",
+        "description": "如果为是，任何不在 世界物品移除列表 中的项目将被删除。"
+      }
+    },
+    "combat": {
+      "MultiHitZombies": {
+        "label": "武器群攻",
+        "description": "当启用时，部分近战武器能横扫多个僵尸。"
+      },
+      "RearVulnerability": {
+        "label": "背后弱点",
+        "description": "僵尸从背后攻击时被咬的可能性。",
+        "options": {
+          "1": {
+            "label": "低"
+          },
+          "2": {
+            "label": "中"
+          },
+          "3": {
+            "label": "高"
+          }
+        }
+      },
+      "FirearmUseDamageChance": {
+        "label": "枪械使用伤害几率",
+        "description": "用伤害几率计算取代命中几率机制。 此模式优先考虑玩家的瞄准。"
+      },
+      "FirearmNoiseMultiplier": {
+        "label": "枪械噪音倍率",
+        "description": "僵尸能听到枪声的距离的倍率。"
+      },
+      "FirearmJamMultiplier": {
+        "label": "枪械卡壳倍率",
+        "description": "枪械卡壳几率的倍率。 设置为 0 则禁用卡壳。"
+      },
+      "FirearmMoodleMultiplier": {
+        "label": "枪械受状态效果影响倍率",
+        "description": "命中率受状态效果影响的倍率。 设置为 0 则禁用状态对命中率的惩罚影响。"
+      },
+      "FirearmWeatherMultiplier": {
+        "label": "枪械受天气效果影响倍率",
+        "description": "天气 (风， 雨和雾) 对命中率影响的倍率。 设置为 0 则禁用天气效果对命中率影响。"
+      },
+      "FirearmHeadGearEffect": {
+        "label": "枪械受头部装备效果影响",
+        "description": "如果启用此选项， 头部装备如焊接面罩将影响命中率。"
+      }
+    },
+    "vehicles": {
+      "EnableVehicles": {
+        "label": "启用汽车",
+        "description": "允许车辆的生成。"
+      },
+      "CarSpawnRate": {
+        "label": "车辆生成率",
+        "description": "地图上发现汽车的频率",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "很低"
+          },
+          "3": {
+            "label": "低"
+          },
+          "4": {
+            "label": "普通"
+          },
+          "5": {
+            "label": "高"
+          }
+        }
+      },
+      "VehicleEasyUse": {
+        "label": "简单模式",
+        "description": "汽车是否被锁住，是否需要钥匙才能启动等。"
+      },
+      "InitialGas": {
+        "label": "初始油量",
+        "description": "控制发现的汽车的油箱装满程度。",
+        "options": {
+          "1": {
+            "label": "很低"
+          },
+          "2": {
+            "label": "低"
+          },
+          "3": {
+            "label": "一般"
+          },
+          "4": {
+            "label": "高"
+          },
+          "5": {
+            "label": "很高"
+          },
+          "6": {
+            "label": "满"
+          }
+        }
+      },
+      "FuelStationGasInfinite": {
+        "label": "加油站无限燃料",
+        "description": "如果启用， 加油站将永远不会耗尽燃料。"
+      },
+      "FuelStationGasMin": {
+        "label": "初始加油站最小燃料",
+        "description": "加油站可以生成的最小燃料量。 勾选下方的\"高级\"选项以使用自定义数量。"
+      },
+      "FuelStationGasMax": {
+        "label": "初始加油站最大燃料",
+        "description": "加油站可以生成的最大燃料量。 勾选下方的\"高级\"选项以使用自定义数量。"
+      },
+      "FuelStationGasEmptyChance": {
+        "label": "初始加油站空置几率",
+        "description": "个别加油站最初没有燃料的几率， 以百分比表示。"
+      },
+      "LockedCar": {
+        "label": "锁车几率",
+        "description": "汽车被锁定的可能性",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "极稀有"
+          },
+          "3": {
+            "label": "稀有"
+          },
+          "4": {
+            "label": "偶尔"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常频繁"
+          }
+        }
+      },
+      "CarGasConsumption": {
+        "label": "耗油量",
+        "description": "车辆的耗油量。"
+      },
+      "CarGeneralCondition": {
+        "label": "基本状况",
+        "description": "地图上发现的车辆的总体状况",
+        "options": {
+          "1": {
+            "label": "很差"
+          },
+          "2": {
+            "label": "差"
+          },
+          "3": {
+            "label": "一般"
+          },
+          "4": {
+            "label": "好"
+          },
+          "5": {
+            "label": "很好"
+          }
+        }
+      },
+      "CarDamageOnImpact": {
+        "label": "车辆碰撞损伤",
+        "description": "控制撞车对车辆造成损坏的程度。",
+        "options": {
+          "1": {
+            "label": "很低"
+          },
+          "2": {
+            "label": "低"
+          },
+          "3": {
+            "label": "普通"
+          },
+          "4": {
+            "label": "高"
+          },
+          "5": {
+            "label": "很高"
+          }
+        }
+      },
+      "DamageToPlayerFromHitByACar": {
+        "label": "撞车对玩家造成的伤害",
+        "description": "玩家在撞车中受到的伤害。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "低"
+          },
+          "3": {
+            "label": "普通"
+          },
+          "4": {
+            "label": "高"
+          },
+          "5": {
+            "label": "非常高"
+          }
+        }
+      },
+      "TrafficJam": {
+        "label": "汽车残骸堵塞",
+        "description": "启用或禁用 在地图主干道上生成的堵车。"
+      },
+      "CarAlarm": {
+        "label": "汽车警报率",
+        "description": "发现带有警报的汽车。",
+        "options": {
+          "1": {
+            "label": "从不"
+          },
+          "2": {
+            "label": "极稀有"
+          },
+          "3": {
+            "label": "稀有"
+          },
+          "4": {
+            "label": "偶尔"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常频繁"
+          }
+        }
+      },
+      "PlayerDamageFromCrash": {
+        "label": "玩家因撞车而受伤",
+        "description": "启用或禁用玩家在车祸中受到伤害。"
+      },
+      "SirenShutoffHours": {
+        "label": "警报关闭时长",
+        "description": "车辆警报持续时间。 0.0意味着响到电池没电。"
+      },
+      "ChanceHasGas": {
+        "label": "有燃料的几率",
+        "description": "控制找到油箱中有汽油的车辆的机会。",
+        "options": {
+          "1": {
+            "label": "低"
+          },
+          "2": {
+            "label": "普通"
+          },
+          "3": {
+            "label": "高"
+          }
+        }
+      },
+      "RecentlySurvivorVehicles": {
+        "label": "最近的幸存者车辆",
+        "description": "控制玩家是否可以发现一辆在感染发生后已被维护和保养的汽车。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "低"
+          },
+          "3": {
+            "label": "普通"
+          },
+          "4": {
+            "label": "高"
+          }
+        }
+      },
+      "ZombieAttractionMultiplier": {
+        "label": "僵尸吸引倍率",
+        "description": "用此来放大或降低发动机的总体响度。"
+      },
+      "SirenEffectsZombies": {
+        "label": "车辆警报器吸引僵尸",
+        "description": "僵尸是否会朝向车辆警报器的声音方向前进。"
+      }
+    },
+    "animals": {
+      "AnimalStatsModifier": {
+        "label": "属性减少速度",
+        "description": "动物属性 (如饥饿， 口渴等) 减少的速度。",
+        "options": {
+          "1": {
+            "label": "超快"
+          },
+          "2": {
+            "label": "非常快"
+          },
+          "3": {
+            "label": "快"
+          },
+          "4": {
+            "label": "正常"
+          },
+          "5": {
+            "label": "慢"
+          },
+          "6": {
+            "label": "非常慢"
+          }
+        }
+      },
+      "AnimalMetaStatsModifier": {
+        "label": "元属性减少速度",
+        "description": "在元状态中动物属性 (如饥饿， 口渴等) 减少的速度。",
+        "options": {
+          "1": {
+            "label": "超快"
+          },
+          "2": {
+            "label": "非常快"
+          },
+          "3": {
+            "label": "快"
+          },
+          "4": {
+            "label": "正常"
+          },
+          "5": {
+            "label": "慢"
+          },
+          "6": {
+            "label": "非常慢"
+          }
+        }
+      },
+      "AnimalPregnancyTime": {
+        "label": "分娩时间",
+        "description": "动物受精直至分娩的时间长度。",
+        "options": {
+          "1": {
+            "label": "超快"
+          },
+          "2": {
+            "label": "非常快"
+          },
+          "3": {
+            "label": "快"
+          },
+          "4": {
+            "label": "正常"
+          },
+          "5": {
+            "label": "慢"
+          },
+          "6": {
+            "label": "非常慢"
+          }
+        }
+      },
+      "AnimalAgeModifier": {
+        "label": "动物成长速度",
+        "description": "动物成长的速度。",
+        "options": {
+          "1": {
+            "label": "非常快"
+          },
+          "2": {
+            "label": "快"
+          },
+          "3": {
+            "label": "正常"
+          },
+          "4": {
+            "label": "正常"
+          },
+          "5": {
+            "label": "慢"
+          },
+          "6": {
+            "label": "非常慢"
+          }
+        }
+      },
+      "AnimalMilkIncModifier": {
+        "label": "牛奶产出速度",
+        "description": "动物的产奶速度。",
+        "options": {
+          "1": {
+            "label": "超快"
+          },
+          "2": {
+            "label": "非常快"
+          },
+          "3": {
+            "label": "快"
+          },
+          "4": {
+            "label": "正常"
+          },
+          "5": {
+            "label": "慢"
+          },
+          "6": {
+            "label": "非常慢"
+          }
+        }
+      },
+      "AnimalWoolIncModifier": {
+        "label": "羊毛产出速度",
+        "description": "动物的产毛速度。",
+        "options": {
+          "1": {
+            "label": "超快"
+          },
+          "2": {
+            "label": "非常快"
+          },
+          "3": {
+            "label": "快"
+          },
+          "4": {
+            "label": "正常"
+          },
+          "5": {
+            "label": "慢"
+          },
+          "6": {
+            "label": "非常慢"
+          }
+        }
+      },
+      "AnimalRanchChance": {
+        "label": "动物生成几率",
+        "description": "在农场中发现动物的几率。",
+        "options": {
+          "1": {
+            "label": "从不"
+          },
+          "2": {
+            "label": "极度罕见"
+          },
+          "3": {
+            "label": "罕见"
+          },
+          "4": {
+            "label": "有时"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "频繁"
+          },
+          "7": {
+            "label": "总是"
+          }
+        }
+      },
+      "AnimalGrassRegrowTime": {
+        "label": "草地重新生长时间",
+        "description": "草地被动物吃掉或被玩家割掉后重新生长所需的小时数。"
+      },
+      "AnimalMetaPredator": {
+        "label": "元捕食者",
+        "description": "如果鸡舍门在晚上没有关闭， 元捕食者 (在游戏中不可见) 可能会攻击你的鸡。"
+      },
+      "AnimalMatingSeason": {
+        "label": "繁殖季节",
+        "description": "开启后， 动物只会在繁殖季节交配。 否则， 它们可以全年繁殖/产卵。"
+      },
+      "AnimalEggHatch": {
+        "label": "孵化时间",
+        "description": "小动物从蛋中孵化出来的时间。",
+        "options": {
+          "1": {
+            "label": "超快"
+          },
+          "2": {
+            "label": "非常快"
+          },
+          "3": {
+            "label": "快"
+          },
+          "4": {
+            "label": "正常"
+          },
+          "5": {
+            "label": "慢"
+          },
+          "6": {
+            "label": "非常慢"
+          }
+        }
+      },
+      "AnimalSoundAttractZombies": {
+        "label": "动物吸引僵尸",
+        "description": "如果开启， 动物的叫声会吸引附近的僵尸。"
+      },
+      "AnimalTrackChance": {
+        "label": "动物足迹几率",
+        "description": "动物留下足迹的几率。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "极稀少"
+          },
+          "3": {
+            "label": "稀少"
+          },
+          "4": {
+            "label": "偶尔"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常频繁"
+          }
+        }
+      },
+      "AnimalPathChance": {
+        "label": "动物路径几率",
+        "description": "正在追猎的动物留下路径的几率。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "极稀少"
+          },
+          "3": {
+            "label": "稀少"
+          },
+          "4": {
+            "label": "偶尔"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常频繁"
+          }
+        }
+      },
+      "MaximumRatIndex": {
+        "label": "最大害虫指数",
+        "description": "例如， 受感染建筑物中老鼠的频率和强度。"
+      },
+      "DaysUntilMaximumRatIndex": {
+        "label": "达到最大害虫指数的天数",
+        "description": "达到最大害虫指数所需的时间。"
+      },
+      "Farming": {
+        "label": "耕作经验获取倍率",
+        "description": "耕作技能升级的速率。",
+        "options": {
+          "1": {
+            "label": "很低"
+          },
+          "2": {
+            "label": "低"
+          },
+          "3": {
+            "label": "正常"
+          },
+          "4": {
+            "label": "高"
+          },
+          "5": {
+            "label": "很高"
+          }
+        }
+      },
+      "PlantResilience": {
+        "label": "作物适应力",
+        "description": "会影响植物每天损失多少水分以及它们避免疾病的能力。",
+        "options": {
+          "1": {
+            "label": "非常高"
+          },
+          "2": {
+            "label": "高"
+          },
+          "3": {
+            "label": "正常"
+          },
+          "4": {
+            "label": "低"
+          },
+          "5": {
+            "label": "非常低"
+          }
+        }
+      },
+      "PlantAbundance": {
+        "label": "作物产量",
+        "description": "影响作物收获时的产量。",
+        "options": {
+          "1": {
+            "label": "非常贫瘠"
+          },
+          "2": {
+            "label": "贫瘠"
+          },
+          "3": {
+            "label": "普通"
+          },
+          "4": {
+            "label": "丰富"
+          },
+          "5": {
+            "label": "非常丰富"
+          }
+        }
+      },
+      "KillInsideCrops": {
+        "label": "室内作物死亡",
+        "description": "当启用时， 建筑物内玩家种植的作物和草药将会死亡。 不影响室内植物。"
+      },
+      "PlantGrowingSeasons": {
+        "label": "作物生长季节",
+        "description": "当启用时， 作物的生长受季节影响。"
+      },
+      "PlaceDirtAboveground": {
+        "label": "非地表农场 [!]",
+        "description": "[!] 建议不要更改此设置。 更改此设置可能会导致性能问题。 [!] 当启用时， 可以在非地表放置泥土并进行耕作。"
+      },
+      "FarmingSpeedNew": {
+        "label": "作物生长速率",
+        "description": "作物生长速度。"
+      },
+      "FarmingAmountNew": {
+        "label": "作物产量",
+        "description": "影响作物收获时的产量。"
+      },
+      "ClayLakeChance": {
+        "label": "黏土生成几率 - 湖泊",
+        "description": "将泥土地面转变为黏土地面的几率。 适用于湖泊。"
+      },
+      "ClayRiverChance": {
+        "label": "黏土生成几率 - 河流",
+        "description": "将泥土地面转变为黏土地面的几率。 适用于河流。"
+      }
+    },
+    "world": {
+      "SurvivorHouseChance": {
+        "label": "随机房屋几率",
+        "description": "增加/降低在地图上发现随机安全屋的概率:要么被烧毁，要么包含战利品，幸存者尸体等。",
+        "options": {
+          "1": {
+            "label": "永不"
+          },
+          "2": {
+            "label": "特别稀少"
+          },
+          "3": {
+            "label": "稀少"
+          },
+          "4": {
+            "label": "偶尔"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常频繁"
+          },
+          "7": {
+            "label": "总是尝试"
+          }
+        }
+      },
+      "VehicleStoryChance": {
+        "label": "随机车辆故事发生几率",
+        "description": "道路事件 (例如， 警察路障) 生成的几率。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "极稀少"
+          },
+          "3": {
+            "label": "稀少"
+          },
+          "4": {
+            "label": "偶尔"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常频繁"
+          }
+        }
+      },
+      "ZoneStoryChance": {
+        "label": "随机区域故事发生几率",
+        "description": "特定地图区域事件 (例如， 森林中的营地) 生成的几率。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "极稀少"
+          },
+          "3": {
+            "label": "稀少"
+          },
+          "4": {
+            "label": "偶尔"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常频繁"
+          }
+        }
+      }
+    },
+    "zombieLore": {
+      "Speed": {
+        "label": "速度",
+        "description": "僵尸的移动速度。",
+        "options": {
+          "1": {
+            "label": "短跑运动员"
+          },
+          "2": {
+            "label": "快速蹒跚"
+          },
+          "3": {
+            "label": "蹒跚"
+          },
+          "4": {
+            "label": "随机"
+          }
+        }
+      },
+      "Strength": {
+        "label": "僵尸力量",
+        "description": "僵尸每次攻击造成的伤害。",
+        "options": {
+          "1": {
+            "label": "超人"
+          },
+          "2": {
+            "label": "普通"
+          },
+          "3": {
+            "label": "弱鸡"
+          },
+          "4": {
+            "label": "随机"
+          }
+        }
+      },
+      "Toughness": {
+        "label": "韧性",
+        "description": "杀死僵尸的难度。",
+        "options": {
+          "1": {
+            "label": "坚强"
+          },
+          "2": {
+            "label": "普通"
+          },
+          "3": {
+            "label": "脆弱"
+          },
+          "4": {
+            "label": "随机"
+          }
+        }
+      },
+      "Transmission": {
+        "label": "传染",
+        "description": "僵尸病毒的传播方式。",
+        "options": {
+          "1": {
+            "label": "血液+唾液"
+          },
+          "2": {
+            "label": "仅唾液"
+          },
+          "3": {
+            "label": "所有感染方式"
+          },
+          "4": {
+            "label": "无"
+          }
+        }
+      },
+      "Mortality": {
+        "label": "致死时间",
+        "description": "僵尸感染致死速度。",
+        "options": {
+          "1": {
+            "label": "立即"
+          },
+          "2": {
+            "label": "0-30 秒"
+          },
+          "3": {
+            "label": "0-1 分钟"
+          },
+          "4": {
+            "label": "0-12 小时"
+          },
+          "5": {
+            "label": "2-3 天"
+          },
+          "6": {
+            "label": "1-2 星期"
+          },
+          "7": {
+            "label": "永不"
+          }
+        }
+      },
+      "Cognition": {
+        "label": "僵尸感知",
+        "description": "僵尸寻路智力。",
+        "options": {
+          "1": {
+            "label": "本能+开门"
+          },
+          "2": {
+            "label": "本能"
+          },
+          "3": {
+            "label": "基础本能"
+          },
+          "4": {
+            "label": "随机"
+          }
+        }
+      },
+      "Memory": {
+        "label": "僵尸记忆",
+        "description": "僵尸听/看到玩家的记忆时间。",
+        "options": {
+          "1": {
+            "label": "长"
+          },
+          "2": {
+            "label": "普通"
+          },
+          "3": {
+            "label": "短"
+          },
+          "4": {
+            "label": "无"
+          },
+          "5": {
+            "label": "随机"
+          },
+          "6": {
+            "label": "在正常和无之间随机"
+          }
+        }
+      },
+      "Sight": {
+        "label": "僵尸视觉",
+        "description": "僵尸的视觉半径。",
+        "options": {
+          "1": {
+            "label": "鹰眼"
+          },
+          "2": {
+            "label": "正常"
+          },
+          "3": {
+            "label": "眼拙"
+          },
+          "4": {
+            "label": "随机"
+          },
+          "5": {
+            "label": "在正常和差之间随机"
+          }
+        }
+      },
+      "Hearing": {
+        "label": "僵尸听觉",
+        "description": "僵尸的听觉半径。",
+        "options": {
+          "1": {
+            "label": "灵敏"
+          },
+          "2": {
+            "label": "正常"
+          },
+          "3": {
+            "label": "耳背"
+          },
+          "4": {
+            "label": "随机"
+          },
+          "5": {
+            "label": "在正常和差之间随机"
+          }
+        }
+      },
+      "SpottedLogic": {
+        "label": "新潜行系统",
+        "description": "激活新的高级潜行机制， 允许你躲在汽车后面躲避僵尸， 考虑特质和天气等因素， 等等。"
+      },
+      "ThumpNoChasing": {
+        "label": "环境攻击",
+        "description": "没有见到/听到玩家时僵尸可以在漫游时攻击门和建筑物。"
+      },
+      "ThumpOnConstruction": {
+        "label": "损毁建筑物",
+        "description": "控制僵尸是否可以摧毁玩家的建筑和防御。"
+      },
+      "ActiveOnly": {
+        "label": "日/夜活跃",
+        "description": "控制僵尸在白天是否更活跃，或者它们更像个夜猫子。 活跃僵尸会应用速度设置。 不活跃的僵尸会变慢，而且通常不追逐。",
+        "options": {
+          "1": {
+            "label": "两者"
+          },
+          "2": {
+            "label": "晚上"
+          },
+          "3": {
+            "label": "白天"
+          }
+        }
+      },
+      "TriggerHouseAlarm": {
+        "label": "僵尸触发房屋警报",
+        "description": "允许僵尸在破坏门窗时触发防盗警报。"
+      },
+      "ZombiesDragDown": {
+        "label": "放倒",
+        "description": "启用后，如果有多个僵尸同时攻击，则根据僵尸的力量，它们可以把你拉倒吃掉。"
+      },
+      "ZombiesCrawlersDragDown": {
+        "label": "爬行者拖拽",
+        "description": "如果爬行僵尸在玩家旁边， 是否会增加被一群僵尸拖倒并杀死的几率。"
+      },
+      "ZombiesFenceLunge": {
+        "label": "僵尸冲刺",
+        "description": "启用后，当你离翻越障碍中的僵尸太近时，翻越的僵尸会选择向你冲刺一段距离。"
+      },
+      "ZombiesArmorFactor": {
+        "label": "僵尸护甲因素",
+        "description": "作为确定僵尸所穿护甲效果的一个倍率。"
+      },
+      "ZombiesMaxDefense": {
+        "label": "僵尸护甲最大防御",
+        "description": "任何穿戴的防护服能为僵尸提供的最大程度防御百分比。"
+      },
+      "ChanceOfAttachedWeapon": {
+        "label": "附加武器的几率",
+        "description": "拥有随机附加武器的百分比几率。"
+      },
+      "ZombiesFallDamage": {
+        "label": "僵尸跌落伤害倍率",
+        "description": "僵尸从高处跌落时受到的伤害。"
+      },
+      "DisableFakeDead": {
+        "label": "假死丧尸复活",
+        "description": "一些看起来像死了的僵尸是否会重新复活并攻击玩家。",
+        "options": {
+          "1": {
+            "label": "世界上的一些丧尸会假装死亡"
+          },
+          "2": {
+            "label": "世界上的一些丧尸,以及你'杀死'的一些僵尸会假死"
+          },
+          "3": {
+            "label": "僵尸永远不会假死"
+          }
+        }
+      },
+      "PlayerSpawnZombieRemoval": {
+        "label": "出生点周围清除僵尸",
+        "description": "僵尸不会在玩家生成的地方出现。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "少量"
+          },
+          "3": {
+            "label": "中等"
+          },
+          "4": {
+            "label": "大量"
+          },
+          "5": {
+            "label": "非常多"
+          }
+        }
+      },
+      "FenceThumpersRequired": {
+        "label": "破坏围栏所需僵尸数",
+        "description": "破坏高围栏所需的僵尸数量"
+      },
+      "FenceDamageMultiplier": {
+        "label": "围栏损害系数",
+        "description": "僵尸破坏高围栏的速度"
+      },
+      "DoorOpeningPercentage": {
+        "label": "随机会开门的僵尸比例",
+        "description": "认知能力允许时，可以开门的僵尸所占百分比。"
+      },
+      "CrawlUnderVehicle": {
+        "label": "爬过车底",
+        "description": "僵尸可以在车底爬行。",
+        "options": {
+          "1": {
+            "label": "从不"
+          },
+          "2": {
+            "label": "非常少"
+          },
+          "3": {
+            "label": "稀少"
+          },
+          "4": {
+            "label": "有时"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常多"
+          },
+          "7": {
+            "label": "全部"
+          }
+        }
+      },
+      "SprinterPercentage": {
+        "label": "随机短跑僵尸比例",
+        "description": "如果启用随机速度， 那么这会控制跑尸的百分比。 在下方勾选\"高级\"选项以使用自定义百分比。"
+      },
+      "Reanimate": {
+        "label": "尸体复活",
+        "description": "尸体尸变速度。",
+        "options": {
+          "1": {
+            "label": "立即"
+          },
+          "2": {
+            "label": "0-30 秒"
+          },
+          "3": {
+            "label": "0-1 分钟"
+          },
+          "4": {
+            "label": "0-12 小时"
+          },
+          "5": {
+            "label": "2-3 天"
+          },
+          "6": {
+            "label": "1-2 星期"
+          }
+        }
+      }
+    },
+    "zombiePopulation": {
+      "PopulationMultiplier": {
+        "label": "僵尸倍率",
+        "description": "调整世界中的僵尸总数。"
+      },
+      "PopulationStartMultiplier": {
+        "label": "僵尸初始倍率",
+        "description": "调整游戏开局时想要的人口密度。"
+      },
+      "PopulationPeakMultiplier": {
+        "label": "僵尸峰值倍率",
+        "description": "调整在峰值日时想要的人口密度。"
+      },
+      "PopulationPeakDay": {
+        "label": "僵尸峰值日",
+        "description": "多少天后达到人口峰值日。"
+      },
+      "RespawnHours": {
+        "label": "刷新间隔",
+        "description": "僵尸在单元格中重生之前必须经过的小时数。 如果为0，则禁用重生。"
+      },
+      "RespawnUnseenHours": {
+        "label": "未巡视的刷新间隔",
+        "description": "一个区块在僵尸可能在其中重生之前必须未被巡视的小时数。"
+      },
+      "RespawnMultiplier": {
+        "label": "刷新倍率",
+        "description": "可在每个固定刷新时间在每个区块想要的人口密度中生成的比例。"
+      },
+      "RedistributeHours": {
+        "label": "重新分配间隔",
+        "description": "僵尸迁移到同一单元格的空位之前必须经过的小时数。 如果为0，则禁用迁移。"
+      },
+      "FollowSoundDistance": {
+        "label": "跟随声音的距离",
+        "description": "僵尸会试图走向它最后听到的声音的大致距离。"
+      },
+      "RallyGroupSize": {
+        "label": "群体规模",
+        "description": "僵尸在空闲时形成群组的实际大小.0表示僵尸不会成群结队。 在建筑物内或森林区域不会成群结队。"
+      },
+      "RallyGroupSizeVariance": {
+        "label": "集结群组大小变异",
+        "description": "僵尸群组大小相对于默认值 (更大和更小) 可以变化的百分比。 例如， 默认群组大小为 20， 变异为 50% 时， 群组大小将在 10-30 之间变化。"
+      },
+      "RallyTravelDistance": {
+        "label": "集群移动距离",
+        "description": "僵尸在空闲时走向群组的实际距离。"
+      },
+      "RallyGroupSeparation": {
+        "label": "群体分离",
+        "description": "群体之间的间距。"
+      },
+      "RallyGroupRadius": {
+        "label": "群体半径",
+        "description": "一组成员与其组长之间站得有多近。"
+      },
+      "ZombiesCountBeforeDelete": {
+        "label": "删除前的僵尸数量",
+        "description": "特定区域内允许存在的最大僵尸数量"
+      }
+    },
+    "xpMultipliers": {
+      "Global": {
+        "label": "全局经验倍率",
+        "description": "所有技能的经验获取倍率。"
+      },
+      "GlobalToggle": {
+        "label": "使用全局经验倍率",
+        "description": "启用后，所有技能使用全局经验倍率，不再使用各自的倍率。"
+      },
+      "Sprinting": {
+        "label": "冲刺经验获取倍率",
+        "description": "冲刺技能的经验获取倍率。"
+      },
+      "Lightfoot": {
+        "label": "轻巧经验获取倍率",
+        "description": "轻巧技能的经验获取倍率。"
+      },
+      "Nimble": {
+        "label": "灵活经验获取倍率",
+        "description": "灵活技能的经验获取倍率。"
+      },
+      "Sneak": {
+        "label": "潜行经验获取倍率",
+        "description": "潜行技能的经验获取倍率。"
+      },
+      "Axe": {
+        "label": "斧头经验获取倍率",
+        "description": "斧头技能的经验获取倍率。"
+      },
+      "Blunt": {
+        "label": "长棍经验获取倍率",
+        "description": "长棍技能的经验获取倍率。"
+      },
+      "SmallBlade": {
+        "label": "短刀经验获取倍率",
+        "description": "短刀技能的经验获取倍率。"
+      },
+      "LongBlade": {
+        "label": "长刀经验获取倍率",
+        "description": "长刀技能的经验获取倍率。"
+      },
+      "SmallBlunt": {
+        "label": "短棍经验获取倍率",
+        "description": "短棍技能的经验获取倍率。"
+      },
+      "Aiming": {
+        "label": "瞄准经验获取倍率",
+        "description": "瞄准技能的经验获取倍率。"
+      },
+      "Reloading": {
+        "label": "装填经验获取倍率",
+        "description": "装填技能的经验获取倍率。"
+      },
+      "Fishing": {
+        "label": "捕鱼经验获取倍率",
+        "description": "捕鱼技能的经验获取倍率。"
+      },
+      "Trapping": {
+        "label": "诱捕经验获取倍率",
+        "description": "诱捕技能的经验获取倍率。"
+      },
+      "Woodwork": {
+        "label": "木工经验获取倍率",
+        "description": "木工技能的经验获取倍率。"
+      },
+      "Cooking": {
+        "label": "烹饪经验获取倍率",
+        "description": "烹饪技能的经验获取倍率。"
+      },
+      "Farming": {
+        "label": "耕作经验获取倍率",
+        "description": "耕作技能的经验获取倍率。"
+      },
+      "Doctor": {
+        "label": "急救经验获取倍率",
+        "description": "急救技能的经验获取倍率。"
+      },
+      "Electricity": {
+        "label": "电工经验获取倍率",
+        "description": "电工技能的经验获取倍率。"
+      },
+      "MetalWelding": {
+        "label": "金工经验获取倍率",
+        "description": "金工技能的经验获取倍率。"
+      },
+      "Mechanics": {
+        "label": "技工经验获取倍率",
+        "description": "技工技能的经验获取倍率。"
+      },
+      "Tailoring": {
+        "label": "缝纫经验获取倍率",
+        "description": "缝纫技能的经验获取倍率。"
+      },
+      "Maintenance": {
+        "label": "维护经验获取倍率",
+        "description": "维护技能的经验获取倍率。"
+      },
+      "PlantScavenging": {
+        "label": "搜寻经验获取倍率",
+        "description": "搜寻技能的经验获取倍率。"
+      },
+      "Fitness": {
+        "label": "体格经验获取倍率",
+        "description": "体格技能的经验获取倍率。"
+      },
+      "Strength": {
+        "label": "力量经验获取倍率",
+        "description": "力量技能的经验获取倍率。"
+      },
+      "FlintKnapping": {
+        "label": "石器经验获取倍率",
+        "description": "石器技能的经验获取倍率。"
+      },
+      "Carving": {
+        "label": "雕刻经验获取倍率",
+        "description": "雕刻技能的经验获取倍率。"
+      },
+      "Tracking": {
+        "label": "追踪经验获取倍率",
+        "description": "追踪技能的经验获取倍率。"
+      },
+      "Butchering": {
+        "label": "屠宰经验获取倍率",
+        "description": "屠宰技能的经验获取倍率。"
+      },
+      "Glassmaking": {
+        "label": "玻璃经验获取倍率",
+        "description": "玻璃技能的经验获取倍率。"
+      },
+      "Husbandry": {
+        "label": "畜牧经验获取倍率",
+        "description": "畜牧技能的经验获取倍率。"
+      },
+      "Spear": {
+        "label": "长矛经验获取倍率",
+        "description": "长矛技能的经验获取倍率。"
+      },
+      "Masonry": {
+        "label": "石工经验获取倍率",
+        "description": "石工技能的经验获取倍率。"
+      },
+      "Pottery": {
+        "label": "陶艺经验获取倍率",
+        "description": "陶艺技能的经验获取倍率。"
+      },
+      "Blacksmith": {
+        "label": "锻造经验获取倍率",
+        "description": "锻造技能的经验获取倍率。"
+      }
+    },
+    "map": {
+      "AllowMiniMap": {
+        "label": "开启迷你地图",
+        "description": "如果启用， 将提供小地图窗口。"
+      },
+      "AllowWorldMap": {
+        "label": "开启世界地图",
+        "description": "如果启用， 可以查看大地图。"
+      },
+      "MapAllKnown": {
+        "label": "地图全开",
+        "description": "如果启用， 游戏开始时大地图将完全显示。"
+      },
+      "MapNeedsLight": {
+        "label": "查看地图需要光源",
+        "description": "如果启用， 除非有光源， 否则无法阅读地图。"
+      }
+    },
+    "basement": {
+      "SpawnFrequency": {
+        "label": "地下室生成频率",
+        "description": "地下室在随机位置生成的频率。",
+        "options": {
+          "1": {
+            "label": "无"
+          },
+          "2": {
+            "label": "极少"
+          },
+          "3": {
+            "label": "少"
+          },
+          "4": {
+            "label": "有时"
+          },
+          "5": {
+            "label": "经常"
+          },
+          "6": {
+            "label": "非常频繁"
+          },
+          "7": {
+            "label": "总是"
+          }
+        }
+      }
+    }
+  },
+  "iniCategories": {
+    "general": {
+      "label": "常规"
+    },
+    "network": {
+      "label": "网络与端口"
+    },
+    "steam": {
+      "label": "Steam 集成"
+    },
+    "discord": {
+      "label": "Discord"
+    },
+    "rcon": {
+      "label": "RCON 远程控制"
+    },
+    "voice": {
+      "label": "语音聊天"
+    },
+    "players": {
+      "label": "玩家与账号"
+    },
+    "safehouse": {
+      "label": "安全屋"
+    },
+    "chat": {
+      "label": "聊天与显示"
+    },
+    "pvp": {
+      "label": "PvP 与安全模式"
+    },
+    "moderation": {
+      "label": "内容管理"
+    },
+    "anticheat": {
+      "label": "反作弊"
+    },
+    "loot": {
+      "label": "物品与世界破坏"
+    },
+    "vehicles": {
+      "label": "车辆"
+    },
+    "mods": {
+      "label": "MOD 与创意工坊"
+    },
+    "radio": {
+      "label": "无线电"
+    },
+    "war": {
+      "label": "阵营战争"
+    },
+    "backups": {
+      "label": "游戏内备份"
+    },
+    "logging": {
+      "label": "日志"
+    },
+    "advanced": {
+      "label": "高级参数"
+    }
+  },
+  "iniCategoryGroups": {
+    "identity": {
+      "label": "身份与基本信息"
+    },
+    "connectivity": {
+      "label": "连接与网络"
+    },
+    "players": {
+      "label": "玩家与权限"
+    },
+    "gameplay": {
+      "label": "游戏内容"
+    },
+    "ops": {
+      "label": "运维与日志"
+    }
+  },
+  "sandboxCategories": {
+    "time": {
+      "label": "时间与季节"
+    },
+    "environment": {
+      "label": "环境与天气"
+    },
+    "world": {
+      "label": "世界故事"
+    },
+    "map": {
+      "label": "地图与导航"
+    },
+    "zombieLore": {
+      "label": "僵尸行为"
+    },
+    "zombiePopulation": {
+      "label": "僵尸数量与分布"
+    },
+    "population": {
+      "label": "人口与分布"
+    },
+    "survival": {
+      "label": "生存与健康"
+    },
+    "combat": {
+      "label": "战斗与枪械"
+    },
+    "loot": {
+      "label": "战利品与资源"
+    },
+    "lootRarity": {
+      "label": "稀有度算法"
+    },
+    "vehicles": {
+      "label": "车辆"
+    },
+    "animals": {
+      "label": "动物与农业"
+    },
+    "xpMultipliers": {
+      "label": "经验倍率"
+    },
+    "basement": {
+      "label": "地下室"
+    }
+  },
+  "sandboxCategoryGroups": {
+    "world": {
+      "label": "世界"
+    },
+    "zombies": {
+      "label": "僵尸"
+    },
+    "survival": {
+      "label": "生存"
+    },
+    "resources": {
+      "label": "资源"
+    },
+    "advanced": {
+      "label": "高级"
+    }
   }
 }

--- a/client/src/locales/zh-TW/serverconfig.json
+++ b/client/src/locales/zh-TW/serverconfig.json
@@ -386,5 +386,3651 @@
     "deletedTitle": "已刪除",
     "templateDeletedDesc": "已儲存的設定“{{name}}”已刪除",
     "deleteTemplateFailed": "刪除已儲存的設定失敗。"
+  },
+  "iniSettings": {
+    "general": {
+      "PublicName": {
+        "label": "Server Name",
+        "description": "Your server name as shown to the public."
+      },
+      "PublicDescription": {
+        "label": "Server Description",
+        "description": "The description that people can see while browsing your server."
+      },
+      "Public": {
+        "label": "Public Server",
+        "description": "Can your server be seen on Steam server browser."
+      },
+      "Open": {
+        "label": "Open (No Whitelist)",
+        "description": "Open to all players without requiring whitelist."
+      },
+      "Password": {
+        "label": "Server Password",
+        "description": "Password required to join the server. Leave empty for no password."
+      },
+      "MaxPlayers": {
+        "label": "Max Players",
+        "description": "Maximum allowed number of players."
+      },
+      "PauseEmpty": {
+        "label": "Pause When Empty",
+        "description": "The server will pause when no players are logged in."
+      },
+      "ServerWelcomeMessage": {
+        "label": "Welcome Message",
+        "description": "The welcome message displayed to players after connecting. Use <LINE> for new lines."
+      },
+      "Map": {
+        "label": "Map",
+        "description": "The map you're playing on. Default is Muldraugh, KY."
+      },
+      "SaveWorldEveryMinutes": {
+        "label": "Auto-Save Interval",
+        "description": "Auto-save world every X minutes. 0 = never."
+      },
+      "AnnounceDeath": {
+        "label": "Announce Deaths",
+        "description": "Server-wide announcement when a character dies."
+      },
+      "AnnounceAnimalDeath": {
+        "label": "Announce Animal Deaths",
+        "description": "Display a global chat message when an animal dies."
+      },
+      "Seed": {
+        "label": "World Seed",
+        "description": "The worldgen seed used to generate the world. Changing this requires deleting map_worldgen.bin."
+      }
+    },
+    "network": {
+      "DefaultPort": {
+        "label": "Game Port",
+        "description": "The port players will use to connect to your server. Must be open on your router."
+      },
+      "UPnP": {
+        "label": "Enable UPnP",
+        "description": "Enable UPnP for automatic port forwarding."
+      },
+      "PingFrequency": {
+        "label": "Ping Frequency",
+        "description": "How often the server checks connection to players (seconds)."
+      },
+      "PingLimit": {
+        "label": "Ping Limit",
+        "description": "Ping limit before being kicked (milliseconds). 100 to disable."
+      },
+      "DenyLoginOnOverloadedServer": {
+        "label": "Deny Login When Overloaded",
+        "description": "Prevent new connections when server is overloaded."
+      },
+      "SpeedLimit": {
+        "label": "Speed Limit",
+        "description": "Maximum movement speed allowed."
+      },
+      "UseTCPForMapDownloads": {
+        "label": "Use TCP for Map Downloads",
+        "description": "Use TCP instead of UDP for map downloads."
+      },
+      "MaxPacketsPerSecond": {
+        "label": "Max Packets Per Second",
+        "description": "Cap on packets per second sent to a connected client. Higher values increase bandwidth use; lower values may cause stutter under load."
+      },
+      "UDPPort": {
+        "label": "UDP Port",
+        "description": "Second port used for UDP connections."
+      },
+      "LoginQueueEnabled": {
+        "label": "Login Queue",
+        "description": "Enable a login queue when the server is full."
+      },
+      "LoginQueueConnectTimeout": {
+        "label": "Login Queue Timeout",
+        "description": "Seconds before a queued connection times out."
+      },
+      "server_browser_announced_ip": {
+        "label": "Announced IP",
+        "description": "IP address broadcast to the server browser. For multi-IP setups like server farms."
+      },
+      "MultiplayerStatisticsPeriod": {
+        "label": "Statistics Period",
+        "description": "Multiplayer statistics update period in seconds. 0 = disabled."
+      }
+    },
+    "pvp": {
+      "PVP": {
+        "label": "Enable PvP",
+        "description": "Allow player vs player combat (each player can still toggle their own PvP)."
+      },
+      "SafetySystem": {
+        "label": "Safety System",
+        "description": "If PvP is enabled, allows players to toggle their own PvP on/off."
+      },
+      "ShowSafety": {
+        "label": "Show Safety Status",
+        "description": "Show skull icon for players with safety off."
+      },
+      "SafetyToggleTimer": {
+        "label": "Safety Toggle Timer",
+        "description": "Time in seconds to switch between PvP on and off."
+      },
+      "SafetyCooldownTimer": {
+        "label": "Safety Cooldown Timer",
+        "description": "Time in seconds before you can toggle safety again."
+      },
+      "PVPMeleeWhileHitReaction": {
+        "label": "Melee While Hit Reaction",
+        "description": "Allow melee attacks during hit reaction in PvP."
+      },
+      "PVPMeleeDamageModifier": {
+        "label": "PvP Melee Damage %",
+        "description": "Melee damage modifier for PvP (percentage)."
+      },
+      "PVPFirearmDamageModifier": {
+        "label": "PvP Firearm Damage %",
+        "description": "Firearm damage modifier for PvP (percentage)."
+      },
+      "PlayerBumpPlayer": {
+        "label": "Player Collision",
+        "description": "Players can bump into each other."
+      },
+      "PVPLogToolChat": {
+        "label": "Log PvP to Chat",
+        "description": "PvP events are logged to admin chat."
+      },
+      "PVPLogToolFile": {
+        "label": "Log PvP to File",
+        "description": "PvP events are logged to a file."
+      },
+      "SafetyDisconnectDelay": {
+        "label": "Safety Disconnect Delay",
+        "description": "Seconds before PvP safety mode resets on disconnect."
+      }
+    },
+    "chat": {
+      "GlobalChat": {
+        "label": "Enable Global Chat",
+        "description": "Enable /all command for server-wide chat."
+      },
+      "ChatStreams": {
+        "label": "Chat Streams",
+        "description": "Enabled chat streams: s=say, r=radio, a=admin, w=whisper, y=yell, sh=safehouse, f=faction, all=global."
+      },
+      "DisplayUserName": {
+        "label": "Display Usernames",
+        "description": "Show player usernames above their heads and in chat."
+      },
+      "ShowFirstAndLastName": {
+        "label": "Show Character Names",
+        "description": "Display character first and last name instead of username."
+      },
+      "MouseOverToSeeDisplayName": {
+        "label": "Mouse Over for Name",
+        "description": "Require mouse hover to see player names."
+      },
+      "HidePlayersBehindYou": {
+        "label": "Hide Players Behind You",
+        "description": "Hide player names for players behind your character."
+      },
+      "AllowNonAsciiUsername": {
+        "label": "Allow Non-ASCII Usernames",
+        "description": "Allow usernames with non-ASCII characters."
+      },
+      "BanKickGlobalSound": {
+        "label": "Ban/Kick Sound",
+        "description": "Play global sound when a player is banned or kicked."
+      },
+      "UsernameDisguises": {
+        "label": "Username Disguises",
+        "description": "Allow players to disguise their username."
+      },
+      "HideDisguisedUserName": {
+        "label": "Hide Disguised Names",
+        "description": "Hide the real username of disguised players."
+      },
+      "ChatMessageCharacterLimit": {
+        "label": "Chat Character Limit",
+        "description": "Maximum characters per chat message."
+      },
+      "ChatMessageSlowModeTime": {
+        "label": "Chat Slow Mode",
+        "description": "Seconds between allowed chat messages per player."
+      }
+    },
+    "players": {
+      "MaxAccountsPerUser": {
+        "label": "Max Accounts Per User",
+        "description": "Limit accounts per Steam user. 0 = unlimited."
+      },
+      "DropOffWhiteListAfterDeath": {
+        "label": "Remove From Whitelist On Death",
+        "description": "Remove player from whitelist if their character dies."
+      },
+      "KickFastPlayers": {
+        "label": "Kick Speed Hackers",
+        "description": "Kick players moving faster than possible. May be buggy."
+      },
+      "SpawnPoint": {
+        "label": "Spawn Point",
+        "description": "Custom spawn point coordinates (X,Y,Z). 0,0,0 for default."
+      },
+      "SpawnItems": {
+        "label": "Spawn Items",
+        "description": "Items new characters spawn with (comma-separated, e.g., Base.BaseballBat,Base.WaterBottleFull)."
+      },
+      "SleepAllowed": {
+        "label": "Allow Sleep",
+        "description": "Whether sleeping is allowed."
+      },
+      "SleepNeeded": {
+        "label": "Sleep Required",
+        "description": "Whether players need to sleep when exhausted."
+      },
+      "PlayerRespawnWithSelf": {
+        "label": "Respawn at Death Location",
+        "description": "Allow respawning at death location."
+      },
+      "PlayerRespawnWithOther": {
+        "label": "Respawn with Partner",
+        "description": "Enable spawning at splitscreen partner location."
+      },
+      "PlayerSaveOnDamage": {
+        "label": "Save on Damage",
+        "description": "Save player state when they take damage."
+      },
+      "Faction": {
+        "label": "Enable Factions",
+        "description": "Allow creation and use of factions."
+      },
+      "FactionDaySurvivedToCreate": {
+        "label": "Days to Create Faction",
+        "description": "Days a player must survive to create a faction."
+      },
+      "FactionPlayersRequiredForTag": {
+        "label": "Players for Faction Tag",
+        "description": "Players required in faction to show tag."
+      },
+      "AllowTradeUI": {
+        "label": "Allow Trading",
+        "description": "Allow players to directly trade with one another."
+      },
+      "AllowCoop": {
+        "label": "Allow Co-op",
+        "description": "Allow co-op/splitscreen players to join."
+      },
+      "KnockedDownAllowed": {
+        "label": "Knocked Down",
+        "description": "Allow players to be knocked down. WIP: may cause visual desync."
+      },
+      "SneakModeHideFromOtherPlayers": {
+        "label": "Sneak Hides From Players",
+        "description": "Players in sneak mode are hidden from other players."
+      },
+      "MapRemotePlayerVisibility": {
+        "label": "Map Player Visibility",
+        "description": "Who can see other players on the in-game map.",
+        "options": {
+          "1": {
+            "label": "Hidden"
+          },
+          "2": {
+            "label": "Friends Only"
+          },
+          "3": {
+            "label": "Friends and Nearby Players"
+          },
+          "4": {
+            "label": "Everyone"
+          }
+        }
+      },
+      "DisableScoreboard": {
+        "label": "Disable Scoreboard",
+        "description": "Disable the in-game scoreboard."
+      },
+      "HideAdminsInPlayerList": {
+        "label": "Hide Admins in Player List",
+        "description": "Hide admin accounts from the player list."
+      }
+    },
+    "safehouse": {
+      "PlayerSafehouse": {
+        "label": "Enable Safehouses",
+        "description": "Allow players to claim safehouses."
+      },
+      "AdminSafehouse": {
+        "label": "Admin Safehouses",
+        "description": "Allow admins to have safehouses."
+      },
+      "SafehouseAllowTrepass": {
+        "label": "Allow Trespass",
+        "description": "Allow non-members to enter safehouses without invite."
+      },
+      "SafehouseAllowFire": {
+        "label": "Allow Fire Damage",
+        "description": "Allow fire to damage safehouses."
+      },
+      "SafehouseAllowLoot": {
+        "label": "Allow Looting",
+        "description": "Allow non-members to take items from safehouses."
+      },
+      "SafehouseAllowRespawn": {
+        "label": "Allow Safehouse Respawn",
+        "description": "Players can respawn in their safehouse."
+      },
+      "SafehouseDaySurvivedToClaim": {
+        "label": "Days to Claim Safehouse",
+        "description": "Days a player must survive before claiming a safehouse."
+      },
+      "SafeHouseRemovalTime": {
+        "label": "Safehouse Removal Time",
+        "description": "Real-time hours of inactivity before removal from safehouse."
+      },
+      "DisableSafehouseWhenOwnerConnected": {
+        "label": "Disable When Owner Online",
+        "description": "Disable safehouse protection when the owner is connected. (Renamed from DisableSafehouseWhenPlayerConnected in the Dec 2025 MP patch.)"
+      },
+      "SafehouseAllowNonResidential": {
+        "label": "Allow Non-Residential",
+        "description": "Allow players to claim non-residential buildings as safehouses."
+      },
+      "SafehouseDisableDisguises": {
+        "label": "Disable Disguises in Safehouse",
+        "description": "Disable username disguises inside safehouses."
+      },
+      "MaxSafezoneSize": {
+        "label": "Max Safezone Size",
+        "description": "Maximum tile size for safezones."
+      }
+    },
+    "loot": {
+      "ItemNumbersLimitPerContainer": {
+        "label": "Container Item Limit",
+        "description": "Max items per container. 0 = unlimited."
+      },
+      "TrashDeleteAll": {
+        "label": "Delete All Trash",
+        "description": "Delete all items when placed in trash."
+      },
+      "RemovePlayerCorpsesOnCorpseRemoval": {
+        "label": "Remove Player Corpses",
+        "description": "Remove player corpses when corpse removal runs."
+      },
+      "AllowDestructionBySledgehammer": {
+        "label": "Sledgehammer Destruction",
+        "description": "Allow players to destroy world objects with sledgehammer."
+      },
+      "NoFire": {
+        "label": "Disable Fire",
+        "description": "Disable all fires except campfires."
+      },
+      "SafehousePreventsLootRespawn": {
+        "label": "Safehouse Blocks Loot Respawn",
+        "description": "Items will not respawn in buildings claimed as safehouses."
+      },
+      "SledgehammerOnlyInSafehouse": {
+        "label": "Sledgehammer Only in Safehouse",
+        "description": "Restrict sledgehammer destruction to safehouses only. Requires Sledgehammer Destruction enabled."
+      }
+    },
+    "mods": {
+      "Mods": {
+        "label": "Mods",
+        "description": "List of installed mod IDs (semicolon-separated)."
+      },
+      "WorkshopItems": {
+        "label": "Workshop Items",
+        "description": "Steam Workshop item IDs to download (semicolon-separated)."
+      },
+      "DoLuaChecksum": {
+        "label": "Lua Checksum",
+        "description": "Verify client Lua matches server. Must be disabled when using PanelBridge — the mod modifies server-side Lua files, which causes checksum mismatches and prevents players from connecting."
+      }
+    },
+    "steam": {
+      "SteamPort1": {
+        "label": "Steam Port 1",
+        "description": "First Steam port."
+      },
+      "SteamPort2": {
+        "label": "Steam Port 2",
+        "description": "Second Steam port."
+      },
+      "SteamScoreboard": {
+        "label": "Steam Scoreboard",
+        "description": "Show Steam usernames and avatars. true/false/admin.",
+        "options": {
+          "true": {
+            "label": "Everyone"
+          },
+          "false": {
+            "label": "No One"
+          },
+          "admin": {
+            "label": "Admins Only"
+          }
+        }
+      },
+      "SteamVAC": {
+        "label": "VAC Ban Check",
+        "description": "Check if connecting players have VAC bans."
+      }
+    },
+    "voice": {
+      "VoiceEnable": {
+        "label": "Enable Voice Chat",
+        "description": "Enable in-game voice chat."
+      },
+      "Voice3D": {
+        "label": "3D Voice",
+        "description": "Enable 3D positional voice chat."
+      },
+      "VoiceMinDistance": {
+        "label": "Voice Min Distance",
+        "description": "Minimum voice distance."
+      },
+      "VoiceMaxDistance": {
+        "label": "Voice Max Distance",
+        "description": "Maximum voice distance."
+      }
+    },
+    "discord": {
+      "DiscordEnable": {
+        "label": "Enable Discord",
+        "description": "Enable built-in Discord integration."
+      },
+      "DiscordToken": {
+        "label": "Discord Token",
+        "description": "Discord bot token."
+      },
+      "DiscordChannel": {
+        "label": "Discord Channel",
+        "description": "Discord channel name."
+      },
+      "DiscordChannelID": {
+        "label": "Discord Channel ID",
+        "description": "Discord channel ID."
+      },
+      "DiscordChatChannel": {
+        "label": "Discord Chat Channel",
+        "description": "The Discord channel name for game chat."
+      },
+      "DiscordLogChannel": {
+        "label": "Discord Log Channel",
+        "description": "The Discord channel name for server logs."
+      },
+      "DiscordCommandChannel": {
+        "label": "Discord Command Channel",
+        "description": "The Discord channel name for commands."
+      },
+      "WebhookAddress": {
+        "label": "Webhook URL",
+        "description": "Slack/Discord incoming webhook URL for notifications."
+      }
+    },
+    "rcon": {
+      "RCONPort": {
+        "label": "RCON Port",
+        "description": "Port for RCON connections."
+      },
+      "RCONPassword": {
+        "label": "RCON Password",
+        "description": "Password for RCON connections."
+      }
+    },
+    "advanced": {
+      "ResetID": {
+        "label": "Reset ID",
+        "description": "Removing this resets zombies and loot (not time)."
+      },
+      "ServerPlayerID": {
+        "label": "Server Player ID",
+        "description": "Identifies if character is from another server."
+      },
+      "PhysicsDelay": {
+        "label": "Physics Delay",
+        "description": "Physics update delay in milliseconds."
+      },
+      "FastForwardMultiplier": {
+        "label": "Fast Forward Multiplier",
+        "description": "Speed multiplier when fast-forwarding."
+      },
+      "CarEngineAttractionModifier": {
+        "label": "Car Engine Attraction",
+        "description": "Modifier for zombie attraction to car engines."
+      },
+      "ZombieUpdateMaxHighPriority": {
+        "label": "Zombie High Priority Updates",
+        "description": "Max high priority zombie updates per tick."
+      },
+      "ZombieUpdateDelta": {
+        "label": "Zombie Update Delta",
+        "description": "Zombie update time delta."
+      },
+      "SwitchZombiesOwnershipEachUpdate": {
+        "label": "Switch Zombie Ownership",
+        "description": "Switch zombie ownership between players each update tick."
+      },
+      "UltraSpeedDoesnotAffectToAnimals": {
+        "label": "Ultra Speed Ignores Animals",
+        "description": "Ultra speed mode does not affect animal simulation."
+      },
+      "UsePhysicsHitReaction": {
+        "label": "Physics Hit Reaction",
+        "description": "Use physics-based hit reactions."
+      }
+    },
+    "war": {
+      "War": {
+        "label": "Enable Faction War",
+        "description": "Enable faction war system. (Disabled by default since the Dec 2025 MP patch.)"
+      },
+      "WarStartDelay": {
+        "label": "War Start Delay",
+        "description": "Seconds before war starts after being declared."
+      },
+      "WarDuration": {
+        "label": "War Duration",
+        "description": "War duration in seconds."
+      },
+      "WarSafehouseHitPoints": {
+        "label": "War Safehouse Hit Points",
+        "description": "Safehouse hit points during faction war."
+      }
+    },
+    "radio": {
+      "DisableRadioStaff": {
+        "label": "Disable Radio for Staff",
+        "description": "Disable radio transmissions from staff access level."
+      },
+      "DisableRadioAdmin": {
+        "label": "Disable Radio for Admins",
+        "description": "Disable radio transmissions from admin access level."
+      },
+      "DisableRadioGM": {
+        "label": "Disable Radio for GMs",
+        "description": "Disable radio transmissions from GM access level."
+      },
+      "DisableRadioOverseer": {
+        "label": "Disable Radio for Overseers",
+        "description": "Disable radio transmissions from overseer access level."
+      },
+      "DisableRadioModerator": {
+        "label": "Disable Radio for Moderators",
+        "description": "Disable radio transmissions from moderator access level."
+      },
+      "DisableRadioInvisible": {
+        "label": "Disable Radio for Invisible",
+        "description": "Disable radio transmissions from invisible players."
+      }
+    },
+    "backups": {
+      "BackupsCount": {
+        "label": "Backup Count",
+        "description": "Number of backup copies to keep."
+      },
+      "BackupsOnStart": {
+        "label": "Backup on Start",
+        "description": "Create a backup when the server starts."
+      },
+      "BackupsOnVersionChange": {
+        "label": "Backup on Version Change",
+        "description": "Create a backup when the game version changes."
+      },
+      "BackupsPeriod": {
+        "label": "Backup Period",
+        "description": "Minutes between automatic backups. 0 = disabled."
+      }
+    },
+    "vehicles": {
+      "DisableVehicleTowing": {
+        "label": "Disable Vehicle Towing",
+        "description": "Disable vehicle towing."
+      },
+      "DisableTrailerTowing": {
+        "label": "Disable Trailer Towing",
+        "description": "Disable trailer towing."
+      },
+      "DisableBurntTowing": {
+        "label": "Disable Burnt Vehicle Towing",
+        "description": "Disable towing of burnt vehicles."
+      }
+    },
+    "moderation": {
+      "BadWordListFile": {
+        "label": "Bad Word List File",
+        "description": "Path to file with prohibited words, one per line."
+      },
+      "GoodWordListFile": {
+        "label": "Good Word List File",
+        "description": "Path to file with allowed words that may contain bad words, one per line."
+      },
+      "BadWordPolicy": {
+        "label": "Bad Word Policy",
+        "description": "Action taken when a bad word is detected in chat.",
+        "options": {
+          "1": {
+            "label": "Ban"
+          },
+          "2": {
+            "label": "Kick"
+          },
+          "3": {
+            "label": "Record Violation"
+          },
+          "4": {
+            "label": "Mute"
+          }
+        }
+      },
+      "BadWordReplacement": {
+        "label": "Bad Word Replacement",
+        "description": "Text that replaces bad words in chat."
+      }
+    },
+    "anticheat": {
+      "AntiCheatSafety": {
+        "label": "Safety",
+        "description": "Anti-cheat protection for the safety system.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSpeed": {
+        "label": "Speed",
+        "description": "Anti-cheat protection for player speed.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatNoClip": {
+        "label": "No Clip",
+        "description": "Anti-cheat protection against moving through solid objects.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatHit": {
+        "label": "Hit Detection",
+        "description": "Anti-cheat protection for character hits.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPacketException": {
+        "label": "Packet Exceptions",
+        "description": "Anti-cheat protection for invalid network packets.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPermission": {
+        "label": "Permissions",
+        "description": "Anti-cheat protection for player permissions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatXP": {
+        "label": "XP Validation",
+        "description": "Anti-cheat protection for player XP.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatSafeHouse": {
+        "label": "Safehouse Protection",
+        "description": "Anti-cheat protection for safehouses.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatPlayer": {
+        "label": "Player Validation",
+        "description": "Anti-cheat protection for player actions.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      },
+      "AntiCheatChecksum": {
+        "label": "Checksum Validation",
+        "description": "Anti-cheat protection for file checksums.",
+        "options": {
+          "1": {
+            "label": "1 - Ban"
+          },
+          "2": {
+            "label": "2 - Kick"
+          },
+          "3": {
+            "label": "3 - Log"
+          },
+          "4": {
+            "label": "4 - Disabled"
+          }
+        }
+      }
+    },
+    "logging": {
+      "ClientCommandFilter": {
+        "label": "Command Log Filter",
+        "description": "Semicolon-separated list of commands to exclude from cmd.txt log. Use -vehicle.* to exclude all vehicle, +vehicle.installPart to include specific."
+      },
+      "ClientActionLogs": {
+        "label": "Client Action Logs",
+        "description": "Semicolon-separated list of actions written to ClientActionLogs.txt."
+      },
+      "PerkLogs": {
+        "label": "Perk Level Logging",
+        "description": "Track changes in player perk levels in PerkLog.txt."
+      }
+    }
+  },
+  "sandboxSettings": {
+    "time": {
+      "DayLength": {
+        "label": "Day Length",
+        "description": "How long a day lasts.",
+        "options": {
+          "1": {
+            "label": "15 Minutes"
+          },
+          "2": {
+            "label": "30 Minutes"
+          },
+          "3": {
+            "label": "1 Hour"
+          },
+          "4": {
+            "label": "1 Hour, 30 Minutes"
+          },
+          "5": {
+            "label": "2 Hours"
+          },
+          "6": {
+            "label": "3 Hours"
+          },
+          "7": {
+            "label": "4 Hours"
+          },
+          "8": {
+            "label": "5 Hours"
+          },
+          "9": {
+            "label": "6 Hours"
+          },
+          "10": {
+            "label": "7 Hours"
+          },
+          "11": {
+            "label": "8 Hours"
+          },
+          "12": {
+            "label": "9 Hours"
+          },
+          "13": {
+            "label": "10 Hours"
+          },
+          "14": {
+            "label": "11 Hours"
+          },
+          "15": {
+            "label": "12 Hours"
+          },
+          "16": {
+            "label": "13 Hours"
+          },
+          "17": {
+            "label": "14 Hours"
+          },
+          "18": {
+            "label": "15 Hours"
+          },
+          "19": {
+            "label": "16 Hours"
+          },
+          "20": {
+            "label": "17 Hours"
+          },
+          "21": {
+            "label": "18 Hours"
+          },
+          "22": {
+            "label": "19 Hours"
+          },
+          "23": {
+            "label": "20 Hours"
+          },
+          "24": {
+            "label": "21 Hours"
+          },
+          "25": {
+            "label": "22 Hours"
+          },
+          "26": {
+            "label": "23 Hours"
+          },
+          "27": {
+            "label": "Real-time"
+          }
+        }
+      },
+      "StartYear": {
+        "label": "Start Year",
+        "description": "Which year the game starts in."
+      },
+      "StartMonth": {
+        "label": "Start Month",
+        "description": "Which month the game starts in (1=Jan, 12=Dec).",
+        "options": {
+          "1": {
+            "label": "January"
+          },
+          "2": {
+            "label": "February"
+          },
+          "3": {
+            "label": "March"
+          },
+          "4": {
+            "label": "April"
+          },
+          "5": {
+            "label": "May"
+          },
+          "6": {
+            "label": "June"
+          },
+          "7": {
+            "label": "July"
+          },
+          "8": {
+            "label": "August"
+          },
+          "9": {
+            "label": "September"
+          },
+          "10": {
+            "label": "October"
+          },
+          "11": {
+            "label": "November"
+          },
+          "12": {
+            "label": "December"
+          }
+        }
+      },
+      "StartDay": {
+        "label": "Start Day",
+        "description": "Which day of the month the game starts on."
+      },
+      "StartTime": {
+        "label": "Start Time",
+        "description": "What time of day the game starts.",
+        "options": {
+          "1": {
+            "label": "7 AM"
+          },
+          "2": {
+            "label": "9 AM"
+          },
+          "3": {
+            "label": "12 PM"
+          },
+          "4": {
+            "label": "2 PM"
+          },
+          "5": {
+            "label": "5 PM"
+          },
+          "6": {
+            "label": "9 PM"
+          },
+          "7": {
+            "label": "12 AM"
+          },
+          "8": {
+            "label": "2 AM"
+          },
+          "9": {
+            "label": "5 AM"
+          }
+        }
+      }
+    },
+    "population": {
+      "Zombies": {
+        "label": "Zombie Count",
+        "description": "Initial zombie population level. Also sets Population Multiplier in Advanced Zombie Options.",
+        "options": {
+          "1": {
+            "label": "Insane"
+          },
+          "2": {
+            "label": "Very High"
+          },
+          "3": {
+            "label": "High"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Low"
+          },
+          "6": {
+            "label": "None"
+          }
+        }
+      },
+      "Distribution": {
+        "label": "Distribution",
+        "description": "How zombies are distributed across the map.",
+        "options": {
+          "1": {
+            "label": "Urban Focused"
+          },
+          "2": {
+            "label": "Uniform"
+          }
+        }
+      },
+      "ZombieVoronoiNoise": {
+        "label": "Randomize Distribution",
+        "description": "Apply randomization to zombie distribution."
+      },
+      "ZombieRespawn": {
+        "label": "Zombie Respawn",
+        "description": "How frequently new zombies are added to the world.",
+        "options": {
+          "1": {
+            "label": "High"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Low"
+          },
+          "4": {
+            "label": "None"
+          }
+        }
+      },
+      "ZombieMigrate": {
+        "label": "Zombie Migration",
+        "description": "Zombies can migrate to empty cells."
+      }
+    },
+    "loot": {
+      "LootItemRemovalList": {
+        "label": "Loot Item Removal List",
+        "description": "Comma-separated item types removed from the world by the loot cleanup system."
+      },
+      "FoodLootNew": {
+        "label": "Food Loot",
+        "description": "Any food that can rot or spoil."
+      },
+      "CannedFoodLootNew": {
+        "label": "Canned Food Loot",
+        "description": "Canned and dried food, beverages."
+      },
+      "LiteratureLootNew": {
+        "label": "Literature Loot",
+        "description": "All readable items including books, fliers, and newspapers."
+      },
+      "SkillBookLoot": {
+        "label": "Skill Book Loot",
+        "description": "Books that provide skill XP multipliers."
+      },
+      "RecipeResourceLoot": {
+        "label": "Recipe Loot",
+        "description": "Items that teach recipes."
+      },
+      "MedicalLootNew": {
+        "label": "Medical Loot",
+        "description": "Medicine, bandages, and first aid tools."
+      },
+      "SurvivalGearsLootNew": {
+        "label": "Survival Gear Loot",
+        "description": "Fishing rods, tents, camping gear."
+      },
+      "WeaponLootNew": {
+        "label": "Melee Weapon Loot",
+        "description": "Weapons that are not tools in other categories."
+      },
+      "RangedWeaponLootNew": {
+        "label": "Ranged Weapon Loot",
+        "description": "Ranged weapons and weapon attachments."
+      },
+      "AmmoLootNew": {
+        "label": "Ammo Loot",
+        "description": "Loose ammo, boxes, and magazines."
+      },
+      "MechanicsLootNew": {
+        "label": "Mechanics Loot",
+        "description": "Vehicle parts and installation tools."
+      },
+      "ClothingLootNew": {
+        "label": "Clothing Loot",
+        "description": "All wearable items that are not containers."
+      },
+      "ContainerLootNew": {
+        "label": "Container Loot",
+        "description": "Backpacks and wearable/equippable containers."
+      },
+      "KeyLootNew": {
+        "label": "Key Loot",
+        "description": "Keys for buildings/cars, key rings, and locks."
+      },
+      "MediaLootNew": {
+        "label": "Media Loot",
+        "description": "VHS tapes and CDs."
+      },
+      "MementoLootNew": {
+        "label": "Memento Loot",
+        "description": "Spiffo items, plushies, and collectible keepsakes."
+      },
+      "CookwareLootNew": {
+        "label": "Cookware Loot",
+        "description": "Cooking items including those that can be weapons. Does not include food."
+      },
+      "MaterialLootNew": {
+        "label": "Material Loot",
+        "description": "Crafting and building materials."
+      },
+      "FarmingLootNew": {
+        "label": "Farming Loot",
+        "description": "Seeds, trowels, shovels, and agriculture tools."
+      },
+      "ToolLootNew": {
+        "label": "Tool Loot",
+        "description": "Tools not in other categories like Mechanics or Farming."
+      },
+      "OtherLootNew": {
+        "label": "Other Loot",
+        "description": "Everything else. Also affects foraging in Town/Road zones."
+      },
+      "RollsMultiplier": {
+        "label": "Rolls Multiplier",
+        "description": "Multiplier for loot table rolls. Higher values may affect performance. NOT recommended to change."
+      },
+      "RemoveStoryLoot": {
+        "label": "Remove Story Loot",
+        "description": "Items on the removal list will not spawn in world stories."
+      },
+      "RemoveZombieLoot": {
+        "label": "Remove Zombie Loot",
+        "description": "Items on the removal list will not spawn on zombies."
+      },
+      "ZombiePopLootEffect": {
+        "label": "Zombie Pop Loot Effect",
+        "description": "If > 0, loot increases relative to nearby zombies, multiplied by this value."
+      },
+      "HoursForLootRespawn": {
+        "label": "Loot Respawn Hours",
+        "description": "Hours after which containers respawn loot. 0 = never."
+      },
+      "MaxItemsForLootRespawn": {
+        "label": "Max Items for Respawn",
+        "description": "Containers with this many items or more will not respawn loot."
+      },
+      "ConstructionPreventsLootRespawn": {
+        "label": "Construction Blocks Respawn",
+        "description": "Player constructions near containers prevent loot respawn."
+      },
+      "SeenHoursPreventLootRespawn": {
+        "label": "Seen Hours Prevent Respawn",
+        "description": "Hours a zone must be unvisited before loot respawns. 0 = disabled."
+      }
+    },
+    "lootRarity": {
+      "InsaneLootFactor": {
+        "label": "Insane Rarity Factor",
+        "description": "Spawn rate for Insane rarity items."
+      },
+      "ExtremeLootFactor": {
+        "label": "Extreme Rarity Factor",
+        "description": "Spawn rate for Extreme rarity items."
+      },
+      "RareLootFactor": {
+        "label": "Rare Rarity Factor",
+        "description": "Spawn rate for Rare rarity items."
+      },
+      "NormalLootFactor": {
+        "label": "Normal Rarity Factor",
+        "description": "Spawn rate for Normal rarity items."
+      },
+      "CommonLootFactor": {
+        "label": "Common Rarity Factor",
+        "description": "Spawn rate for Common rarity items."
+      },
+      "AbundantLootFactor": {
+        "label": "Abundant Rarity Factor",
+        "description": "Spawn rate for Abundant rarity items."
+      },
+      "MaximumLooted": {
+        "label": "Max Looted Building Chance",
+        "description": "Chance that any building is already looted when found."
+      },
+      "DaysUntilMaximumLooted": {
+        "label": "Days Until Max Looted",
+        "description": "Days before Maximum Looted Building Chance is reached."
+      },
+      "RuralLooted": {
+        "label": "Rural Looted Chance",
+        "description": "Chance that any rural building is already looted."
+      },
+      "MaximumDiminishedLoot": {
+        "label": "Max Diminished Loot %",
+        "description": "Maximum loot that won't spawn when diminished days reached."
+      },
+      "DaysUntilMaximumDiminishedLoot": {
+        "label": "Days Until Max Diminished",
+        "description": "Days before Maximum Diminished Loot is reached."
+      },
+      "MaximumLootedBuildingRooms": {
+        "label": "Max Looted Building Rooms",
+        "description": "Buildings with more than this many rooms will not be auto-looted."
+      }
+    },
+    "environment": {
+      "DayNightCycle": {
+        "label": "Day/Night Cycle",
+        "description": "Whether time of day changes naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Endless Day"
+          },
+          "3": {
+            "label": "Endless Night"
+          }
+        }
+      },
+      "ClimateCycle": {
+        "label": "Weather Cycle",
+        "description": "Whether weather changes or remains fixed.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "No Weather"
+          },
+          "3": {
+            "label": "Endless Rain"
+          },
+          "4": {
+            "label": "Endless Storm"
+          },
+          "5": {
+            "label": "Endless Snow"
+          },
+          "6": {
+            "label": "Endless Blizzard"
+          }
+        }
+      },
+      "FogCycle": {
+        "label": "Fog Cycle",
+        "description": "Whether fog occurs naturally.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "No Fog"
+          },
+          "3": {
+            "label": "Endless Fog"
+          }
+        }
+      },
+      "WaterShut": {
+        "label": "Water Shutoff",
+        "description": "When plumbing fixtures stop being infinite water sources.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0 - 30 Days"
+          },
+          "3": {
+            "label": "0 - 2 Months"
+          },
+          "4": {
+            "label": "0 - 6 Months"
+          },
+          "5": {
+            "label": "0 - 1 Year"
+          },
+          "6": {
+            "label": "0 - 5 Years"
+          },
+          "7": {
+            "label": "2 - 6 Months"
+          },
+          "8": {
+            "label": "6 - 12 Months"
+          },
+          "9": {
+            "label": "Disabled"
+          }
+        }
+      },
+      "ElecShut": {
+        "label": "Electricity Shutoff",
+        "description": "When the world's electricity turns off.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "14 - 30 Days"
+          },
+          "3": {
+            "label": "14 Days - 2 Months"
+          },
+          "4": {
+            "label": "14 Days - 6 Months"
+          },
+          "5": {
+            "label": "14 Days - 1 Year"
+          },
+          "6": {
+            "label": "14 Days - 5 Years"
+          },
+          "7": {
+            "label": "2 - 6 Months"
+          },
+          "8": {
+            "label": "6 - 12 Months"
+          },
+          "9": {
+            "label": "Disabled"
+          }
+        }
+      },
+      "AlarmDecay": {
+        "label": "Alarm Battery Decay",
+        "description": "How long alarm batteries last after power shuts off.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0 - 30 Days"
+          },
+          "3": {
+            "label": "0 - 2 Months"
+          },
+          "4": {
+            "label": "0 - 6 Months"
+          },
+          "5": {
+            "label": "0 - 1 Year"
+          },
+          "6": {
+            "label": "0 - 5 Years"
+          },
+          "7": {
+            "label": "2 - 6 Months"
+          },
+          "8": {
+            "label": "6 - 12 Months"
+          },
+          "9": {
+            "label": "Disabled"
+          }
+        }
+      },
+      "WaterShutModifier": {
+        "label": "Water Shutoff Modifier",
+        "description": "Fine-tune water shutoff timing in days."
+      },
+      "ElecShutModifier": {
+        "label": "Electricity Shutoff Modifier",
+        "description": "Fine-tune electricity shutoff timing in days."
+      },
+      "AlarmDecayModifier": {
+        "label": "Alarm Decay Modifier",
+        "description": "Fine-tune alarm battery decay timing in days."
+      },
+      "Temperature": {
+        "label": "Temperature",
+        "description": "Global temperature setting.",
+        "options": {
+          "1": {
+            "label": "Very Cold"
+          },
+          "2": {
+            "label": "Cold"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Hot"
+          },
+          "5": {
+            "label": "Very Hot"
+          }
+        }
+      },
+      "Rain": {
+        "label": "Rainfall",
+        "description": "How often it rains.",
+        "options": {
+          "1": {
+            "label": "Very Dry"
+          },
+          "2": {
+            "label": "Dry"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Rainy"
+          },
+          "5": {
+            "label": "Very Rainy"
+          }
+        }
+      },
+      "ErosionSpeed": {
+        "label": "Erosion Speed",
+        "description": "How fast nature reclaims the world.",
+        "options": {
+          "1": {
+            "label": "Very Fast (20 Days)"
+          },
+          "2": {
+            "label": "Fast (50 Days)"
+          },
+          "3": {
+            "label": "Normal (100 Days)"
+          },
+          "4": {
+            "label": "Slow (200 Days)"
+          },
+          "5": {
+            "label": "Very Slow (500 Days)"
+          }
+        }
+      },
+      "ErosionDays": {
+        "label": "Custom Erosion Days",
+        "description": "Custom erosion days. 0 = use Erosion Speed option."
+      },
+      "MaxFogIntensity": {
+        "label": "Max Fog Intensity",
+        "description": "Maximum intensity of fog.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Moderate"
+          },
+          "3": {
+            "label": "Low"
+          },
+          "4": {
+            "label": "None"
+          }
+        }
+      },
+      "MaxRainFxIntensity": {
+        "label": "Max Rain FX Intensity",
+        "description": "Maximum intensity of rain effects.",
+        "options": {
+          "1": {
+            "label": "Normal"
+          },
+          "2": {
+            "label": "Moderate"
+          },
+          "3": {
+            "label": "Low"
+          }
+        }
+      },
+      "EnableSnowOnGround": {
+        "label": "Snow on Ground",
+        "description": "Whether snow accumulates on the ground."
+      },
+      "NightDarkness": {
+        "label": "Night Darkness",
+        "description": "Ambient lighting level at night.",
+        "options": {
+          "1": {
+            "label": "Pitch Black"
+          },
+          "2": {
+            "label": "Dark"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Bright"
+          }
+        }
+      },
+      "NightLength": {
+        "label": "Night Length",
+        "description": "Duration from dusk to dawn.",
+        "options": {
+          "1": {
+            "label": "Always Night"
+          },
+          "2": {
+            "label": "Long"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Short"
+          },
+          "5": {
+            "label": "Always Day"
+          }
+        }
+      },
+      "TimeSinceApo": {
+        "label": "Time Since Apocalypse",
+        "description": "How long after the apocalypse the game begins. Affects erosion and food spoilage.",
+        "options": {
+          "1": {
+            "label": "0"
+          },
+          "2": {
+            "label": "1"
+          },
+          "3": {
+            "label": "2"
+          },
+          "4": {
+            "label": "3"
+          },
+          "5": {
+            "label": "4"
+          },
+          "6": {
+            "label": "5"
+          },
+          "7": {
+            "label": "6"
+          },
+          "8": {
+            "label": "7"
+          },
+          "9": {
+            "label": "8"
+          },
+          "10": {
+            "label": "9"
+          },
+          "11": {
+            "label": "10"
+          },
+          "12": {
+            "label": "11"
+          },
+          "13": {
+            "label": "12"
+          }
+        }
+      },
+      "FireSpread": {
+        "label": "Fire Spread",
+        "description": "Whether fires spread when started."
+      }
+    },
+    "survival": {
+      "StatsDecrease": {
+        "label": "Stats Decrease",
+        "description": "How fast hunger, thirst, and fatigue decrease.",
+        "options": {
+          "1": {
+            "label": "Very Fast"
+          },
+          "2": {
+            "label": "Fast"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Slow"
+          },
+          "5": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "Nutrition": {
+        "label": "Nutrition",
+        "description": "Food nutrition affects player weight and condition."
+      },
+      "FoodRotSpeed": {
+        "label": "Food Rot Speed",
+        "description": "How fast food spoils.",
+        "options": {
+          "1": {
+            "label": "Very Fast"
+          },
+          "2": {
+            "label": "Fast"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Slow"
+          },
+          "5": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "FridgeFactor": {
+        "label": "Fridge Effectiveness",
+        "description": "How effective fridges are at preserving food.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          },
+          "6": {
+            "label": "No decay"
+          }
+        }
+      },
+      "StarterKit": {
+        "label": "Starter Kit",
+        "description": "Spawn with chips, water bottle, backpack, bat, and hammer."
+      },
+      "CharacterFreePoints": {
+        "label": "Free Character Points",
+        "description": "Extra free points during character creation."
+      },
+      "BoneFracture": {
+        "label": "Bone Fractures",
+        "description": "Survivors can get broken limbs from impacts, falls, etc."
+      },
+      "InjurySeverity": {
+        "label": "Injury Severity",
+        "description": "Impact of injuries and healing time.",
+        "options": {
+          "1": {
+            "label": "Low"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "High"
+          }
+        }
+      },
+      "EndRegen": {
+        "label": "Endurance Recovery",
+        "description": "Recovery from tiredness after actions.",
+        "options": {
+          "1": {
+            "label": "Very Fast"
+          },
+          "2": {
+            "label": "Fast"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Slow"
+          },
+          "5": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "HoursForCorpseRemoval": {
+        "label": "Corpse Removal Hours",
+        "description": "Hours before zombie corpses disappear. 0 = no maggots spawn."
+      },
+      "DecayingCorpseHealthImpact": {
+        "label": "Corpse Health Impact",
+        "description": "Impact of nearby decaying bodies on health/emotions.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Insane"
+          }
+        }
+      },
+      "ZombieHealthImpact": {
+        "label": "Zombie Health Impact",
+        "description": "Whether living zombies also affect player health/emotions."
+      },
+      "BloodLevel": {
+        "label": "Blood Level",
+        "description": "How much blood sprays on surfaces.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Ultra Gore"
+          }
+        }
+      },
+      "ClothingDegradation": {
+        "label": "Clothing Degradation",
+        "description": "How quickly clothing degrades and gets dirty.",
+        "options": {
+          "1": {
+            "label": "Disabled"
+          },
+          "2": {
+            "label": "Slow"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Fast"
+          }
+        }
+      },
+      "DaysForRottenFoodRemoval": {
+        "label": "Rotten Food Removal Days",
+        "description": "Days before rotten food is removed. -1 = never."
+      },
+      "AllClothesUnlocked": {
+        "label": "All Clothes Unlocked",
+        "description": "Select from every clothing item during character creation."
+      },
+      "EnableTaintedWaterText": {
+        "label": "Tainted Water Warning",
+        "description": "Show warning marking tainted water."
+      },
+      "EnablePoisoning": {
+        "label": "Enable Poisoning",
+        "description": "Whether poison can be added to food.",
+        "options": {
+          "1": {
+            "label": "True"
+          },
+          "2": {
+            "label": "False"
+          },
+          "3": {
+            "label": "Only bleach poisoning is disabled"
+          }
+        }
+      },
+      "MaggotSpawn": {
+        "label": "Maggot Spawn",
+        "description": "When maggots spawn in corpses.",
+        "options": {
+          "1": {
+            "label": "In and Around Bodies"
+          },
+          "2": {
+            "label": "In Bodies Only"
+          },
+          "3": {
+            "label": "Never"
+          }
+        }
+      },
+      "MuscleStrainFactor": {
+        "label": "Muscle Strain Factor",
+        "description": "Multiplier for muscle strain from swinging weapons or carrying heavy loads."
+      },
+      "DiscomfortFactor": {
+        "label": "Discomfort Factor",
+        "description": "Multiplier for discomfort from worn items."
+      },
+      "WoundInfectionFactor": {
+        "label": "Wound Infection Factor",
+        "description": "Damage from serious wound infections. 0 = disabled."
+      },
+      "NoBlackClothes": {
+        "label": "No Black Clothes",
+        "description": "Prevent randomized clothing from becoming near-black."
+      },
+      "EasyClimbing": {
+        "label": "Easy Climbing",
+        "description": "Disable failure chances when climbing sheet ropes or walls."
+      },
+      "NegativeTraitsPenalty": {
+        "label": "Negative Traits Penalty",
+        "description": "Diminishing returns on bonus points from negative traits.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "1 point penalty for every 3 negative traits selected"
+          },
+          "3": {
+            "label": "1 point penalty for every 2 negative traits selected"
+          },
+          "4": {
+            "label": "1 point penalty for every negative trait selected after the first"
+          }
+        }
+      },
+      "MinutesPerPage": {
+        "label": "Minutes Per Page",
+        "description": "In-game minutes to read one page of a skill book."
+      },
+      "LiteratureCooldown": {
+        "label": "Literature Cooldown",
+        "description": "Days before previously read literature can benefit again."
+      },
+      "LevelForMediaXPCutoff": {
+        "label": "Media XP Cutoff Level",
+        "description": "Skill level at which TV/VHS/media no longer provides XP."
+      },
+      "LevelForDismantleXPCutoff": {
+        "label": "Dismantle XP Cutoff Level",
+        "description": "Skill level at which scrapping furniture gives no XP."
+      },
+      "BloodSplatLifespanDays": {
+        "label": "Blood Splat Lifespan",
+        "description": "Days before blood splats disappear. 0 = never."
+      },
+      "MetaKnowledge": {
+        "label": "Meta Knowledge",
+        "description": "How unseen/unread media is displayed.",
+        "options": {
+          "1": {
+            "label": "Fully revealed"
+          },
+          "2": {
+            "label": "Shown as ???"
+          },
+          "3": {
+            "label": "Completely hidden"
+          }
+        }
+      },
+      "SeeNotLearntRecipe": {
+        "label": "See Unlearned Recipes",
+        "description": "See station recipes even if not yet learned."
+      },
+      "LightBulbLifespan": {
+        "label": "Light Bulb Lifespan",
+        "description": "Higher = bulbs last longer. 0 = never break."
+      },
+      "MaximumFireFuelHours": {
+        "label": "Max Fire Fuel Hours",
+        "description": "Max hours of fuel for campfires, wood stoves, etc."
+      },
+      "Alarm": {
+        "label": "House Alarms",
+        "description": "Frequency of residential alarms.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "LockedHouses": {
+        "label": "Locked Houses",
+        "description": "Frequency of locked houses.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "Helicopter": {
+        "label": "Helicopter Events",
+        "description": "Helicopter frequency.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Once"
+          },
+          "3": {
+            "label": "Sometimes"
+          },
+          "4": {
+            "label": "Often"
+          }
+        }
+      },
+      "MetaEvent": {
+        "label": "Meta Events",
+        "description": "Distant gunshots, screams, etc.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Sometimes"
+          },
+          "3": {
+            "label": "Often"
+          }
+        }
+      },
+      "SleepingEvent": {
+        "label": "Sleeping Events",
+        "description": "Events that happen while sleeping.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Sometimes"
+          },
+          "3": {
+            "label": "Often"
+          }
+        }
+      },
+      "NatureAbundance": {
+        "label": "Nature Abundance",
+        "description": "Governs abundance of wild foods, medicinal plants, etc.",
+        "options": {
+          "1": {
+            "label": "Very Poor"
+          },
+          "2": {
+            "label": "Poor"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundant"
+          },
+          "5": {
+            "label": "Very Abundant"
+          }
+        }
+      },
+      "FishAbundance": {
+        "label": "Fish Abundance",
+        "description": "Governs abundance of fish.",
+        "options": {
+          "1": {
+            "label": "Very Poor"
+          },
+          "2": {
+            "label": "Poor"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundant"
+          },
+          "5": {
+            "label": "Very Abundant"
+          }
+        }
+      },
+      "AnnotatedMapChance": {
+        "label": "Annotated Map Chance",
+        "description": "Chance of finding maps annotated with local features.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "ConstructionBonusPoints": {
+        "label": "Construction Bonus Points",
+        "description": "Extra points for carpentry/metalworking constructions."
+      },
+      "GeneratorSpawning": {
+        "label": "Generator Spawning",
+        "description": "How many generators spawn in the world.",
+        "options": {
+          "1": {
+            "label": "None (not recommended)"
+          },
+          "2": {
+            "label": "Insanely Rare"
+          },
+          "3": {
+            "label": "Extremely Rare"
+          },
+          "4": {
+            "label": "Rare"
+          },
+          "5": {
+            "label": "Normal"
+          },
+          "6": {
+            "label": "Common"
+          },
+          "7": {
+            "label": "Abundant"
+          }
+        }
+      },
+      "GeneratorFuelConsumption": {
+        "label": "Generator Fuel Consumption",
+        "description": "How fast generators consume fuel."
+      },
+      "AllowExteriorGenerator": {
+        "label": "Allow Exterior Generator",
+        "description": "Generators can be placed outdoors and inside tents."
+      },
+      "GeneratorTileRange": {
+        "label": "Generator Tile Range",
+        "description": "Horizontal range of generators in tiles."
+      },
+      "GeneratorVerticalPowerRange": {
+        "label": "Generator Vertical Range",
+        "description": "Vertical range of generators in floors."
+      },
+      "CompostTime": {
+        "label": "Compost Time",
+        "description": "How long composting takes.",
+        "options": {
+          "1": {
+            "label": "1 Week"
+          },
+          "2": {
+            "label": "2 Weeks"
+          },
+          "3": {
+            "label": "3 Weeks"
+          },
+          "4": {
+            "label": "4 Weeks"
+          },
+          "5": {
+            "label": "6 Weeks"
+          },
+          "6": {
+            "label": "8 Weeks"
+          },
+          "7": {
+            "label": "10 Weeks"
+          },
+          "8": {
+            "label": "12 Weeks"
+          }
+        }
+      },
+      "AttackBlockMovements": {
+        "label": "Attack Block Movements",
+        "description": "Player can't move while performing melee attacks."
+      },
+      "WorldItemRemovalList": {
+        "label": "World Item Removal List",
+        "description": "Types of items removed from world (comma separated, e.g. Base.Vest)."
+      },
+      "HoursForWorldItemRemoval": {
+        "label": "World Item Removal Hours",
+        "description": "Hours before listed items disappear from world. 0 = disabled."
+      },
+      "ItemRemovalListBlacklistToggle": {
+        "label": "Item Removal Blacklist Toggle",
+        "description": "If true, removal list acts as blacklist (remove everything except listed). Default is whitelist."
+      }
+    },
+    "combat": {
+      "MultiHitZombies": {
+        "label": "Multi-Hit Zombies",
+        "description": "A melee weapon can hit multiple zombies in one swing."
+      },
+      "RearVulnerability": {
+        "label": "Rear Vulnerability",
+        "description": "Zombies take more damage when attacked from behind.",
+        "options": {
+          "1": {
+            "label": "Low"
+          },
+          "2": {
+            "label": "Medium"
+          },
+          "3": {
+            "label": "High"
+          }
+        }
+      },
+      "FirearmUseDamageChance": {
+        "label": "Firearm Use Damage Chance",
+        "description": "Chance of weapon condition loss per use. 0 = never."
+      },
+      "FirearmNoiseMultiplier": {
+        "label": "Firearm Noise Multiplier",
+        "description": "Multiplier for gun noise attracting zombies."
+      },
+      "FirearmJamMultiplier": {
+        "label": "Firearm Jam Multiplier",
+        "description": "Multiplier for jamming chance."
+      },
+      "FirearmMoodleMultiplier": {
+        "label": "Firearm Moodle Multiplier",
+        "description": "Multiplier for panic/stress from gun use."
+      },
+      "FirearmWeatherMultiplier": {
+        "label": "Firearm Weather Multiplier",
+        "description": "Multiplier for rain affecting gun condition."
+      },
+      "FirearmHeadGearEffect": {
+        "label": "Firearm Head Gear Effect",
+        "description": "How much head-covering gear like helmets affects firearm aim/shoulder."
+      }
+    },
+    "vehicles": {
+      "EnableVehicles": {
+        "label": "Enable Vehicles",
+        "description": "Whether vehicles spawn and can be used."
+      },
+      "CarSpawnRate": {
+        "label": "Car Spawn Rate",
+        "description": "How many vehicles spawn.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Very Low"
+          },
+          "3": {
+            "label": "Low"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "High"
+          }
+        }
+      },
+      "VehicleEasyUse": {
+        "label": "Vehicle Easy Use",
+        "description": "All vehicles are automatic and easy to start."
+      },
+      "InitialGas": {
+        "label": "Initial Vehicle Gas",
+        "description": "How full the gas tank of discovered vehicles will be.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          },
+          "6": {
+            "label": "Full"
+          }
+        }
+      },
+      "FuelStationGasInfinite": {
+        "label": "Infinite Fuel Station Gas",
+        "description": "If enabled, gas pumps will never run out of fuel."
+      },
+      "FuelStationGasMin": {
+        "label": "Fuel Station Gas Min",
+        "description": "The minimum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasMax": {
+        "label": "Fuel Station Gas Max",
+        "description": "The maximum amount of gasoline that can spawn in gas pumps."
+      },
+      "FuelStationGasEmptyChance": {
+        "label": "Fuel Station Empty Chance",
+        "description": "The chance, as a percentage, that individual gas pumps will initially have no fuel."
+      },
+      "LockedCar": {
+        "label": "Locked Car Chance",
+        "description": "Chance of vehicle doors being locked.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "CarGasConsumption": {
+        "label": "Gas Consumption",
+        "description": "Rate of fuel consumption in vehicles."
+      },
+      "CarGeneralCondition": {
+        "label": "Car General Condition",
+        "description": "Initial condition of discovered vehicles.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "CarDamageOnImpact": {
+        "label": "Car Damage on Impact",
+        "description": "Damage vehicles take from collisions.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "DamageToPlayerFromHitByACar": {
+        "label": "Car Damage to Player",
+        "description": "How much damage players receive from vehicle impacts.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "TrafficJam": {
+        "label": "Traffic Jams",
+        "description": "Whether traffic jams spawn on roads."
+      },
+      "CarAlarm": {
+        "label": "Car Alarms",
+        "description": "Chance of vehicles having active alarms.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "PlayerDamageFromCrash": {
+        "label": "Crash Damage to Player",
+        "description": "If the player can get injured from being in a car accident."
+      },
+      "SirenShutoffHours": {
+        "label": "Siren Shutoff Hours",
+        "description": "Hours before vehicle siren batteries die. 0 = instant."
+      },
+      "ChanceHasGas": {
+        "label": "Chance Has Gas",
+        "description": "The chance of finding a vehicle with gas in its tank.",
+        "options": {
+          "1": {
+            "label": "Low"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "High"
+          }
+        }
+      },
+      "RecentlySurvivorVehicles": {
+        "label": "Recently Survivor Vehicles",
+        "description": "Whether a player can discover a car that has been cared for after the Knox infection struck.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          }
+        }
+      },
+      "ZombieAttractionMultiplier": {
+        "label": "Vehicle Zombie Attraction",
+        "description": "Multiplier for vehicle sounds attracting zombies."
+      },
+      "SirenEffectsZombies": {
+        "label": "Siren Effects Zombies",
+        "description": "If zombies will head towards the sound of vehicle sirens."
+      }
+    },
+    "animals": {
+      "AnimalStatsModifier": {
+        "label": "Animal Stats Speed",
+        "description": "Speed at which animal stats (hunger, thirst etc.) reduce.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalMetaStatsModifier": {
+        "label": "Animal Meta Stats Speed",
+        "description": "Speed at which animal stats reduce while in meta (overworld).",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalPregnancyTime": {
+        "label": "Animal Pregnancy Time",
+        "description": "How long animals will be pregnant for before giving birth.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalAgeModifier": {
+        "label": "Animal Aging Speed",
+        "description": "Speed at which animals age.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalMilkIncModifier": {
+        "label": "Milk Production Speed",
+        "description": "Speed of milk production.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalWoolIncModifier": {
+        "label": "Wool Production Speed",
+        "description": "Speed of wool production.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalRanchChance": {
+        "label": "Animal Ranch Chance",
+        "description": "The chance of finding animals in farms.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      },
+      "AnimalGrassRegrowTime": {
+        "label": "Grass Regrow Time",
+        "description": "The number of hours grass will regrow after being eaten by an animal or cut by the player."
+      },
+      "AnimalMetaPredator": {
+        "label": "Meta Predator",
+        "description": "If a meta fox may attack your chickens if the hutch door is left open at night."
+      },
+      "AnimalMatingSeason": {
+        "label": "Mating Season",
+        "description": "Restrict mating to spring/early summer or allow year-round."
+      },
+      "AnimalEggHatch": {
+        "label": "Egg Hatch Time",
+        "description": "How long before baby animals will hatch from eggs.",
+        "options": {
+          "1": {
+            "label": "Ultra Fast"
+          },
+          "2": {
+            "label": "Very Fast"
+          },
+          "3": {
+            "label": "Fast"
+          },
+          "4": {
+            "label": "Normal"
+          },
+          "5": {
+            "label": "Slow"
+          },
+          "6": {
+            "label": "Very Slow"
+          }
+        }
+      },
+      "AnimalSoundAttractZombies": {
+        "label": "Animal Sound Attracts Zombies",
+        "description": "If true, animal calls will attract nearby zombies."
+      },
+      "AnimalTrackChance": {
+        "label": "Animal Track Chance",
+        "description": "The chance of animals leaving tracks.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "AnimalPathChance": {
+        "label": "Animal Path Chance",
+        "description": "The chance of creating a path for animals to be hunted.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "MaximumRatIndex": {
+        "label": "Maximum Rat Index",
+        "description": "Maximum rat infestation level. 0 = no rats."
+      },
+      "DaysUntilMaximumRatIndex": {
+        "label": "Days Until Max Rat Index",
+        "description": "How many days until rat population peaks."
+      },
+      "Farming": {
+        "label": "Agriculture Multiplier",
+        "description": "Rate at which Agriculture skill levels up.",
+        "options": {
+          "1": {
+            "label": "Very Low"
+          },
+          "2": {
+            "label": "Low"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "High"
+          },
+          "5": {
+            "label": "Very High"
+          }
+        }
+      },
+      "PlantResilience": {
+        "label": "Plant Resilience",
+        "description": "How tough crops are.",
+        "options": {
+          "1": {
+            "label": "Very High"
+          },
+          "2": {
+            "label": "High"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Low"
+          },
+          "5": {
+            "label": "Very Low"
+          }
+        }
+      },
+      "PlantAbundance": {
+        "label": "Plant Abundance",
+        "description": "How much food crops produce.",
+        "options": {
+          "1": {
+            "label": "Very Poor"
+          },
+          "2": {
+            "label": "Poor"
+          },
+          "3": {
+            "label": "Normal"
+          },
+          "4": {
+            "label": "Abundant"
+          },
+          "5": {
+            "label": "Very Abundant"
+          }
+        }
+      },
+      "KillInsideCrops": {
+        "label": "Kill Indoor Crops",
+        "description": "Whether stepping on indoor crops destroys them."
+      },
+      "PlantGrowingSeasons": {
+        "label": "Plant Growing Seasons",
+        "description": "Restrict crop growth to appropriate seasons."
+      },
+      "PlaceDirtAboveground": {
+        "label": "Place Dirt Aboveground",
+        "description": "Allow placing dirt on built floors above ground."
+      },
+      "FarmingSpeedNew": {
+        "label": "Farming Speed",
+        "description": "Growth speed multiplier. Lower = faster."
+      },
+      "FarmingAmountNew": {
+        "label": "Farming Amount",
+        "description": "Multiplier for number of crops harvested."
+      },
+      "ClayLakeChance": {
+        "label": "Clay Lake Chance",
+        "description": "Chance of finding clay when digging near lakes."
+      },
+      "ClayRiverChance": {
+        "label": "Clay River Chance",
+        "description": "Chance of finding clay when digging near rivers."
+      }
+    },
+    "world": {
+      "SurvivorHouseChance": {
+        "label": "Survivor House Chance",
+        "description": "Chance of finding survivor-modified houses.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always Tries"
+          }
+        }
+      },
+      "VehicleStoryChance": {
+        "label": "Vehicle Story Chance",
+        "description": "Chance of finding story-decorated vehicles.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      },
+      "ZoneStoryChance": {
+        "label": "Zone Story Chance",
+        "description": "Chance of encountering zone-based story setups.",
+        "options": {
+          "1": {
+            "label": "Never"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          }
+        }
+      }
+    },
+    "zombieLore": {
+      "Speed": {
+        "label": "Zombie Speed",
+        "description": "How fast zombies move.",
+        "options": {
+          "1": {
+            "label": "Sprinters"
+          },
+          "2": {
+            "label": "Fast Shamblers"
+          },
+          "3": {
+            "label": "Shamblers"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Strength": {
+        "label": "Strength",
+        "description": "How strong zombies are.",
+        "options": {
+          "1": {
+            "label": "Superhuman"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Weak"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Toughness": {
+        "label": "Toughness",
+        "description": "How tough zombies are to kill.",
+        "options": {
+          "1": {
+            "label": "Tough"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Fragile"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Transmission": {
+        "label": "Transmission",
+        "description": "How the zombie infection spreads.",
+        "options": {
+          "1": {
+            "label": "Blood and Saliva"
+          },
+          "2": {
+            "label": "Saliva Only"
+          },
+          "3": {
+            "label": "Everyone's Infected"
+          },
+          "4": {
+            "label": "None"
+          }
+        }
+      },
+      "Mortality": {
+        "label": "Infection Mortality",
+        "description": "How deadly the infection is.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0-30 Seconds"
+          },
+          "3": {
+            "label": "0-1 Minutes"
+          },
+          "4": {
+            "label": "0-12 Hours"
+          },
+          "5": {
+            "label": "2-3 Days"
+          },
+          "6": {
+            "label": "1-2 Weeks"
+          },
+          "7": {
+            "label": "Never"
+          }
+        }
+      },
+      "Cognition": {
+        "label": "Cognition",
+        "description": "What zombies can interact with.",
+        "options": {
+          "1": {
+            "label": "Navigate and Use Doors"
+          },
+          "2": {
+            "label": "Navigate"
+          },
+          "3": {
+            "label": "Basic Navigation"
+          },
+          "4": {
+            "label": "Random"
+          }
+        }
+      },
+      "Memory": {
+        "label": "Memory",
+        "description": "How long zombies remember where they last saw a target.",
+        "options": {
+          "1": {
+            "label": "Long"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Short"
+          },
+          "4": {
+            "label": "None"
+          },
+          "5": {
+            "label": "Random"
+          },
+          "6": {
+            "label": "Random between Normal and None"
+          }
+        }
+      },
+      "Sight": {
+        "label": "Sight",
+        "description": "How far zombies can see targets.",
+        "options": {
+          "1": {
+            "label": "Eagle"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Poor"
+          },
+          "4": {
+            "label": "Random"
+          },
+          "5": {
+            "label": "Random between Normal and Poor"
+          }
+        }
+      },
+      "Hearing": {
+        "label": "Hearing",
+        "description": "How well zombies can hear sounds.",
+        "options": {
+          "1": {
+            "label": "Pinpoint"
+          },
+          "2": {
+            "label": "Normal"
+          },
+          "3": {
+            "label": "Poor"
+          },
+          "4": {
+            "label": "Random"
+          },
+          "5": {
+            "label": "Random between Normal and Poor"
+          }
+        }
+      },
+      "SpottedLogic": {
+        "label": "New Stealth System",
+        "description": "How zombies decide to chase their targets."
+      },
+      "ThumpNoChasing": {
+        "label": "Environmental Attacks",
+        "description": "Zombies that weren't chasing a player will not thump constructions."
+      },
+      "ThumpOnConstruction": {
+        "label": "Damage Construction",
+        "description": "Zombies thump player-built structures."
+      },
+      "ActiveOnly": {
+        "label": "Day/Night Zombie Speed Effect",
+        "description": "Zombies active during specific times.",
+        "options": {
+          "1": {
+            "label": "Both"
+          },
+          "2": {
+            "label": "Night"
+          },
+          "3": {
+            "label": "Day"
+          }
+        }
+      },
+      "TriggerHouseAlarm": {
+        "label": "Zombie House Alarm Triggering",
+        "description": "Whether zombies can randomly trigger house alarms."
+      },
+      "ZombiesDragDown": {
+        "label": "Zombies Drag Down",
+        "description": "Multiple zombies can pull player to ground."
+      },
+      "ZombiesCrawlersDragDown": {
+        "label": "Crawlers Drag Down",
+        "description": "Crawlers can drag players down."
+      },
+      "ZombiesFenceLunge": {
+        "label": "Fence Lunge",
+        "description": "Zombies can lunge at you over fences."
+      },
+      "ZombiesArmorFactor": {
+        "label": "Zombies Armor Factor",
+        "description": "Multiplier for zombie armor from clothing. Higher = harder to kill."
+      },
+      "ZombiesMaxDefense": {
+        "label": "Maximum Zombie Armor Defense",
+        "description": "Maximum defense value zombies can have."
+      },
+      "ChanceOfAttachedWeapon": {
+        "label": "Chance Of Attached Weapon",
+        "description": "Chance a zombie has a weapon stuck in them."
+      },
+      "ZombiesFallDamage": {
+        "label": "Zombie Fall Damage Multiplier",
+        "description": "Whether zombies can die from falling."
+      },
+      "DisableFakeDead": {
+        "label": "Fake Dead Zombie Reanimation",
+        "description": "No zombies will pretend to be dead.",
+        "options": {
+          "1": {
+            "label": "World Zombies"
+          },
+          "2": {
+            "label": "World and Combat Zombies"
+          },
+          "3": {
+            "label": "Never"
+          }
+        }
+      },
+      "PlayerSpawnZombieRemoval": {
+        "label": "Spawn Zone Clear",
+        "description": "Distance around spawn points cleared of zombies.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Small"
+          },
+          "3": {
+            "label": "Medium"
+          },
+          "4": {
+            "label": "Large"
+          },
+          "5": {
+            "label": "Very Large"
+          }
+        }
+      },
+      "FenceThumpersRequired": {
+        "label": "Zombies To Damage Fences",
+        "description": "Minimum zombies needed to damage a fence."
+      },
+      "FenceDamageMultiplier": {
+        "label": "Fence Damage Multiplier",
+        "description": "Multiplier for damage zombies do to fences."
+      },
+      "DoorOpeningPercentage": {
+        "label": "Random Door Opening Amount",
+        "description": "Percentage of zombies that can open doors when cognition allows it."
+      },
+      "CrawlUnderVehicle": {
+        "label": "Crawl Under Vehicle",
+        "description": "Crawler zombies can crawl under vehicles.",
+        "options": {
+          "1": {
+            "label": "Crawlers Only"
+          },
+          "2": {
+            "label": "Extremely Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      },
+      "SprinterPercentage": {
+        "label": "Random Sprinter Amount",
+        "description": "Percentage of sprinter zombies when Speed is set to Random."
+      },
+      "Reanimate": {
+        "label": "Reanimate Time",
+        "description": "Dead zombies can get back up after being killed.",
+        "options": {
+          "1": {
+            "label": "Instant"
+          },
+          "2": {
+            "label": "0-30 Seconds"
+          },
+          "3": {
+            "label": "0-1 Minutes"
+          },
+          "4": {
+            "label": "0-12 Hours"
+          },
+          "5": {
+            "label": "2-3 Days"
+          },
+          "6": {
+            "label": "1-2 Weeks"
+          }
+        }
+      }
+    },
+    "zombiePopulation": {
+      "PopulationMultiplier": {
+        "label": "Population Multiplier",
+        "description": "Overall zombie population multiplier."
+      },
+      "PopulationStartMultiplier": {
+        "label": "Start Multiplier",
+        "description": "Zombie population at game start."
+      },
+      "PopulationPeakMultiplier": {
+        "label": "Peak Multiplier",
+        "description": "Zombie population at peak day."
+      },
+      "PopulationPeakDay": {
+        "label": "Peak Day",
+        "description": "Day when zombie population peaks."
+      },
+      "RespawnHours": {
+        "label": "Respawn Hours",
+        "description": "Hours before zombies respawn. 0 = disabled."
+      },
+      "RespawnUnseenHours": {
+        "label": "Unseen Hours",
+        "description": "Hours a chunk must be unseen before respawn."
+      },
+      "RespawnMultiplier": {
+        "label": "Respawn Multiplier",
+        "description": "Fraction of population that respawns."
+      },
+      "RedistributeHours": {
+        "label": "Redistribute Hours",
+        "description": "Hours between zombie redistribution across the map."
+      },
+      "FollowSoundDistance": {
+        "label": "Follow Sound Distance",
+        "description": "How far zombies will follow sounds in cells."
+      },
+      "RallyGroupSize": {
+        "label": "Rally Group Size",
+        "description": "Base number of zombies in rally groups."
+      },
+      "RallyGroupSizeVariance": {
+        "label": "Rally Group Size Variance",
+        "description": "The amount, as a percentage, that zombie groups can vary in size from the default (both larger and smaller)."
+      },
+      "RallyTravelDistance": {
+        "label": "Rally Travel Distance",
+        "description": "How far rally groups travel in cells."
+      },
+      "RallyGroupSeparation": {
+        "label": "Rally Group Separation",
+        "description": "Minimum distance between rally groups."
+      },
+      "RallyGroupRadius": {
+        "label": "Rally Group Radius",
+        "description": "Radius of area a rally group spreads across."
+      },
+      "ZombiesCountBeforeDelete": {
+        "label": "Zombies Count Before Delete",
+        "description": "Minimum zombie count in a cell before deletion can occur."
+      }
+    },
+    "xpMultipliers": {
+      "Global": {
+        "label": "Global XP Multiplier",
+        "description": "The rate at which all skills level up."
+      },
+      "GlobalToggle": {
+        "label": "Use Global Multiplier For All Skills",
+        "description": "When enabled, all skills will use the Global Multiplier instead of individual values."
+      },
+      "Sprinting": {
+        "label": "Sprinting XP",
+        "description": "XP multiplier for Sprinting skill."
+      },
+      "Lightfoot": {
+        "label": "Lightfoot XP",
+        "description": "XP multiplier for Lightfoot skill."
+      },
+      "Nimble": {
+        "label": "Nimble XP",
+        "description": "XP multiplier for Nimble skill."
+      },
+      "Sneak": {
+        "label": "Sneaking XP",
+        "description": "XP multiplier for Sneaking skill."
+      },
+      "Axe": {
+        "label": "Axe XP",
+        "description": "XP multiplier for Axe skill."
+      },
+      "Blunt": {
+        "label": "Blunt XP",
+        "description": "XP multiplier for Blunt skill."
+      },
+      "SmallBlade": {
+        "label": "Small Blade XP",
+        "description": "XP multiplier for Small Blade skill."
+      },
+      "LongBlade": {
+        "label": "Long Blade XP",
+        "description": "XP multiplier for Long Blade skill."
+      },
+      "SmallBlunt": {
+        "label": "Small Blunt XP",
+        "description": "XP multiplier for Small Blunt skill."
+      },
+      "Aiming": {
+        "label": "Aiming XP",
+        "description": "XP multiplier for Aiming skill."
+      },
+      "Reloading": {
+        "label": "Reloading XP",
+        "description": "XP multiplier for Reloading skill."
+      },
+      "Fishing": {
+        "label": "Fishing XP",
+        "description": "XP multiplier for Fishing skill."
+      },
+      "Trapping": {
+        "label": "Trapping XP",
+        "description": "XP multiplier for Trapping skill."
+      },
+      "Woodwork": {
+        "label": "Carpentry XP",
+        "description": "XP multiplier for Carpentry skill."
+      },
+      "Cooking": {
+        "label": "Cooking XP",
+        "description": "XP multiplier for Cooking skill."
+      },
+      "Farming": {
+        "label": "Farming XP",
+        "description": "XP multiplier for Farming skill."
+      },
+      "Doctor": {
+        "label": "First Aid XP",
+        "description": "XP multiplier for First Aid skill."
+      },
+      "Electricity": {
+        "label": "Electricity XP",
+        "description": "XP multiplier for Electricity skill."
+      },
+      "MetalWelding": {
+        "label": "Metalworking XP",
+        "description": "XP multiplier for Metalworking skill."
+      },
+      "Mechanics": {
+        "label": "Mechanics XP",
+        "description": "XP multiplier for Mechanics skill."
+      },
+      "Tailoring": {
+        "label": "Tailoring XP",
+        "description": "XP multiplier for Tailoring skill."
+      },
+      "Maintenance": {
+        "label": "Maintenance XP",
+        "description": "XP multiplier for Maintenance skill."
+      },
+      "PlantScavenging": {
+        "label": "Foraging XP",
+        "description": "XP multiplier for Foraging skill."
+      },
+      "Fitness": {
+        "label": "Fitness XP",
+        "description": "XP multiplier for Fitness skill."
+      },
+      "Strength": {
+        "label": "Strength XP",
+        "description": "XP multiplier for Strength skill."
+      },
+      "FlintKnapping": {
+        "label": "Knapping XP",
+        "description": "XP multiplier for Knapping skill."
+      },
+      "Carving": {
+        "label": "Carving XP",
+        "description": "XP multiplier for Carving skill."
+      },
+      "Tracking": {
+        "label": "Tracking XP",
+        "description": "XP multiplier for Tracking skill."
+      },
+      "Butchering": {
+        "label": "Butchering XP",
+        "description": "XP multiplier for Butchering skill."
+      },
+      "Glassmaking": {
+        "label": "Glassmaking XP",
+        "description": "XP multiplier for Glassmaking skill."
+      },
+      "Husbandry": {
+        "label": "Animal Husbandry XP",
+        "description": "XP multiplier for Animal Husbandry skill."
+      },
+      "Spear": {
+        "label": "Spear XP",
+        "description": "XP multiplier for Spear skill."
+      },
+      "Masonry": {
+        "label": "Masonry XP",
+        "description": "XP multiplier for Masonry skill."
+      },
+      "Pottery": {
+        "label": "Pottery XP",
+        "description": "XP multiplier for Pottery skill."
+      },
+      "Blacksmith": {
+        "label": "Blacksmith XP",
+        "description": "XP multiplier for Blacksmith skill."
+      }
+    },
+    "map": {
+      "AllowMiniMap": {
+        "label": "Allow Mini Map",
+        "description": "Whether the in-game mini map is available."
+      },
+      "AllowWorldMap": {
+        "label": "Allow World Map",
+        "description": "Whether the in-game world map is available."
+      },
+      "MapAllKnown": {
+        "label": "Map All Known",
+        "description": "The entire map is revealed from the start."
+      },
+      "MapNeedsLight": {
+        "label": "Map Needs Light",
+        "description": "Map can only be used when there is enough light."
+      }
+    },
+    "basement": {
+      "SpawnFrequency": {
+        "label": "Basement Spawn Frequency",
+        "description": "How often basements appear in buildings.",
+        "options": {
+          "1": {
+            "label": "None"
+          },
+          "2": {
+            "label": "Very Rare"
+          },
+          "3": {
+            "label": "Rare"
+          },
+          "4": {
+            "label": "Sometimes"
+          },
+          "5": {
+            "label": "Often"
+          },
+          "6": {
+            "label": "Very Often"
+          },
+          "7": {
+            "label": "Always"
+          }
+        }
+      }
+    }
+  },
+  "iniCategories": {
+    "general": {
+      "label": "General"
+    },
+    "network": {
+      "label": "Network & Ports"
+    },
+    "steam": {
+      "label": "Steam Integration"
+    },
+    "discord": {
+      "label": "Discord"
+    },
+    "rcon": {
+      "label": "RCON"
+    },
+    "voice": {
+      "label": "Voice Chat"
+    },
+    "players": {
+      "label": "Players & Accounts"
+    },
+    "safehouse": {
+      "label": "Safehouses"
+    },
+    "chat": {
+      "label": "Chat & Communication"
+    },
+    "pvp": {
+      "label": "PvP & Safety"
+    },
+    "moderation": {
+      "label": "Moderation"
+    },
+    "anticheat": {
+      "label": "Anti-Cheat"
+    },
+    "loot": {
+      "label": "Loot & Items"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "mods": {
+      "label": "Mods & Workshop"
+    },
+    "radio": {
+      "label": "Radio"
+    },
+    "war": {
+      "label": "Faction War"
+    },
+    "backups": {
+      "label": "Backups"
+    },
+    "logging": {
+      "label": "Logging"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
+  },
+  "iniCategoryGroups": {
+    "identity": {
+      "label": "Identity"
+    },
+    "connectivity": {
+      "label": "Connectivity"
+    },
+    "players": {
+      "label": "Players"
+    },
+    "gameplay": {
+      "label": "Gameplay"
+    },
+    "ops": {
+      "label": "Ops"
+    }
+  },
+  "sandboxCategories": {
+    "time": {
+      "label": "Time & Season"
+    },
+    "environment": {
+      "label": "Environment & Weather"
+    },
+    "world": {
+      "label": "World & Stories"
+    },
+    "map": {
+      "label": "Map & Navigation"
+    },
+    "zombieLore": {
+      "label": "Zombie Behavior"
+    },
+    "zombiePopulation": {
+      "label": "Zombie Population"
+    },
+    "population": {
+      "label": "Population & Distribution"
+    },
+    "survival": {
+      "label": "Survival & Health"
+    },
+    "combat": {
+      "label": "Combat & Firearms"
+    },
+    "loot": {
+      "label": "Loot & Resources"
+    },
+    "lootRarity": {
+      "label": "Loot Rarity"
+    },
+    "vehicles": {
+      "label": "Vehicles"
+    },
+    "animals": {
+      "label": "Animals & Farming"
+    },
+    "xpMultipliers": {
+      "label": "XP Multipliers"
+    },
+    "basement": {
+      "label": "Basements"
+    }
+  },
+  "sandboxCategoryGroups": {
+    "world": {
+      "label": "World"
+    },
+    "zombies": {
+      "label": "Zombies"
+    },
+    "survival": {
+      "label": "Survival"
+    },
+    "resources": {
+      "label": "Resources"
+    },
+    "advanced": {
+      "label": "Advanced"
+    }
   }
 }

--- a/client/src/pages/ServerConfig.tsx
+++ b/client/src/pages/ServerConfig.tsx
@@ -123,11 +123,13 @@ import {
   getIniSettingLabel,
   getIniSettingDescription,
   getIniSettingOptionLabel,
+  getIniSettingSearchText,
   getIniCategoryLabel,
   getIniCategoryGroupLabel,
   getSandboxSettingLabel,
   getSandboxSettingDescription,
   getSandboxSettingOptionLabel,
+  getSandboxSettingSearchText,
   getSandboxCategoryLabel,
   getSandboxCategoryGroupLabel,
   getUnrecognizedSandboxOptionWarning
@@ -778,6 +780,7 @@ export function resolveServerConfigDeepLink(searchParams: URLSearchParams) {
 
 export default function ServerConfig() {
   const { t, i18n } = useTranslation('serverconfig')
+  const searchLocale = i18n.resolvedLanguage || i18n.language
   const [searchParams] = useSearchParams()
   const initialDeepLink = resolveServerConfigDeepLink(searchParams)
   // List separator is a language property, not something a joined list of
@@ -1672,34 +1675,26 @@ export default function ServerConfig() {
 
   // Filter settings by search + filter mode
   const filteredIniSettings = useMemo(() => {
-    const lower = deferredSearchQuery.toLowerCase()
+    const lower = deferredSearchQuery.toLocaleLowerCase(searchLocale)
     const filtered = INI_SCHEMA.filter(s => {
-      if (deferredSearchQuery && !(
-        s.key.toLowerCase().includes(lower) ||
-        getIniSettingLabel(s).toLowerCase().includes(lower) ||
-        getIniSettingDescription(s).toLowerCase().includes(lower)
-      )) return false
+      if (deferredSearchQuery && !getIniSettingSearchText(s).toLocaleLowerCase(searchLocale).includes(lower)) return false
       if (filterMode === 'modified' && !isIniNonDefault(s)) return false
       if (filterMode === 'nondefault' && !isIniModified(s)) return false
       return true
     })
     return groupByCategory(filtered)
-  }, [deferredSearchQuery, filterMode, isIniModified, isIniNonDefault, i18n.language])
+  }, [deferredSearchQuery, filterMode, isIniModified, isIniNonDefault, searchLocale])
 
   const filteredSandboxSettings = useMemo(() => {
-    const lower = deferredSearchQuery.toLowerCase()
+    const lower = deferredSearchQuery.toLocaleLowerCase(searchLocale)
     const filtered = SANDBOX_SCHEMA.filter(s => {
-      if (deferredSearchQuery && !(
-        s.key.toLowerCase().includes(lower) ||
-        getSandboxSettingLabel(s).toLowerCase().includes(lower) ||
-        getSandboxSettingDescription(s).toLowerCase().includes(lower)
-      )) return false
+      if (deferredSearchQuery && !getSandboxSettingSearchText(s).toLocaleLowerCase(searchLocale).includes(lower)) return false
       if (filterMode === 'modified' && !isSandboxNonDefault(s)) return false
       if (filterMode === 'nondefault' && !isSandboxModified(s)) return false
       return true
     })
     return groupByCategory(filtered)
-  }, [deferredSearchQuery, filterMode, isSandboxModified, isSandboxNonDefault, i18n.language])
+  }, [deferredSearchQuery, filterMode, isSandboxModified, isSandboxNonDefault, searchLocale])
 
   // Modified-count per category for rail badges
   const iniModifiedByCategory = useMemo(() => {

--- a/client/src/pages/ServerConfig.tsx
+++ b/client/src/pages/ServerConfig.tsx
@@ -132,7 +132,8 @@ import {
   getSandboxSettingSearchText,
   getSandboxCategoryLabel,
   getSandboxCategoryGroupLabel,
-  getUnrecognizedSandboxOptionWarning
+  getUnrecognizedSandboxOptionWarning,
+  formatRawConfigValue,
 } from '@/lib/serverConfigSchema'
 
 type EditorMode = 'structured' | 'raw'
@@ -307,7 +308,7 @@ const IniSettingRow = memo(({
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <code className="bg-muted px-1 rounded">{setting.key}</code>
           {setting.default !== undefined && (
-            <span className={isDifferentFromDefault ? 'text-warning' : ''}>{t('row.defaultValue', { value: String(setting.default) })}</span>
+            <span className={isDifferentFromDefault ? 'text-warning' : ''}>{t('row.defaultValue', { value: formatRawConfigValue(setting.default) })}</span>
           )}
         </div>
       </div>
@@ -444,7 +445,7 @@ const IniSettingRow = memo(({
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <code className="bg-muted px-1 rounded">{setting.key}</code>
         {setting.default !== undefined && (
-          <span className={isDifferentFromDefault ? 'text-warning' : ''}>{t('row.defaultValue', { value: String(setting.default) })}</span>
+          <span className={isDifferentFromDefault ? 'text-warning' : ''}>{t('row.defaultValue', { value: formatRawConfigValue(setting.default) })}</span>
         )}
       </div>
     </div>
@@ -500,7 +501,7 @@ export const SandboxSettingRow = memo(({
           <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
             <code className="bg-muted px-1 rounded">{setting.key}</code>
             {setting.default !== undefined && (
-              <span className={isDifferentFromDefault ? 'text-warning' : ''}>{t('row.defaultValue', { value: String(setting.default) })}</span>
+              <span className={isDifferentFromDefault ? 'text-warning' : ''}>{t('row.defaultValue', { value: formatRawConfigValue(setting.default) })}</span>
             )}
           </div>
         </div>
@@ -3892,14 +3893,14 @@ export default function ServerConfig() {
                                               onClick={() => opt.name && opt.default !== undefined && handleOptionChange(opt.name, opt.default, group.name)}
                                               disabled={isSaving}
                                               // eslint-disable-next-line local/no-dead-disabled-title -- pure hint naming the action + value; disables only transiently while a save is in flight (the adjacent spinner is the self-evident why). Triaged 2026-08-27. Note: the wrapping Radix Tooltip here has the same "no pointer/focus events on a disabled native button" limitation as this title, so its content is equally unreachable while isSaving -- out of scope for this rule (it only checks title+disabled), flagged here rather than fixed since isSaving is brief and self-evident.
-                                              title={t('modSettingsTab.resetToDefaultTitle', { value: opt.default })}
+                                              title={t('modSettingsTab.resetToDefaultTitle', { value: formatRawConfigValue(opt.default) })}
                                             >
                                               <Undo2 className="w-3 h-3" />
-                                              <span>{t('modSettingsTab.resetToDefaultLabel', { value: String(opt.default) })}</span>
+                                              <span>{t('modSettingsTab.resetToDefaultLabel', { value: formatRawConfigValue(opt.default) })}</span>
                                             </button>
                                           </TooltipTrigger>
                                           <TooltipContent side="left">
-                                            <p>{t('modSettingsTab.resetToDefaultTooltip', { value: String(opt.default) })}</p>
+                                            <p>{t('modSettingsTab.resetToDefaultTooltip', { value: formatRawConfigValue(opt.default) })}</p>
                                           </TooltipContent>
                                         </Tooltip>
                                       )}

--- a/client/src/pages/__tests__/ServerConfig.unrecognizedSandboxOption.test.tsx
+++ b/client/src/pages/__tests__/ServerConfig.unrecognizedSandboxOption.test.tsx
@@ -29,6 +29,17 @@ const META_EVENT: SandboxSetting = {
 }
 
 describe('ServerConfig -- unrecognized sandbox select value', () => {
+  it('shows the original key without adding its internal section prefix', () => {
+    const setting: SandboxSetting = {
+      ...META_EVENT,
+      key: 'Strength',
+      section: 'ZombieLore',
+    }
+    const { container } = render(<SandboxSettingRow setting={setting} value={2} onChange={vi.fn()} />)
+    expect(container.querySelector('code')).toHaveTextContent('Strength')
+    expect(container.querySelector('code')).not.toHaveTextContent('ZombieLore.Strength')
+  })
+
   it('shows a warning when the live value has no matching option', () => {
     render(<SandboxSettingRow setting={META_EVENT} value={5} onChange={vi.fn()} />)
     expect(screen.getByText(/does not recognize/i)).toBeInTheDocument()


### PR DESCRIPTION
## Summary

- Add schema-backed translations for the Server Config page, including INI and Sandbox categories, groups, field labels, descriptions, and select options.
- Keep the original raw configuration key visible in each row; qualified section paths are included only in the search index.
- Make search match raw keys, qualified paths, schema English, active-locale labels, descriptions, categories, groups, and option labels.
- Preserve the existing numeric range helper below inputs. Descriptions remain purpose text and are not replaced by option tables or value ranges.
- Keep Project Zomboid official Sandbox labels as a fallback when a locale entry is only the schema English fallback.

## Compatibility

- No INI/Sandbox key names, file formats, save paths, or dynamic mod-setting behavior were changed.
- Ambiguous Sandbox keys such as `Strength` and `Farming` remain disambiguated by their section/category for translation and search.
- Existing non-Chinese locales retain their current wording; entries without an authored panel translation fall back to English or the official Project Zomboid label as before.

## Validation

- 5 focused Vitest files passed: 2,076 tests.
- TypeScript project build passed.
- Production Vite build passed.
- `npm run check:i18n` passed with no new suspicious French duplicates.
- `npm run check:i18n-staleness` passed with 0 candidates.
- `git diff --check` passed.

The locale files include the schema keys required by this repository's strict locale-parity test. This PR adds Simplified Chinese wording; it does not claim to add Traditional Chinese translations.