### PR TITLE
Windows updater: hash staged bundle via .NET, not Get-FileHash; UNVERIFIABLE vs MISMATCH

### DIFF
--- a/build.js
+++ b/build.js
@@ -656,9 +656,18 @@ rem ============================================================
   rem Json above never had this problem. Still wrapped in try/catch: a
   rem locked/unreadable file is a real possibility this doesn't remove, and
   rem now reports UNVERIFIABLE with the actual exception text instead of
-  rem being misread as MISMATCH.
+  rem being misread as MISMATCH. The exception message has its own parens
+  rem defensively stripped to brackets, same as the client check's own
+  rem diagnostic text below -- a literal ")" inside a delayed-expansion
+  rem value used within an "if (...) ( ... )" block PREMATURELY CLOSES that
+  rem block at runtime, taking the rest of the line as a new command.
+  rem cmd.exe's block parser does not know or care that the paren only
+  rem exists inside what will become a quoted string argument -- confirmed
+  rem the hard way while building the client check's own diagnostic below
+  rem (a "(...)"-wrapped file list broke it with "is not recognized as an
+  rem internal or external command").
   set "STAGED_HASH_STATUS="
-  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "$j = Get-Content -LiteralPath $env:JOURNAL -Raw | ConvertFrom-Json; $expected = $j.hashes.binarySha256; if (-not $expected) { 'NOHASH' } else { try { $actual = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.IO.File]::ReadAllBytes($env:STAGED_NAME))).Replace('-','').ToLowerInvariant(); if ($actual -ieq $expected) { 'OK' } else { 'MISMATCH actual=' + $actual + ' expected=' + $expected } } catch { 'UNVERIFIABLE ' + $_.Exception.Message } }"\`) do set "STAGED_HASH_STATUS=%%F"
+  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "$j = Get-Content -LiteralPath $env:JOURNAL -Raw | ConvertFrom-Json; $expected = $j.hashes.binarySha256; if (-not $expected) { 'NOHASH' } else { try { $actual = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.IO.File]::ReadAllBytes($env:STAGED_NAME))).Replace('-','').ToLowerInvariant(); if ($actual -ieq $expected) { 'OK' } else { 'MISMATCH actual=' + $actual + ' expected=' + $expected } } catch { 'UNVERIFIABLE ' + $_.Exception.Message.Replace('(','[').Replace(')',']').Replace('|',':') } }"\`) do set "STAGED_HASH_STATUS=%%F"
 
   if not "!STAGED_HASH_STATUS!"=="OK" (
     if "!STAGED_HASH_STATUS:~0,12!"=="UNVERIFIABLE" (
@@ -695,7 +704,7 @@ rem ============================================================
   rem uses the .NET SHA256 type directly rather than Get-FileHash, for the
   rem same reason the binary check above does now -- see its comment.
   set "STAGED_CLIENT_HASH_STATUS="
-  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "$j = Get-Content -LiteralPath $env:JOURNAL -Raw | ConvertFrom-Json; $expected = $j.hashes.clientSha256; if (-not $expected) { 'NOHASH' } else { try { $root = (Resolve-Path -LiteralPath $env:STAGED_CLIENT).Path; $pairs = @(Get-ChildItem -LiteralPath $root -Recurse -File | ForEach-Object { $rel = $_.FullName.Substring($root.Length + 1).Replace([char]92,[char]47); $h = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.IO.File]::ReadAllBytes($_.FullName))).Replace('-','').ToLowerInvariant(); $rel + '|' + $h }); [System.Array]::Sort($pairs, [System.StringComparer]::Ordinal); $nul = [char]0; $nl = [char]10; $combined = ($pairs | ForEach-Object { $p = $_.Split('|',2); $p[0] + $nul + $p[1] + $nl }) -join ''; $bytes = [System.Text.Encoding]::UTF8.GetBytes($combined); $actual = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash($bytes)).Replace('-','').ToLowerInvariant(); if ($actual -ieq $expected) { 'OK' } else { 'MISMATCH actual=' + $actual + ' expected=' + $expected } } catch { 'UNVERIFIABLE ' + $_.Exception.Message } }"\`) do set "STAGED_CLIENT_HASH_STATUS=%%F"
+  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "$j = Get-Content -LiteralPath $env:JOURNAL -Raw | ConvertFrom-Json; $expected = $j.hashes.clientSha256; if (-not $expected) { 'NOHASH' } else { try { $root = (Resolve-Path -LiteralPath $env:STAGED_CLIENT).Path; $pairs = @(Get-ChildItem -LiteralPath $root -Recurse -File | ForEach-Object { $rel = $_.FullName.Substring($root.Length + 1).Replace([char]92,[char]47); $h = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.IO.File]::ReadAllBytes($_.FullName))).Replace('-','').ToLowerInvariant(); $rel + ':' + $h }); [System.Array]::Sort($pairs, [System.StringComparer]::Ordinal); $nul = [char]0; $nl = [char]10; $combined = ($pairs | ForEach-Object { $p = $_.Split(':',2); $p[0] + $nul + $p[1] + $nl }) -join ''; $bytes = [System.Text.Encoding]::UTF8.GetBytes($combined); $actual = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash($bytes)).Replace('-','').ToLowerInvariant(); if ($actual -ieq $expected) { 'OK' } else { 'MISMATCH actual=' + $actual + ' expected=' + $expected + ' root=' + $root + ' pairs={' + ($pairs -join ';') + '}' } } catch { 'UNVERIFIABLE ' + $_.Exception.Message.Replace('(','[').Replace(')',']').Replace('|',':') } }"\`) do set "STAGED_CLIENT_HASH_STATUS=%%F"
 
   if not "!STAGED_CLIENT_HASH_STATUS!"=="OK" (
     if "!STAGED_CLIENT_HASH_STATUS:~0,12!"=="UNVERIFIABLE" (

--- a/build.js
+++ b/build.js
@@ -638,19 +638,34 @@ rem ============================================================
   rem (applyUpdateBundle()) already verifies against it before touching
   rem anything. This mirrors that check on Windows, with the same
   rem [av_quarantine] failure code Linux uses for a hash mismatch.
-  rem main-is-red, 2026-09-05: this check reports [MISMATCH] on a genuinely
-  rem uncorrupted staged binary on a clean, unprivileged GitHub windows-2022
-  rem runner -- reproduced 5/5 times across every test that reaches this
-  rem line, never once locally. The status string below now carries the
-  rem actual/expected hashes (or the exception message, if Get-FileHash
-  rem itself throws) into the log line instead of a bare MISMATCH, so the
-  rem next run says WHICH of those it actually is instead of requiring
-  rem another round trip to find out.
+  rem main-is-red, 2026-09-05: on a clean, unprivileged GitHub windows-2022
+  rem runner, Get-FileHash is not recognized at all -- Windows PowerShell
+  rem 5.1's module autoload for it silently fails there (confirmed via a
+  rem two-round diagnostic: round 1 logged [MISMATCH] with no detail; round
+  rem 2 carried the actual/expected hashes or the exception text, and it
+  rem came back "The term 'Get-FileHash' is not recognized...", 5/5 times,
+  rem never once locally). That silent MISMATCH conflated "I computed a
+  rem hash and it differs" with "I could not compute a hash at all" and
+  rem stamped both [av_quarantine] -- a real user whose PowerShell can't
+  rem load that module, or whose AV holds the staged file, would have every
+  rem update refused forever with a label that blames corruption instead of
+  rem environment. Fixed at the root by computing SHA256 via the .NET types
+  rem directly ([System.Security.Cryptography.SHA256], File.ReadAllBytes)
+  rem instead of the Get-FileHash cmdlet -- these are always available
+  rem regardless of PSModulePath/autoload state, the same way ConvertFrom-
+  rem Json above never had this problem. Still wrapped in try/catch: a
+  rem locked/unreadable file is a real possibility this doesn't remove, and
+  rem now reports UNVERIFIABLE with the actual exception text instead of
+  rem being misread as MISMATCH.
   set "STAGED_HASH_STATUS="
-  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "$j = Get-Content -LiteralPath $env:JOURNAL -Raw | ConvertFrom-Json; $expected = $j.hashes.binarySha256; if (-not $expected) { 'NOHASH' } else { try { $actual = (Get-FileHash -LiteralPath $env:STAGED_NAME -Algorithm SHA256).Hash; if ($actual -ieq $expected) { 'OK' } else { 'MISMATCH actual=' + $actual + ' expected=' + $expected } } catch { 'ERROR ' + $_.Exception.Message } }"\`) do set "STAGED_HASH_STATUS=%%F"
+  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "$j = Get-Content -LiteralPath $env:JOURNAL -Raw | ConvertFrom-Json; $expected = $j.hashes.binarySha256; if (-not $expected) { 'NOHASH' } else { try { $actual = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.IO.File]::ReadAllBytes($env:STAGED_NAME))).Replace('-','').ToLowerInvariant(); if ($actual -ieq $expected) { 'OK' } else { 'MISMATCH actual=' + $actual + ' expected=' + $expected } } catch { 'UNVERIFIABLE ' + $_.Exception.Message } }"\`) do set "STAGED_HASH_STATUS=%%F"
 
   if not "!STAGED_HASH_STATUS!"=="OK" (
-    call :stamp "Apply: staged binary hash check [!STAGED_HASH_STATUS!] -- refusing to apply [av_quarantine]"
+    if "!STAGED_HASH_STATUS:~0,12!"=="UNVERIFIABLE" (
+      call :stamp "Apply: staged binary hash check [!STAGED_HASH_STATUS!] -- refusing to apply [hash_unverifiable]"
+    ) else (
+      call :stamp "Apply: staged binary hash check [!STAGED_HASH_STATUS!] -- refusing to apply [av_quarantine]"
+    )
     del /f /q "%MARKER%" >nul 2>&1
     goto :eof
   )
@@ -676,12 +691,18 @@ rem ============================================================
   rem client file (relative path + per-file sha256, ordinal-sorted, then
   rem hashed together) computed by stageUpdateBundle() (updateBundle.js) and
   rem verified there before every apply on Linux; this reproduces the exact
-  rem same value on Windows, same [av_quarantine] failure code as the binary.
+  rem same value on Windows, same posture as the binary. Per-file hashing
+  rem uses the .NET SHA256 type directly rather than Get-FileHash, for the
+  rem same reason the binary check above does now -- see its comment.
   set "STAGED_CLIENT_HASH_STATUS="
-  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "$j = Get-Content -LiteralPath $env:JOURNAL -Raw | ConvertFrom-Json; $expected = $j.hashes.clientSha256; if (-not $expected) { 'NOHASH' } else { $root = (Resolve-Path -LiteralPath $env:STAGED_CLIENT).Path; $pairs = @(Get-ChildItem -LiteralPath $root -Recurse -File | ForEach-Object { $rel = $_.FullName.Substring($root.Length + 1).Replace([char]92,[char]47); $h = (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant(); $rel + '|' + $h }); [System.Array]::Sort($pairs, [System.StringComparer]::Ordinal); $nul = [char]0; $nl = [char]10; $combined = ($pairs | ForEach-Object { $p = $_.Split('|',2); $p[0] + $nul + $p[1] + $nl }) -join ''; $bytes = [System.Text.Encoding]::UTF8.GetBytes($combined); $actual = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash($bytes)).Replace('-','').ToLowerInvariant(); if ($actual -ieq $expected) { 'OK' } else { 'MISMATCH' } }"\`) do set "STAGED_CLIENT_HASH_STATUS=%%F"
+  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "$j = Get-Content -LiteralPath $env:JOURNAL -Raw | ConvertFrom-Json; $expected = $j.hashes.clientSha256; if (-not $expected) { 'NOHASH' } else { try { $root = (Resolve-Path -LiteralPath $env:STAGED_CLIENT).Path; $pairs = @(Get-ChildItem -LiteralPath $root -Recurse -File | ForEach-Object { $rel = $_.FullName.Substring($root.Length + 1).Replace([char]92,[char]47); $h = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.IO.File]::ReadAllBytes($_.FullName))).Replace('-','').ToLowerInvariant(); $rel + '|' + $h }); [System.Array]::Sort($pairs, [System.StringComparer]::Ordinal); $nul = [char]0; $nl = [char]10; $combined = ($pairs | ForEach-Object { $p = $_.Split('|',2); $p[0] + $nul + $p[1] + $nl }) -join ''; $bytes = [System.Text.Encoding]::UTF8.GetBytes($combined); $actual = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash($bytes)).Replace('-','').ToLowerInvariant(); if ($actual -ieq $expected) { 'OK' } else { 'MISMATCH actual=' + $actual + ' expected=' + $expected } } catch { 'UNVERIFIABLE ' + $_.Exception.Message } }"\`) do set "STAGED_CLIENT_HASH_STATUS=%%F"
 
   if not "!STAGED_CLIENT_HASH_STATUS!"=="OK" (
-    call :stamp "Apply: staged frontend hash check [!STAGED_CLIENT_HASH_STATUS!] -- refusing to apply [av_quarantine]"
+    if "!STAGED_CLIENT_HASH_STATUS:~0,12!"=="UNVERIFIABLE" (
+      call :stamp "Apply: staged frontend hash check [!STAGED_CLIENT_HASH_STATUS!] -- refusing to apply [hash_unverifiable]"
+    ) else (
+      call :stamp "Apply: staged frontend hash check [!STAGED_CLIENT_HASH_STATUS!] -- refusing to apply [av_quarantine]"
+    )
     del /f /q "%MARKER%" >nul 2>&1
     goto :eof
   )

--- a/build.js
+++ b/build.js
@@ -638,8 +638,16 @@ rem ============================================================
   rem (applyUpdateBundle()) already verifies against it before touching
   rem anything. This mirrors that check on Windows, with the same
   rem [av_quarantine] failure code Linux uses for a hash mismatch.
+  rem main-is-red, 2026-09-05: this check reports [MISMATCH] on a genuinely
+  rem uncorrupted staged binary on a clean, unprivileged GitHub windows-2022
+  rem runner -- reproduced 5/5 times across every test that reaches this
+  rem line, never once locally. The status string below now carries the
+  rem actual/expected hashes (or the exception message, if Get-FileHash
+  rem itself throws) into the log line instead of a bare MISMATCH, so the
+  rem next run says WHICH of those it actually is instead of requiring
+  rem another round trip to find out.
   set "STAGED_HASH_STATUS="
-  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "$j = Get-Content -LiteralPath $env:JOURNAL -Raw | ConvertFrom-Json; $expected = $j.hashes.binarySha256; if (-not $expected) { 'NOHASH' } else { $actual = (Get-FileHash -LiteralPath $env:STAGED_NAME -Algorithm SHA256).Hash; if ($actual -ieq $expected) { 'OK' } else { 'MISMATCH' } }"\`) do set "STAGED_HASH_STATUS=%%F"
+  for /f "usebackq delims=" %%F in (\`powershell -NoProfile -Command "$j = Get-Content -LiteralPath $env:JOURNAL -Raw | ConvertFrom-Json; $expected = $j.hashes.binarySha256; if (-not $expected) { 'NOHASH' } else { try { $actual = (Get-FileHash -LiteralPath $env:STAGED_NAME -Algorithm SHA256).Hash; if ($actual -ieq $expected) { 'OK' } else { 'MISMATCH actual=' + $actual + ' expected=' + $expected } } catch { 'ERROR ' + $_.Exception.Message } }"\`) do set "STAGED_HASH_STATUS=%%F"
 
   if not "!STAGED_HASH_STATUS!"=="OK" (
     call :stamp "Apply: staged binary hash check [!STAGED_HASH_STATUS!] -- refusing to apply [av_quarantine]"

--- a/server/tests/supervisor-restart.test.js
+++ b/server/tests/supervisor-restart.test.js
@@ -724,7 +724,11 @@ describe.skipIf(!!skipReason)(
         expect(countLaunches(result.stdout)).toBe(1);
         expect(result.status).toBe(0);
         const log = readSupervisorLog(dir);
-        expect(log).toMatch(/staged frontend hash check \[MISMATCH\].*av_quarantine/i);
+        // main-is-red follow-up: the status now carries actual/expected
+        // hashes (or an UNVERIFIABLE exception message) instead of a bare
+        // MISMATCH -- match the prefix, not the exact bracket contents,
+        // same as the binary check's own test above.
+        expect(log).toMatch(/staged frontend hash check \[MISMATCH[^\]]*\].*av_quarantine/i);
         expect(log).not.toMatch(/bundle activated/i);
         expect(
           fs.readFileSync(path.join(dir, "client", "dist", "index.html"), "utf8"),

--- a/server/tests/supervisor-restart.test.js
+++ b/server/tests/supervisor-restart.test.js
@@ -4,6 +4,39 @@ import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { generateStartBat as generateStartBatForStaticChecks } from "../../build.js";
+
+// main-is-red, 2026-09-05: both staged-bundle hash checks used to call
+// Get-FileHash -- and on a clean, unprivileged GitHub windows-2022 runner,
+// Get-FileHash is not recognized at all (Windows PowerShell 5.1's module
+// autoload for it silently fails there, confirmed via a two-round CI
+// diagnostic), which every scenario below that reaches either check read
+// as a hash MISMATCH and refused a perfectly good update. Fixed by
+// computing SHA256 via .NET types directly, which don't depend on module
+// autoload. Runs everywhere (not gated behind win32/csc.exe like the
+// scenarios below) since it's a static check, not a behavioral one --
+// deliberately so, unlike this file's usual philosophy (see the header
+// comment on the describe block below): a *dynamic* repro of "Get-FileHash
+// is unavailable but everything else still works" turned out to be
+// unreliable to force on a machine where module autoload genuinely works,
+// because ConvertFrom-Json (called earlier in the same script) triggers
+// loading the whole Microsoft.PowerShell.Utility module as a side effect,
+// which then satisfies Get-FileHash too regardless of any PSModulePath
+// shim aimed only at that one cmdlet -- confirmed empirically while
+// building this test. A plain textual guard is what actually catches a
+// regression here, including god's specific warning that a fully-qualified
+// `Microsoft.PowerShell.Utility\Get-FileHash` would NOT be enough -- that
+// still contains the name, so it still fails this.
+describe("Start.bat never depends on the Get-FileHash cmdlet for staged-bundle integrity", () => {
+  it("does not invoke Get-FileHash anywhere in the generated script", () => {
+    // Matches an actual invocation (`Get-FileHash -LiteralPath ...` or a
+    // module-qualified `Microsoft.PowerShell.Utility\Get-FileHash ...`),
+    // not the several `rem` comments in build.js that mention the cmdlet
+    // by name to explain why it was removed -- those are prose, never
+    // followed by a parameter.
+    expect(generateStartBatForStaticChecks()).not.toMatch(/Get-FileHash\s+-/);
+  });
+});
 
 // Behavioral test for build.js's generated Start.bat crash-loop supervisor
 // (build.js's generateStartBat()). This does NOT grep the template text --

--- a/server/tests/supervisor-restart.test.js
+++ b/server/tests/supervisor-restart.test.js
@@ -660,7 +660,12 @@ describe.skipIf(!!skipReason)(
         expect(countLaunches(result.stdout)).toBe(1);
         expect(result.status).toBe(0);
         const log = readSupervisorLog(dir);
-        expect(log).toMatch(/staged binary hash check \[MISMATCH\].*av_quarantine/i);
+        // main-is-red follow-up: the status now carries actual/expected
+        // hashes (or an exception message) instead of a bare MISMATCH, so
+        // a real CI failure names what actually happened instead of
+        // requiring another round trip -- match the prefix, not the exact
+        // bracket contents.
+        expect(log).toMatch(/staged binary hash check \[MISMATCH[^\]]*\].*av_quarantine/i);
         expect(log).not.toMatch(/bundle activated/i);
         // Nothing was renamed: old client stays live, no binary backup was
         // ever created (the hash check runs before any backup/rename step).


### PR DESCRIPTION
Supersedes #144, which went CONFLICTING after its first two commits landed on main via push #23 (rebased copies), so GitHub could not build its merge ref and stopped running checks.

Root cause of the four red `supervisor-restart.test.js` cases on `windows-2022`, verbatim from the runner via #144's diagnostic: `The term 'Get-FileHash' is not recognized`. Windows PowerShell 5.1 module autoload fails under the runner's PowerShell-7-shaped `PSModulePath` — and would on any user machine with the same shape, refusing every update forever with an AV label.

- `eda73b9b` — hash check status carries actual/expected, or the exception text.
- `4ffb2bb6` — both generated hash checks compute SHA256 via .NET directly (verified byte-identical to `Get-FileHash` and Node `crypto`); **UNVERIFIABLE** (`hash_unverifiable`, exception logged) is now distinct from **MISMATCH** (`av_quarantine`); both still refuse the apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012D3C1BfjepnXUMyUtTivLp