### PR TITLE
fix: manage deactivated mod updates and expand support diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+**v1.3.2 candidate:**
+
+- **SteamCMD setup and updates now recover when SteamCMD is missing on Windows as well as Linux**, report the self-heal progress in the visible installation log, reject concurrent downloads safely, and avoid false Linux 503 responses caused by an unavailable Windows-only process probe.
+- **Discord configuration changes are serialized against the running bot**, preventing overlapping config, webhook-event, or command-permission saves from racing with reconnects.
+- **Translation fallback parameters now resolve correctly**, and 31 previously unmirrored fallback keys are present across all nine supported locales.
+- **Support bundles now collect deeper and broader logs**, including nested PZ/install logs, SteamCMD logs, alternate server paths, additional log extensions, and per-root scan counts.
+- **Support bundles now include sandbox-option diagnostics**, with PZ and PanelBridge versions, exception excerpts, triggering command counts, configured mods, and installed mod metadata for Build 42 compatibility investigations.
+
+### Fixed
+
+**SteamCMD / installer**
+
+- Windows now self-heals a missing SteamCMD installation instead of failing immediately, matching the Linux path.
+- Concurrent SteamCMD downloads are rejected before they can overwrite one another.
+- The setup UI now shows SteamCMD self-heal progress when installation begins from a later setup step.
+- Linux no longer reports a false 503 when a Windows-only process-state probe is unavailable.
+
+**Discord**
+
+- Configuration, webhook-event, and command-permission updates now serialize against the Discord bot singleton, preventing stale overlapping writes and reconnect races.
+
+**Localization**
+
+- Registered fallback keys with interpolation parameters now receive their values correctly instead of rendering unresolved placeholders.
+- Missing fallback keys are mirrored across every supported locale and guarded by tests.
+
+**Diagnostics**
+
+- Support bundles now retain enough PZ, SteamCMD, and PanelBridge context to investigate sandbox-option exceptions and identify candidate mods without guessing.
+
 ## [1.3.1] - 2026-09-10
 
 **TL;DR:**

--- a/server/routes/debug.js
+++ b/server/routes/debug.js
@@ -234,9 +234,9 @@ async function getAvailableLogFiles(logsDir) {
   return files;
 }
 
-const SUPPORT_LOG_FILE_RE = /\.(log|txt)$/i;
+const SUPPORT_LOG_FILE_RE = /\.(log|txt|out|err|trace)$/i;
 const CRASH_FILE_RE =
-  /^(hs_err_pid.*|.*(?:crash|error|exception).*)\.(log|txt)$/i;
+  /^(hs_err_pid.*|.*(?:crash|error|exception).*)\.(log|txt|out|err|trace)$/i;
 
 async function resolveSearchRoot(candidate) {
   if (!candidate) return null;
@@ -257,31 +257,53 @@ async function collectBundleFilesFromDir(
   archivePrefix,
   entries,
   seenFiles,
+  {
+    maxDepth = 0,
+    skipDirectories = [],
+    maxFiles = 500,
+  } = {},
 ) {
-  if (!dir) return;
+  if (!dir) return { addedFiles: 0, visitedDirectories: 0 };
 
-  try {
-    await fs.promises.access(dir);
-  } catch {
-    return;
-  }
+  const skipped = new Set(skipDirectories.map((name) => name.toLowerCase()));
+  let addedFiles = 0;
+  let visitedDirectories = 0;
 
-  const dirEntries = await fs.promises.readdir(dir, { withFileTypes: true });
+  const visit = async (currentDir, relativeParts, depth) => {
+    if (addedFiles >= maxFiles) return;
+    let dirEntries;
+    try {
+      dirEntries = await fs.promises.readdir(currentDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    visitedDirectories += 1;
 
-  for (const entry of dirEntries) {
-    if (!entry.isFile()) continue;
-    if (!matcher(entry.name)) continue;
+    for (const entry of dirEntries) {
+      if (addedFiles >= maxFiles) break;
+      const filePath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        if (depth < maxDepth && !skipped.has(entry.name.toLowerCase())) {
+          await visit(filePath, [...relativeParts, entry.name], depth + 1);
+        }
+        continue;
+      }
+      if (!entry.isFile() || !matcher(entry.name)) continue;
 
-    const filePath = path.join(dir, entry.name);
-    const dedupeKey = path.resolve(filePath).toLowerCase();
-    if (seenFiles.has(dedupeKey)) continue;
+      const dedupeKey = path.resolve(filePath).toLowerCase();
+      if (seenFiles.has(dedupeKey)) continue;
 
-    seenFiles.add(dedupeKey);
-    entries.push({
-      filePath,
-      archivePath: `${archivePrefix}/${entry.name}`,
-    });
-  }
+      seenFiles.add(dedupeKey);
+      entries.push({
+        filePath,
+        archivePath: `${archivePrefix}/${[...relativeParts, entry.name].join("/")}`,
+      });
+      addedFiles += 1;
+    }
+  };
+
+  await visit(path.resolve(dir), [], 0);
+  return { addedFiles, visitedDirectories };
 }
 
 // ───────────────────────────────────────────────────────────────────────
@@ -685,6 +707,205 @@ const SUPPORT_INI_KEYS = [
   "HideDisguisedUserName",
   "AntiCheatProtectionType",
 ];
+
+const SANDBOX_DIAGNOSTIC_MAX_LOG_BYTES = 512 * 1024;
+const SANDBOX_DIAGNOSTIC_MAX_EXCERPTS = 8;
+const SANDBOX_DIAGNOSTIC_MAX_MODS = 500;
+
+async function readTailText(filePath, maxBytes = SANDBOX_DIAGNOSTIC_MAX_LOG_BYTES) {
+  let handle = null;
+  try {
+    const stats = await fs.promises.stat(filePath);
+    if (!stats.isFile()) return null;
+    const length = Math.min(stats.size, maxBytes);
+    handle = await fs.promises.open(filePath, "r");
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await handle.read(buffer, 0, length, stats.size - length);
+    return buffer.subarray(0, bytesRead).toString("utf8");
+  } catch {
+    return null;
+  } finally {
+    if (handle) await handle.close().catch(() => {});
+  }
+}
+
+function parseModInfoMetadata(content, infoPath, fallbackName) {
+  const fields = {};
+  const ids = [];
+  for (const raw of String(content || "").split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#") || line.startsWith(";")) continue;
+    const separator = line.indexOf("=");
+    if (separator <= 0) continue;
+    const key = line.slice(0, separator).trim().toLowerCase();
+    const value = line.slice(separator + 1).trim();
+    if (key === "id" && value) ids.push(value);
+    if (["name", "modversion", "pzversion", "require"].includes(key)) fields[key] = value;
+  }
+  if (ids.length === 0 && fallbackName) ids.push(fallbackName);
+  return {
+    path: infoPath,
+    ids,
+    name: fields.name || null,
+    modversion: fields.modversion || null,
+    pzversion: fields.pzversion || null,
+    require: fields.require || null,
+  };
+}
+
+async function inspectModDirectory(modDir, fallbackName, source, workshopId, configuredMods) {
+  const roots = [modDir];
+  for (const child of (await safeReaddir(modDir)) || []) {
+    const childPath = path.join(modDir, child);
+    const stats = await safeStat(childPath);
+    if (stats?.isDirectory()) roots.push(childPath);
+  }
+
+  const records = [];
+  for (const root of roots) {
+    const infoPath = path.join(root, "mod.info");
+    const infoStats = await safeStat(infoPath);
+    if (!infoStats?.isFile()) continue;
+    let metadata;
+    try {
+      metadata = parseModInfoMetadata(
+        await fs.promises.readFile(infoPath, "utf8"),
+        infoPath,
+        fallbackName,
+      );
+    } catch {
+      continue;
+    }
+
+    const sandboxOptionFiles = [];
+    const mediaPath = path.join(root, "media");
+    for (const name of (await safeReaddir(mediaPath)) || []) {
+      if (!/sandbox/i.test(name)) continue;
+      const candidate = path.join(mediaPath, name);
+      const stats = await safeStat(candidate);
+      if (stats?.isFile()) sandboxOptionFiles.push(candidate);
+    }
+
+    records.push({
+      source,
+      workshopId: workshopId || null,
+      folder: fallbackName,
+      configuredIds: metadata.ids.filter((id) => configuredMods.has(id)),
+      ...metadata,
+      sandboxOptionFiles,
+    });
+  }
+  return records;
+}
+
+async function collectSandboxModMetadata(activeServer, ini) {
+  const configuredMods = new Set(ini?.Mods || []);
+  const records = [];
+  const inspectRoot = async (root, source, workshopId = null) => {
+    for (const name of (await safeReaddir(root)) || []) {
+      if (records.length >= SANDBOX_DIAGNOSTIC_MAX_MODS) break;
+      const modDir = path.join(root, name);
+      const stats = await safeStat(modDir);
+      if (!stats?.isDirectory()) continue;
+      records.push(...await inspectModDirectory(
+        modDir,
+        name,
+        source,
+        workshopId,
+        configuredMods,
+      ));
+    }
+  };
+
+  if (activeServer?.installPath) {
+    const workshopBase = path.join(
+      activeServer.installPath,
+      "steamapps",
+      "workshop",
+      "content",
+      "108600",
+    );
+    for (const workshopId of ini?.WorkshopItems || []) {
+      if (!/^\d+$/.test(workshopId)) continue;
+      await inspectRoot(
+        path.join(workshopBase, workshopId, "mods"),
+        "workshop",
+        workshopId,
+      );
+      if (records.length >= SANDBOX_DIAGNOSTIC_MAX_MODS) break;
+    }
+  }
+
+  if (activeServer?.zomboidDataPath && records.length < SANDBOX_DIAGNOSTIC_MAX_MODS) {
+    for (const directoryName of ["mods", "Mods"]) {
+      await inspectRoot(
+        path.join(activeServer.zomboidDataPath, directoryName),
+        "local",
+      );
+      if (records.length >= SANDBOX_DIAGNOSTIC_MAX_MODS) break;
+    }
+  }
+  return records.slice(0, SANDBOX_DIAGNOSTIC_MAX_MODS);
+}
+
+async function buildSandboxOptionsDiagnostics(activeServer, knownSecrets = []) {
+  if (!activeServer?.zomboidDataPath || !activeServer?.serverConfigPath) {
+    return { available: false, reason: "Active server paths are not configured" };
+  }
+
+  const serverName = activeServer.serverName || activeServer.name || null;
+  const ini = serverName
+    ? await parseServerIni(path.join(activeServer.serverConfigPath, `${serverName}.ini`))
+    : null;
+  const logPath = path.join(activeServer.zomboidDataPath, "server-console.txt");
+  const logText = await readTailText(logPath);
+  const lines = logText ? logText.split(/\r?\n/) : [];
+  const signature = /ArrayIndexOutOfBoundsException|SandboxOptions\$EnumSandboxOption\.getValueTranslationByIndexOrNull/;
+  const exceptionCount = lines.filter((line) => /ArrayIndexOutOfBoundsException/.test(line)).length;
+  const actionCount = lines.filter((line) => /getAllSandboxOptions/.test(line)).length;
+  const excerpts = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!signature.test(lines[index])) continue;
+    const excerpt = lines.slice(Math.max(0, index - 4), index + 8).join("\n");
+    const redacted = redactRawLogText(excerpt, knownSecrets);
+    if (!excerpts.some((entry) => entry.excerpt === redacted)) {
+      excerpts.push({ path: logPath, excerpt: redacted });
+    }
+    if (excerpts.length >= SANDBOX_DIAGNOSTIC_MAX_EXCERPTS) break;
+  }
+
+  const installedMods = await collectSandboxModMetadata(activeServer, ini);
+  const pzVersion = logText?.match(/\bversion=([^\s]+)\s+b[0-9a-f]+/i)?.[1] || null;
+  const bridgeVersion = logText?.match(/\[PanelBridge\]\s+Initializing v([^\s]+)/i)?.[1] || null;
+  const detected = exceptionCount > 0;
+  return {
+    available: true,
+    serverName,
+    pzVersion,
+    panelBridgeVersion: bridgeVersion,
+    configuredMods: ini?.Mods || [],
+    workshopItems: ini?.WorkshopItems || [],
+    detected,
+    error: detected
+      ? {
+          type: "sandbox-enum-index",
+          exception: "java.lang.ArrayIndexOutOfBoundsException",
+          javaMethod: "SandboxOptions$EnumSandboxOption.getValueTranslationByIndexOrNull",
+          action: "getAllSandboxOptions",
+          exceptionCount,
+          actionCount,
+          excerpts,
+          optionName: null,
+          note: "The PZ stack does not include the option name. Candidate mods are listed below from installed mod.info and sandbox-option metadata.",
+        }
+      : { exceptionCount: 0, actionCount },
+    candidateMods: installedMods.filter(
+      (mod) => mod.configuredIds.length > 0 || mod.sandboxOptionFiles.length > 0,
+    ),
+    installedMods,
+    logFiles: logText ? [logPath] : [],
+  };
+}
 
 async function buildServerConfigSummary(activeServer) {
   const configDir = activeServer?.serverConfigPath;
@@ -1342,13 +1563,14 @@ function buildBundleReadme() {
     "11. `network-interfaces.json` — local IPs (no MACs).",
     "12. `process.json` — process flags, versions, active handle counts.",
     "13. `server-config-summary.json` — sanitized effective server settings, mod/map lists, sandbox integrity, and whether the Mods/WorkshopItems lists are the same length (a mismatch is a cheap signal of an unresolved mod).",
-    "14. `pz-build-info.json` — installed Project Zomboid branch and Steam build ID.",
-    "15. `oidc-status.json` — whether SSO is configured, issuer/client/redirect/scope, which fields are pinned by an env var, and whether a client secret is set (never its value). No live IdP check — see the file's own notes.",
-    "16. `roles-and-permissions.json` — every role, what it grants, how many/which local users hold it. Start here for \"why can't this person see X\".",
-    "17. `world-map-diagnostics.json` — whether `curl` is present on this host (a missing one is the most likely new World Map support ticket this release) and the resolved B42 tile-build source/directory/reason.",
-    "18. `db-write-health.json` — db.json's write circuit-breaker state and retry count. Does NOT cover config-file (INI/Lua) writes — see the file's own notes for why.",
-    "19. `backups-summary.json` — the last 20 backup runs. Only successful runs are recorded; a failed scheduled backup shows up in `admin-panel/error.log` instead, not here.",
-    "20. `discord-bot-status.json` — connected or not, which guild/channel/mod-role it's wired to, and the last start failure if any (token presence only, never the value).",
+    "14. `sandbox-options-diagnostics.json` — PZ/PanelBridge versions, sandbox-option exception signatures and excerpts, triggering action counts, configured mods, and installed mod.info/sandbox-option metadata.",
+    "15. `pz-build-info.json` — installed Project Zomboid branch and Steam build ID.",
+    "16. `oidc-status.json` — whether SSO is configured, issuer/client/redirect/scope, which fields are pinned by an env var, and whether a client secret is set (never its value). No live IdP check — see the file's own notes.",
+    "17. `roles-and-permissions.json` — every role, what it grants, how many/which local users hold it. Start here for \"why can't this person see X\".",
+    "18. `world-map-diagnostics.json` — whether `curl` is present on this host (a missing one is the most likely new World Map support ticket this release) and the resolved B42 tile-build source/directory/reason.",
+    "19. `db-write-health.json` — db.json's write circuit-breaker state and retry count. Does NOT cover config-file (INI/Lua) writes — see the file's own notes for why.",
+    "20. `backups-summary.json` — the last 20 backup runs. Only successful runs are recorded; a failed scheduled backup shows up in `admin-panel/error.log` instead, not here.",
+    "21. `discord-bot-status.json` — connected or not, which guild/channel/mod-role it's wired to, and the last start failure if any (token presence only, never the value).",
     "",
     "## Then the raw logs",
     "",
@@ -1409,6 +1631,9 @@ async function buildBundleDiagnostics(activeServer, req, knownSecrets) {
     wrap("process.json", () => buildProcessSnapshot()),
     wrap("network-interfaces.json", () => buildNetworkInterfaces()),
     wrap("server-config-summary.json", () => buildServerConfigSummary(activeServer)),
+    wrap("sandbox-options-diagnostics.json", () =>
+      buildSandboxOptionsDiagnostics(activeServer, knownSecrets),
+    ),
     wrap("pz-build-info.json", () => buildPzBuildInfo(activeServer)),
     wrap("oidc-status.json", () => buildOidcStatus()),
     wrap("roles-and-permissions.json", () => buildRolesAndPermissions()),
@@ -1458,85 +1683,145 @@ async function buildBundleDiagnostics(activeServer, req, knownSecrets) {
 async function getSupportBundleEntries() {
   const paths = getDataPaths();
   const activeServer = await getActiveServer().catch(() => null);
+  const settings = await getAllSettings().catch(() => ({}));
 
   const installRoot = await resolveSearchRoot(activeServer?.installPath || "");
+  const serverPathRoot = await resolveSearchRoot(activeServer?.serverPath || "");
+  const steamcmdRoot = await resolveSearchRoot(settings?.steamcmdPath || "");
   const zomboidDataRoot = await resolveSearchRoot(
     activeServer?.zomboidDataPath || "",
   );
 
   const entries = [];
   const seenFiles = new Set();
+  const collectionReports = [];
+  const scan = async (root, matcher, archivePrefix, options = {}) => {
+    const result = await collectBundleFilesFromDir(
+      root,
+      matcher,
+      archivePrefix,
+      entries,
+      seenFiles,
+      options,
+    );
+    collectionReports.push({
+      root,
+      archivePrefix,
+      ...result,
+      maxDepth: options.maxDepth ?? 0,
+      maxFiles: options.maxFiles ?? 500,
+    });
+  };
 
-  await collectBundleFilesFromDir(
+  await scan(
     paths.logsDir,
     (name) => SUPPORT_LOG_FILE_RE.test(name) && !name.startsWith("."),
     "admin-panel",
-    entries,
-    seenFiles,
+    { maxDepth: 2, maxFiles: 200 },
   );
 
-  await collectBundleFilesFromDir(
+  await scan(
     zomboidDataRoot,
     (name) => SUPPORT_LOG_FILE_RE.test(name),
     "zomboid-server/root",
-    entries,
-    seenFiles,
+    {
+      maxDepth: 1,
+      maxFiles: 500,
+      skipDirectories: [
+        "backups",
+        "lua",
+        "map",
+        "maps",
+        "mods",
+        "saves",
+        "workshop",
+      ],
+    },
   );
 
-  await collectBundleFilesFromDir(
+  await scan(
     zomboidDataRoot ? path.join(zomboidDataRoot, "Logs") : null,
     (name) => SUPPORT_LOG_FILE_RE.test(name),
     "zomboid-server/Logs",
-    entries,
-    seenFiles,
+    { maxDepth: 3, maxFiles: 1000 },
   );
 
-  await collectBundleFilesFromDir(
+  await scan(
     installRoot ? path.join(installRoot, "logs") : null,
     (name) => SUPPORT_LOG_FILE_RE.test(name),
     "zomboid-install/logs",
-    entries,
-    seenFiles,
+    { maxDepth: 3, maxFiles: 1000 },
   );
 
-  await collectBundleFilesFromDir(
+  await scan(
+    installRoot ? path.join(installRoot, "steamapps", "logs") : null,
+    (name) => SUPPORT_LOG_FILE_RE.test(name),
+    "zomboid-install/steamapps-logs",
+    { maxDepth: 3, maxFiles: 1000 },
+  );
+
+  await scan(
+    steamcmdRoot ? path.join(steamcmdRoot, "logs") : null,
+    (name) => SUPPORT_LOG_FILE_RE.test(name),
+    "steamcmd/logs",
+    { maxDepth: 3, maxFiles: 1000 },
+  );
+
+  const alternateServerRoots = [serverPathRoot].filter(
+    (root) => root && root.toLowerCase() !== installRoot?.toLowerCase(),
+  );
+  for (const root of alternateServerRoots) {
+    await scan(
+      root,
+      (name) => SUPPORT_LOG_FILE_RE.test(name),
+      "zomboid-server/alternate-root",
+      { maxDepth: 1, maxFiles: 500 },
+    );
+    await scan(
+      path.join(root, "logs"),
+      (name) => SUPPORT_LOG_FILE_RE.test(name),
+      "zomboid-server/alternate-logs",
+      { maxDepth: 3, maxFiles: 1000 },
+    );
+  }
+
+  await scan(
     installRoot,
     (name) => CRASH_FILE_RE.test(name),
     "crash-logs/install-root",
-    entries,
-    seenFiles,
+    { maxDepth: 2, maxFiles: 100 },
   );
 
-  await collectBundleFilesFromDir(
+  await scan(
     installRoot ? path.join(installRoot, "logs") : null,
     (name) => CRASH_FILE_RE.test(name),
     "crash-logs/install-logs",
-    entries,
-    seenFiles,
+    { maxDepth: 3, maxFiles: 200 },
   );
 
-  await collectBundleFilesFromDir(
+  await scan(
     zomboidDataRoot,
     (name) => CRASH_FILE_RE.test(name),
     "crash-logs/server-root",
-    entries,
-    seenFiles,
+    { maxDepth: 2, maxFiles: 200 },
   );
 
-  await collectBundleFilesFromDir(
+  await scan(
     zomboidDataRoot ? path.join(zomboidDataRoot, "Logs") : null,
     (name) => CRASH_FILE_RE.test(name),
     "crash-logs/server-logs",
-    entries,
-    seenFiles,
+    { maxDepth: 3, maxFiles: 200 },
   );
 
   return {
     entries,
     activeServer,
+    collectionReports,
     sources: {
       panelLogsDir: paths.logsDir,
       installRoot,
+      serverPathRoot,
+      steamcmdRoot,
       zomboidDataRoot,
     },
   };
@@ -1596,7 +1881,8 @@ router.get("/logs/download-zip", requirePermission("diagnostics.manage"), async 
   try {
     log.info("GET /logs/download-zip");
 
-    const { entries, activeServer, sources } = await getSupportBundleEntries();
+    const { entries, activeServer, sources, collectionReports } =
+      await getSupportBundleEntries();
     if (entries.length === 0) {
       return res.status(404).json({ error: "No support logs found" });
     }
@@ -1640,6 +1926,7 @@ router.get("/logs/download-zip", requirePermission("diagnostics.manage"), async 
       `Zomboid Data Dir: ${sources.zomboidDataRoot || "n/a"}`,
       `Install Dir: ${sources.installRoot || "n/a"}`,
       `Included Files: ${entries.length}`,
+      `Scanned Roots: ${collectionReports.filter((report) => report.root).length}`,
       "",
       "WARNING: This bundle contains real logs. Known credential shapes",
       "(RCON/join/SFTP passwords, the Discord bot token, the Steam Web API",
@@ -1651,8 +1938,17 @@ router.get("/logs/download-zip", requirePermission("diagnostics.manage"), async 
       "- admin-panel: panel combined/error logs",
       "- zomboid-server: server-console and runtime logs",
       "- zomboid-install: install-side connection/workshop/system logs",
+      "- steamcmd: SteamCMD download/update logs when the configured path is available",
       "- crash-logs: matching crash/error dump files",
       "- docker-container-logs.txt / managed-service-logs.txt: container/service stdout+stderr for a Docker- or systemd-managed server (see README.md)",
+      "",
+      "Log scan results:",
+      ...collectionReports
+        .filter((report) => report.root)
+        .map(
+          (report) =>
+            `- ${report.archivePrefix}: ${report.addedFiles} file(s), ${report.visitedDirectories} directorie(s) visited, depth ${report.maxDepth}`,
+        ),
     ].join("\n");
 
     archive.append(manifest, { name: "support-bundle-info.txt" });
@@ -6573,6 +6869,7 @@ export {
   buildBundleDiagnostics,
   buildSystemInfo,
   buildServerConfigSummary,
+  buildSandboxOptionsDiagnostics,
   buildOidcStatus,
   buildRolesAndPermissions,
   checkCurlAvailable,
@@ -6590,6 +6887,7 @@ export {
   redactRawLogText,
   collectBundleKnownSecrets,
   createRedactingLogStream,
+  collectBundleFilesFromDir,
 };
 // Exported for direct unit testing of the GET /diagnostics thumbnail-
 // resolution check -- see server/tests/thumbnailResolutionCheck.test.js.

--- a/server/routes/mods.js
+++ b/server/routes/mods.js
@@ -2827,6 +2827,28 @@ router.post("/add-to-ini", async (req, res) => {
   }
 });
 
+export function extractWorkshopModId(description, title) {
+  const patterns = [
+    /Mod\s*ID\s*[:=]\s*([^\n\r\[\]<>]+)/i,
+    /\bid\s*=\s*([^\n\r\[\]<>]+)/i,
+    /\bMod\s*:\s*([^\n\r\[\]<>]+)/i,
+    /\[code\][\s\S]*?id\s*=\s*([^\s\n\r\[\]]+)[\s\S]*?\[\/code\]/i,
+    /IDs\s*[:=]\s*([^\n\r\[\]<>]+)/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = String(description || "").match(pattern);
+    if (!match) continue;
+    const candidate = match[1].trim();
+    if (/^[A-Za-z0-9_-]+$/.test(candidate) && candidate.length > 0) {
+      return candidate;
+    }
+  }
+
+  const potentialId = String(title || "").trim();
+  return /^[A-Za-z0-9_-]{4,29}$/.test(potentialId) ? potentialId : null;
+}
+
 // Helper function to fetch mod ID from Steam Workshop page description
 async function fetchModIdFromWorkshop(workshopId) {
   try {
@@ -2868,60 +2890,10 @@ async function fetchModIdFromWorkshop(workshopId) {
 
     const description = modInfo.description || "";
     const title = modInfo.title || "";
-
-    // Try various patterns to find the mod ID in the description
-    // Pattern 1: "Mod ID: SomeName" or "ModID: SomeName"
-    let match = description.match(/Mod\s*ID\s*[:=]\s*([^\s\n\r\[\]<>]+)/i);
-    if (match) {
-      log.info(`Found Mod ID from "Mod ID:" pattern: ${match[1]}`);
-      return match[1].trim();
-    }
-
-    // Pattern 2: "id=SomeName" (common in description)
-    match = description.match(/\bid\s*=\s*([^\s\n\r\[\]<>]+)/i);
-    if (match) {
-      log.info(`Found Mod ID from "id=" pattern: ${match[1]}`);
-      return match[1].trim();
-    }
-
-    // Pattern 3: Workshop ID matches a pattern like "Mod: ModName"
-    match = description.match(/\bMod\s*:\s*([A-Za-z0-9_-]+)/i);
-    if (match && match[1].length > 3) {
-      log.info(`Found Mod ID from "Mod:" pattern: ${match[1]}`);
-      return match[1].trim();
-    }
-
-    // Pattern 4: Look for [code] blocks that might contain mod.info content
-    // Use [\s\S] to match newlines
-    match = description.match(
-      /\[code\][\s\S]*?id\s*=\s*([^\s\n\r\[\]]+)[\s\S]*?\[\/code\]/i,
-    );
-    if (match) {
-      log.info(`Found Mod ID from [code] block: ${match[1]}`);
-      return match[1].trim();
-    }
-
-    // Pattern 5: "Ids: ModId" (plural)
-    match = description.match(/IDs\s*[:=]\s*([^\s\n\r\[\]<>]+)/i);
-    if (match) {
-      log.info(`Found Mod ID from "IDs:" pattern: ${match[1]}`);
-      return match[1].trim();
-    }
-
-    // Pattern 6: If specific workshop ID is mentioned near "Mod ID"
-    // Sometimes description has multiple mods, but we want the one for THIS item?
-    // Usually one workshop item = one mod, but obscure cases exist.
-
-    // Pattern 7: Fallback - Title as Mod ID if looks like ID
-    // Only use if the title is already a clean ID-like string (no spaces, special chars)
-    const potentialId = title.replace(/[^a-zA-Z0-9_-]/g, "");
-    if (
-      potentialId === title &&
-      potentialId.length > 3 &&
-      potentialId.length < 30
-    ) {
-      log.info(`Using title as Mod ID (exact match): ${potentialId}`);
-      return potentialId;
+    const detectedId = extractWorkshopModId(description, title);
+    if (detectedId) {
+      log.info(`Found Mod ID from Steam Workshop metadata: ${detectedId}`);
+      return detectedId;
     }
 
     log.warn(

--- a/server/services/modChecker.js
+++ b/server/services/modChecker.js
@@ -1641,35 +1641,49 @@ export class ModChecker extends EventEmitter {
           );
         }
 
+        const restartEligibleUpdates =
+          iniWorkshopIds === null
+            ? newUpdates
+            : newUpdates.filter((mod) =>
+                iniWorkshopIds.has(String(mod.workshopId)),
+              );
+        if (newUpdates.length > 0 && restartEligibleUpdates.length === 0) {
+          log.info(
+            "All pending mod updates belong to deactivated mods — skipping auto-restart",
+          );
+        }
+
         // Check startup grace period — don't trigger auto-restart too soon after startup
         const inGracePeriod =
           this.startedAt &&
           performance.now() - this.startedAt < this.startupGraceMs;
-        if (inGracePeriod && newUpdates.length > 0) {
+        if (inGracePeriod && restartEligibleUpdates.length > 0) {
           const remaining = Math.round(
             (this.startupGraceMs - (performance.now() - this.startedAt)) / 1000,
           );
           log.info(
-            `Startup grace period active (${remaining}s remaining) — skipping auto-restart for ${newUpdates.length} update(s)`,
+            `Startup grace period active (${remaining}s remaining) — skipping auto-restart for ${restartEligibleUpdates.length} update(s)`,
           );
-          newUpdates.length = 0; // Clear — don't trigger callback during grace
+          restartEligibleUpdates.length = 0;
         }
 
         // Only trigger callback if NOT already pending a restart AND there are genuinely new updates
         if (
           this.onUpdateCallback &&
           !this.pendingRestart &&
-          newUpdates.length > 0
+          restartEligibleUpdates.length > 0
         ) {
           try {
             log.info(
-              `Triggering auto-restart callback for ${newUpdates.length} new update(s)`,
+              `Triggering auto-restart callback for ${restartEligibleUpdates.length} new update(s)`,
             );
-            const callbackResult = await this.onUpdateCallback(newUpdates);
+            const callbackResult = await this.onUpdateCallback(
+              restartEligibleUpdates,
+            );
             // Mark updates only when work actually happened or no restart is needed.
             // Transient aborts, such as a running server with disconnected RCON, retry.
             if (this.pendingRestart || callbackResult?.markProcessed === true) {
-              for (const m of newUpdates) {
+              for (const m of restartEligibleUpdates) {
                 const steamTs = m.latestTimestamp?.getTime?.() || 0;
                 if (steamTs) {
                   this.processedUpdates.set(m.workshopId, steamTs);

--- a/server/tests/bugfixes.test.js
+++ b/server/tests/bugfixes.test.js
@@ -15,11 +15,35 @@ import {
 import {
   compareDefinitionSets,
   createConflictScanSnapshots,
+  extractWorkshopModId,
   filterOwnedClientModIds,
   getModDetailsFromWorkshop,
   groupIntoPairs,
   scoreWorkshopDependencyMatch,
 } from "../routes/mods.js";
+
+describe("extractWorkshopModId", () => {
+  it("rejects a spaced description value instead of truncating it to the first word", () => {
+    expect(
+      extractWorkshopModId(
+        "Workshop ID: 3785483068\\nMod ID: Kentucky Cellar",
+        "Kentucky Cellar",
+      ),
+    ).toBeNull();
+  });
+
+  it("accepts a clean Mod ID from the description", () => {
+    expect(extractWorkshopModId("Mod ID: KentuckyCellar", "Kentucky Cellar")).toBe(
+      "KentuckyCellar",
+    );
+  });
+
+  it("accepts a clean title as the final fallback", () => {
+    expect(extractWorkshopModId("No mod ID listed", "KentuckyCellar")).toBe(
+      "KentuckyCellar",
+    );
+  });
+});
 import {
   ModChecker,
   getWorkshopAcfCandidates,

--- a/server/tests/modCheckerCrossServerPhantomUpdates.test.js
+++ b/server/tests/modCheckerCrossServerPhantomUpdates.test.js
@@ -155,6 +155,26 @@ describe("modChecker.js does not treat every mod in a (possibly host-shared) Wor
       expect(result.mods.map((m) => m.workshopId)).toEqual([MOD_RELEVANT]);
     });
 
+    it("reports a deactivated tracked mod without triggering its auto-restart", async () => {
+      getTrackedMods.mockResolvedValue([
+        { workshop_id: MOD_RELEVANT, name: "Deactivated Mod" },
+      ]);
+      const checker = makeChecker({
+        acfMods: [MOD_RELEVANT],
+        steamUpdates: [MOD_RELEVANT],
+      });
+      checker.serverManager = {
+        getServerConfig: async () => ({ WorkshopItems: MOD_PHANTOM }),
+      };
+      const callback = vi.fn(async () => ({ markProcessed: true }));
+      await checker.setUpdateCallback(callback);
+
+      const result = await checker.checkForUpdates();
+
+      expect(result.mods.map((m) => m.workshopId)).toEqual([MOD_RELEVANT]);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
     it("still excludes a genuine phantom (neither in the ini nor tracked for this server) even when the ini IS readable and lists something else", async () => {
       getTrackedMods.mockResolvedValue([
         { workshop_id: MOD_RELEVANT, name: "Relevant Mod" },

--- a/server/tests/supportBundleCollectors.test.js
+++ b/server/tests/supportBundleCollectors.test.js
@@ -12,6 +12,7 @@ const {
   buildBundleDiagnostics,
   buildSystemInfo,
   buildServerConfigSummary,
+  buildSandboxOptionsDiagnostics,
   buildOidcStatus,
   buildRolesAndPermissions,
   checkCurlAvailable,
@@ -21,12 +22,49 @@ const {
   buildDiscordBotStatus,
   buildDockerContainerLogsText,
   buildManagedServiceLogsText,
+  collectBundleFilesFromDir,
 } = await import("../routes/debug.js");
 const { setDockerClient } = await import("../services/managedContainer.js");
 
 function fakeReq(services = {}, headers = {}) {
   return { app: { get: (key) => services[key] }, headers };
 }
+
+describe("support bundle: recursive log discovery", () => {
+  let root;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "pz-bundle-log-tree-"));
+    fs.mkdirSync(path.join(root, "nested", "runtime"), { recursive: true });
+    fs.mkdirSync(path.join(root, "Saves", "Multiplayer"), { recursive: true });
+    fs.writeFileSync(path.join(root, "root.txt"), "root");
+    fs.writeFileSync(path.join(root, "nested", "runtime", "server.err"), "err");
+    fs.writeFileSync(path.join(root, "Saves", "Multiplayer", "ignored.log"), "save");
+  });
+
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it("finds nested log extensions while skipping game data directories", async () => {
+    const entries = [];
+    const result = await collectBundleFilesFromDir(
+      root,
+      (name) => /\.(log|txt|err)$/i.test(name),
+      "server-logs",
+      entries,
+      new Set(),
+      { maxDepth: 3, skipDirectories: ["saves"] },
+    );
+
+    expect(result.addedFiles).toBe(2);
+    expect(entries.map((entry) => entry.archivePath)).toEqual(
+      expect.arrayContaining([
+        "server-logs/root.txt",
+        "server-logs/nested/runtime/server.err",
+      ]),
+    );
+    expect(entries.some((entry) => entry.archivePath.includes("ignored.log"))).toBe(false);
+  });
+});
 
 describe("support bundle: curl availability (World Map's runtime dependency)", () => {
   afterEach(() => mockExecFile.mockReset());
@@ -290,6 +328,86 @@ describe("support bundle: server config summary flags a Mods/WorkshopItems lengt
       serverName: "servertest",
     });
     expect(result.ini.modsWorkshopCountMismatch).toBe(false);
+  });
+});
+
+describe("support bundle: sandbox-options diagnostics identify the failure and candidate mods", () => {
+  let dataDir;
+  let configDir;
+  let installDir;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "pz-bundle-sandbox-data-"));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "pz-bundle-sandbox-config-"));
+    installDir = fs.mkdtempSync(path.join(os.tmpdir(), "pz-bundle-sandbox-install-"));
+    const modRoot = path.join(
+      installDir,
+      "steamapps",
+      "workshop",
+      "content",
+      "108600",
+      "123",
+      "mods",
+      "ExampleMod",
+      "42",
+    );
+    fs.mkdirSync(path.join(modRoot, "media"), { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, "servertest.ini"),
+      "Mods=ExampleMod\nWorkshopItems=123\n",
+    );
+    fs.writeFileSync(
+      path.join(dataDir, "server-console.txt"),
+      [
+        "version=42.20.4 b0bbce05d5 demo=false",
+        "[PanelBridge] Initializing v1.7.57",
+        "POST /command: action=getAllSandboxOptions args={}",
+        "java.lang.ArrayIndexOutOfBoundsException at SandboxOptions$EnumSandboxOption.getValueTranslationByIndexOrNull(SandboxOptions.java:1270).",
+        "Lua(Vanilla).getAllSandboxOptions(PanelBridge.lua:4864)",
+      ].join("\n"),
+    );
+    fs.writeFileSync(
+      path.join(modRoot, "mod.info"),
+      "name=Example Mod\nid=ExampleMod\nmodversion=2.4.1\npzversion=42.20\n",
+    );
+    fs.writeFileSync(
+      path.join(modRoot, "media", "sandbox-options.txt"),
+      "option=ExampleMod.SomeOption\n",
+    );
+  });
+
+  afterEach(() => {
+    for (const directory of [dataDir, configDir, installDir]) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("captures the PZ exception, versions, and installed mod metadata", async () => {
+    const result = await buildSandboxOptionsDiagnostics({
+      name: "servertest",
+      serverName: "servertest",
+      serverConfigPath: configDir,
+      zomboidDataPath: dataDir,
+      installPath: installDir,
+    });
+
+    expect(result.detected).toBe(true);
+    expect(result.pzVersion).toBe("42.20.4");
+    expect(result.panelBridgeVersion).toBe("1.7.57");
+    expect(result.error.javaMethod).toContain("getValueTranslationByIndexOrNull");
+    expect(result.error.optionName).toBeNull();
+    expect(result.candidateMods).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "Example Mod",
+          modversion: "2.4.1",
+          workshopId: "123",
+          sandboxOptionFiles: expect.arrayContaining([
+            expect.stringContaining("sandbox-options.txt"),
+          ]),
+        }),
+      ]),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Keep deactivated tracked-mod updates visible without allowing them to trigger automatic server restarts.
- Stop truncating spaced Workshop description values such as `Mod ID: Kentucky Cellar` into the invalid partial ID `Kentucky`; trust on-disk `mod.info` when available and reject ambiguous fallback text.
- Expand support bundles with recursive PZ/install/SteamCMD log discovery and sandbox-options diagnostics for Build 42 PanelBridge failures.
- Add the v1.3.2 candidate changelog entry.

## Issues

Closes #152
Closes #157

Issue #155 remains a separate World Map POI-search feature request and is intentionally not bundled into this fix.

## Validation

- `npm run lint:server`
- 144 focused server tests across `bugfixes.test.js`, `modCheckerCrossServerPhantomUpdates.test.js`, and `supportBundleCollectors.test.js`
- The shared per-file Vitest teardown race was fixed separately in `fdecb067`; the full GitHub server gate passed after that fix.